### PR TITLE
chore(gateway): migrate pyproject.toml license to PEP 639 string form

### DIFF
--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     { name = "kisaragi-mochi" },
 ]


### PR DESCRIPTION
## Summary

Migrates `gateway/pyproject.toml` from the legacy `license = { text = "MIT" }` form to the PEP 639 SPDX-string form `license = "MIT"`. The built wheel now records `License-Expression: MIT` in metadata.

## Why this matters

Issue #13 traces this to PEP 639 standardization: pip 24+, hatchling 1.26+, and twine 5.1+ expect the SPDX string form, and the legacy `text = "..."` form is deprecated in metadata 2.4+. The change is one character of meaningful content, but it is also the safest moment to make it because there are no downstream consumers yet -- the project is at v0.1.0.

## Changes

`gateway/pyproject.toml` line 7: `license = { text = "MIT" }` -> `license = "MIT"`. No code changes anywhere else. The `Classifier: License :: OSI Approved :: MIT License` entry that was already in the file is unaffected.

## Testing

Per the issue's "Steps" section:

```
$ python3 -m venv /tmp/stackchan-venv
$ /tmp/stackchan-venv/bin/pip install build hatchling
$ cd gateway && /tmp/stackchan-venv/bin/python -m build --wheel
* Building wheel...
Successfully built stackchan_mcp-0.1.0-py3-none-any.whl

$ unzip -p dist/stackchan_mcp-0.1.0-py3-none-any.whl '*METADATA' | grep License
License-Expression: MIT
Classifier: License :: OSI Approved :: MIT License
```

The build picked the latest hatchling automatically (>= 1.26 supports PEP 639). The wheel emits the `License-Expression: MIT` field that the issue's acceptance criterion calls for.

Closes #13
