### PR TITLE
fix(firmware): interpolate servo motion to avoid SCS0009 bus hang

### DIFF
--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -497,6 +497,7 @@ private:
         uint32_t move_duration_ms = 0;
         bool moving = false;
     };
+    // TODO: motion_mutex_/scs_bus_mutex_/servo_task_handle_ have no destroy path; board is singleton via DECLARE_BOARD.
     AxisMotion yaw_motion_;
     AxisMotion pitch_motion_;
     SemaphoreHandle_t motion_mutex_ = nullptr;     // protects AxisMotion fields
@@ -505,6 +506,20 @@ private:
     static constexpr uint32_t MOTION_TICK_MS = 20;
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
+
+    static int YawDegToPos(int deg) {
+        int pos = 460 + deg * 16 / 5;
+        if (pos < 0) pos = 0;
+        if (pos > 1000) pos = 1000;
+        return pos;
+    }
+
+    static int PitchDegToPos(int deg) {
+        int pos = 620 + deg * 16 / 5;
+        if (pos < 0) pos = 0;
+        if (pos > 1000) pos = 1000;
+        return pos;
+    }
 
     void InitializePowerSaveTimer() {
         power_save_timer_ = new PowerSaveTimer(-1, 60, 300);
@@ -799,6 +814,20 @@ private:
         if (servo_ok_) {
             motion_mutex_ = xSemaphoreCreateMutex();
             scs_bus_mutex_ = xSemaphoreCreateMutex();
+            if (motion_mutex_ == nullptr || scs_bus_mutex_ == nullptr) {
+                ESP_LOGE(TAG, "Failed to create servo mutexes: motion=%p scs_bus=%p; disabling servo",
+                         motion_mutex_, scs_bus_mutex_);
+                if (motion_mutex_ != nullptr) {
+                    vSemaphoreDelete(motion_mutex_);
+                    motion_mutex_ = nullptr;
+                }
+                if (scs_bus_mutex_ != nullptr) {
+                    vSemaphoreDelete(scs_bus_mutex_);
+                    scs_bus_mutex_ = nullptr;
+                }
+                servo_ok_ = false;
+                return;
+            }
 
             int yaw_pos_actual = scs_bus_.ReadPos(SERVO_YAW_ID);
             int pitch_pos_actual = scs_bus_.ReadPos(SERVO_PITCH_ID);
@@ -821,7 +850,18 @@ private:
                                         "servo_motion", 4096, this, 5,
                                         &servo_task_handle_);
             if (ok != pdPASS) {
-                ESP_LOGE(TAG, "Failed to create servo_motion task");
+                ESP_LOGE(TAG, "Failed to create servo_motion task; disabling servo");
+                if (motion_mutex_ != nullptr) {
+                    vSemaphoreDelete(motion_mutex_);
+                    motion_mutex_ = nullptr;
+                }
+                if (scs_bus_mutex_ != nullptr) {
+                    vSemaphoreDelete(scs_bus_mutex_);
+                    scs_bus_mutex_ = nullptr;
+                }
+                servo_task_handle_ = nullptr;
+                servo_ok_ = false;
+                return;
             }
         }
     }
@@ -920,6 +960,7 @@ private:
 
         while (true) {
             vTaskDelay(pdMS_TO_TICKS(MOTION_TICK_MS));
+            if (!servo_ok_) continue;
 
             AxisMotion yaw_local;
             AxisMotion pitch_local;
@@ -962,9 +1003,7 @@ private:
 
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
             if (yaw_local.moving) {
-                int yaw_pos = 460 + new_yaw_current * 16 / 5;
-                if (yaw_pos < 0) yaw_pos = 0;
-                if (yaw_pos > 1000) yaw_pos = 1000;
+                int yaw_pos = YawDegToPos(new_yaw_current);
                 int r = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, MOTION_PER_WRITE_TIME_MS, 0);
                 if (r <= 0) {
                     ESP_LOGW(TAG, "Motion yaw WritePos failed: r=%d (deg=%d, pos=%d)",
@@ -973,9 +1012,7 @@ private:
             }
             vTaskDelay(kInterFrameGap);
             if (pitch_local.moving) {
-                int pitch_pos = 620 + new_pitch_current * 16 / 5;
-                if (pitch_pos < 0) pitch_pos = 0;
-                if (pitch_pos > 1000) pitch_pos = 1000;
+                int pitch_pos = PitchDegToPos(new_pitch_current);
                 int r = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, MOTION_PER_WRITE_TIME_MS, 0);
                 if (r <= 0) {
                     ESP_LOGW(TAG, "Motion pitch WritePos failed: r=%d (deg=%d, pos=%d)",
@@ -985,12 +1022,16 @@ private:
             xSemaphoreGive(scs_bus_mutex_);
 
             xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            yaw_motion_.current_deg = new_yaw_current;
+            if (yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
+                yaw_motion_.current_deg = new_yaw_current;
+            }
             if (!new_yaw_moving && yaw_motion_.target_deg == yaw_local.target_deg
                 && yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
                 yaw_motion_.moving = false;
             }
-            pitch_motion_.current_deg = new_pitch_current;
+            if (pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
+                pitch_motion_.current_deg = new_pitch_current;
+            }
             if (!new_pitch_moving && pitch_motion_.target_deg == pitch_local.target_deg
                 && pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
                 pitch_motion_.moving = false;
@@ -1432,16 +1473,12 @@ private:
             [this](const PropertyList& properties) -> ReturnValue {
                 int yaw = properties["yaw"].value<int>();
                 int pitch = properties["pitch"].value<int>();
-                int yaw_pos = 460 + yaw * 16 / 5;
-                int pitch_pos = 620 + pitch * 16 / 5;
-                if (yaw_pos < 0) yaw_pos = 0;
-                if (yaw_pos > 1000) yaw_pos = 1000;
-                if (pitch_pos < 0) pitch_pos = 0;
-                if (pitch_pos > 1000) pitch_pos = 1000;
+                int yaw_pos = YawDegToPos(yaw);
+                int pitch_pos = PitchDegToPos(pitch);
                 WriteHeadAngles(yaw, pitch);
                 bool yaw_motion_started = false;
                 bool pitch_motion_started = false;
-                if (motion_mutex_ != nullptr) {
+                if (servo_ok_) {
                     xSemaphoreTake(motion_mutex_, portMAX_DELAY);
                     yaw_motion_started = yaw_motion_.moving;
                     pitch_motion_started = pitch_motion_.moving;
@@ -1465,12 +1502,12 @@ private:
             "Get the current head angles (yaw, pitch) of the robot in degrees.",
             PropertyList(),
             [this](const PropertyList& properties) -> ReturnValue {
-                if (scs_bus_mutex_ != nullptr) {
+                int yaw_pos = -1;
+                int pitch_pos = -1;
+                if (servo_ok_) {
                     xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-                }
-                int yaw_pos = scs_bus_.ReadPos(SERVO_YAW_ID);
-                int pitch_pos = scs_bus_.ReadPos(SERVO_PITCH_ID);
-                if (scs_bus_mutex_ != nullptr) {
+                    yaw_pos = scs_bus_.ReadPos(SERVO_YAW_ID);
+                    pitch_pos = scs_bus_.ReadPos(SERVO_PITCH_ID);
                     xSemaphoreGive(scs_bus_mutex_);
                 }
                 int yaw = (yaw_pos - 460) * 5 / 16;
@@ -1532,27 +1569,41 @@ private:
             "self.robot.uart_diag",
             "Diagnostic: send raw 8 bytes (FF FF 01 04 03 E8 00 00) directly via uart_write_bytes. Returns sent byte count and rx buffer length before/after.",
             PropertyList(),
-            [](const PropertyList& properties) -> ReturnValue {
+            [this](const PropertyList& properties) -> ReturnValue {
                 cJSON* root = cJSON_CreateObject();
 
                 size_t buf_before = 0;
-                esp_err_t err_b = uart_get_buffered_data_len(SERVO_UART_NUM, &buf_before);
+                esp_err_t err_b = ESP_ERR_INVALID_STATE;
+                int written = -1;
+                esp_err_t err_wait = ESP_ERR_INVALID_STATE;
+                esp_err_t err_a = ESP_ERR_INVALID_STATE;
+                size_t buf_after = 0;
+                const uint8_t bytes[] = {0xFF, 0xFF, 0x01, 0x04, 0x03, 0xE8, 0x00, 0x00};
+
+                if (servo_ok_) {
+                    xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+
+                    err_b = uart_get_buffered_data_len(SERVO_UART_NUM, &buf_before);
+
+                    written = uart_write_bytes(SERVO_UART_NUM, (const char*)bytes, sizeof(bytes));
+
+                    // Wait for TX FIFO drain
+                    err_wait = uart_wait_tx_done(SERVO_UART_NUM, pdMS_TO_TICKS(100));
+
+                    vTaskDelay(pdMS_TO_TICKS(20));
+
+                    err_a = uart_get_buffered_data_len(SERVO_UART_NUM, &buf_after);
+
+                    xSemaphoreGive(scs_bus_mutex_);
+                }
                 cJSON_AddStringToObject(root, "buf_before_status", esp_err_to_name(err_b));
                 cJSON_AddNumberToObject(root, "buf_before", buf_before);
 
-                const uint8_t bytes[] = {0xFF, 0xFF, 0x01, 0x04, 0x03, 0xE8, 0x00, 0x00};
-                int written = uart_write_bytes(SERVO_UART_NUM, (const char*)bytes, sizeof(bytes));
                 cJSON_AddNumberToObject(root, "written", written);
                 cJSON_AddNumberToObject(root, "expected", (int)sizeof(bytes));
 
-                // Wait for TX FIFO drain
-                esp_err_t err_wait = uart_wait_tx_done(SERVO_UART_NUM, pdMS_TO_TICKS(100));
                 cJSON_AddStringToObject(root, "tx_done_status", esp_err_to_name(err_wait));
 
-                vTaskDelay(pdMS_TO_TICKS(20));
-
-                size_t buf_after = 0;
-                esp_err_t err_a = uart_get_buffered_data_len(SERVO_UART_NUM, &buf_after);
                 cJSON_AddStringToObject(root, "buf_after_status", esp_err_to_name(err_a));
                 cJSON_AddNumberToObject(root, "buf_after", buf_after);
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -19,6 +19,9 @@
 #include <esp_lcd_ili9341.h>
 #include <esp_timer.h>
 #include <esp_random.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/semphr.h>
 #include "esp_video.h"
 #include <cJSON.h>
 #include <lvgl.h>
@@ -481,6 +484,28 @@ private:
     int servo_wobble_step_ = 0;       // 0..3 sequence index
     bool servo_wobble_active_ = false;
 
+    // Issue #1: Servo motion task — interpolate WritePos to avoid SCS0009 bus
+    // collisions on large-angle reversals. A dedicated FreeRTOS task ticks at
+    // MOTION_TICK_MS, walks current_deg → target_deg over move_duration_ms, and
+    // issues short MOTION_PER_WRITE_TIME_MS WritePos commands so the servo never
+    // receives a discontinuous jump.
+    struct AxisMotion {
+        int target_deg = 0;
+        int start_deg = 0;
+        int current_deg = 0;
+        uint32_t move_start_ms = 0;
+        uint32_t move_duration_ms = 0;
+        bool moving = false;
+    };
+    AxisMotion yaw_motion_;
+    AxisMotion pitch_motion_;
+    SemaphoreHandle_t motion_mutex_ = nullptr;     // protects AxisMotion fields
+    SemaphoreHandle_t scs_bus_mutex_ = nullptr;    // serializes UART access (WritePos/ReadPos)
+    TaskHandle_t servo_task_handle_ = nullptr;
+    static constexpr uint32_t MOTION_TICK_MS = 20;
+    static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
+    static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
+
     void InitializePowerSaveTimer() {
         power_save_timer_ = new PowerSaveTimer(-1, 60, 300);
         power_save_timer_->OnEnterSleepMode([this]() {
@@ -770,6 +795,35 @@ private:
         // every WritePos after the first one ("starts moving once, then
         // never again" symptom).
         ESP_LOGI(TAG, "Servo bus init: %s (Level=1, ACK enabled)", servo_ok_ ? "OK" : "FAILED");
+
+        if (servo_ok_) {
+            motion_mutex_ = xSemaphoreCreateMutex();
+            scs_bus_mutex_ = xSemaphoreCreateMutex();
+
+            int yaw_pos_actual = scs_bus_.ReadPos(SERVO_YAW_ID);
+            int pitch_pos_actual = scs_bus_.ReadPos(SERVO_PITCH_ID);
+            if (yaw_pos_actual >= 0) {
+                yaw_motion_.current_deg = (yaw_pos_actual - 460) * 5 / 16;
+                ESP_LOGI(TAG, "Restored yaw_motion_.current_deg=%d from ReadPos=%d",
+                         yaw_motion_.current_deg, yaw_pos_actual);
+            } else {
+                ESP_LOGW(TAG, "Failed to ReadPos(yaw); current_deg stays at 0");
+            }
+            if (pitch_pos_actual >= 0) {
+                pitch_motion_.current_deg = (pitch_pos_actual - 620) * 5 / 16;
+                ESP_LOGI(TAG, "Restored pitch_motion_.current_deg=%d from ReadPos=%d",
+                         pitch_motion_.current_deg, pitch_pos_actual);
+            } else {
+                ESP_LOGW(TAG, "Failed to ReadPos(pitch); current_deg stays at 0");
+            }
+
+            BaseType_t ok = xTaskCreate(&StackChanBoard::ServoTaskTrampoline,
+                                        "servo_motion", 4096, this, 5,
+                                        &servo_task_handle_);
+            if (ok != pdPASS) {
+                ESP_LOGE(TAG, "Failed to create servo_motion task");
+            }
+        }
     }
 
     // ---- Phase 7: head-touch (Si12T) sensing + reaction ----------------
@@ -777,20 +831,32 @@ private:
     // Convenience wrapper around the existing servo write path. Mirrors the
     // math used in the self.robot.set_head_angles MCP tool so that touch
     // reactions and explicit MCP calls produce identical motion.
-    void WriteHeadAngles(int yaw_deg, int pitch_deg) {
-        int yaw_pos = 460 + yaw_deg * 16 / 5;
-        int pitch_pos = 620 + pitch_deg * 16 / 5;
-        if (yaw_pos < 0) yaw_pos = 0;
-        if (yaw_pos > 1000) yaw_pos = 1000;
-        if (pitch_pos < 0) pitch_pos = 0;
-        if (pitch_pos > 1000) pitch_pos = 1000;
-        scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, 100, 0);
-        // Inter-frame gap: SCS0009 needs a few ms between half-duplex frames
-        // even with Level=1 ACK wait. Empirically without this delay, the
-        // pitch WritePos can collide with the yaw servo's still-in-progress
-        // motion and time out, hanging the bus until power cycle.
-        vTaskDelay(pdMS_TO_TICKS(10));
-        scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, 100, 0);
+    //
+    // Issue #1: previously this issued WritePos(id, pos, 100, 0) directly,
+    // which hung the SCS0009 bus on large-angle reversals (the second
+    // servo's frame collided with the first servo still being driven).
+    // Now it sets the target and lets the servo_motion task interpolate.
+    void WriteHeadAngles(int yaw_deg, int pitch_deg,
+                         uint32_t duration_ms = MOTION_DEFAULT_DURATION_MS) {
+        if (!servo_ok_) {
+            ESP_LOGW(TAG, "WriteHeadAngles skipped: servo not initialized");
+            return;
+        }
+        uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+
+        xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+        yaw_motion_.target_deg = yaw_deg;
+        yaw_motion_.start_deg = yaw_motion_.current_deg;
+        yaw_motion_.move_start_ms = now_ms;
+        yaw_motion_.move_duration_ms = duration_ms;
+        yaw_motion_.moving = (yaw_motion_.target_deg != yaw_motion_.current_deg);
+
+        pitch_motion_.target_deg = pitch_deg;
+        pitch_motion_.start_deg = pitch_motion_.current_deg;
+        pitch_motion_.move_start_ms = now_ms;
+        pitch_motion_.move_duration_ms = duration_ms;
+        pitch_motion_.moving = (pitch_motion_.target_deg != pitch_motion_.current_deg);
+        xSemaphoreGive(motion_mutex_);
     }
 
     // Servo wobble: yaw -A -> +A -> -A -> 0, each step SERVO_WOBBLE_STEP_MS.
@@ -803,10 +869,10 @@ private:
     void ServoWobbleStepAdvance() {
         const int A = SERVO_WOBBLE_AMPLITUDE_DEG;
         switch (servo_wobble_step_) {
-            case 0: WriteHeadAngles(-A, 0); break;
-            case 1: WriteHeadAngles(+A, 0); break;
-            case 2: WriteHeadAngles(-A, 0); break;
-            case 3: WriteHeadAngles(  0, 0); break;
+            case 0: WriteHeadAngles(-A, 0, SERVO_WOBBLE_STEP_MS); break;
+            case 1: WriteHeadAngles(+A, 0, SERVO_WOBBLE_STEP_MS); break;
+            case 2: WriteHeadAngles(-A, 0, SERVO_WOBBLE_STEP_MS); break;
+            case 3: WriteHeadAngles(  0, 0, SERVO_WOBBLE_STEP_MS); break;
             default:
                 servo_wobble_active_ = false;
                 return;
@@ -843,6 +909,94 @@ private:
         servo_wobble_active_ = true;
         // Kick off the first step immediately.
         ServoWobbleStepAdvance();
+    }
+
+    static void ServoTaskTrampoline(void* arg) {
+        static_cast<StackChanBoard*>(arg)->ServoTaskMain();
+    }
+
+    void ServoTaskMain() {
+        constexpr TickType_t kInterFrameGap = pdMS_TO_TICKS(10);
+
+        while (true) {
+            vTaskDelay(pdMS_TO_TICKS(MOTION_TICK_MS));
+
+            AxisMotion yaw_local;
+            AxisMotion pitch_local;
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            yaw_local = yaw_motion_;
+            pitch_local = pitch_motion_;
+            xSemaphoreGive(motion_mutex_);
+
+            if (!yaw_local.moving && !pitch_local.moving) continue;
+
+            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+
+            int new_yaw_current = yaw_local.current_deg;
+            bool new_yaw_moving = yaw_local.moving;
+            if (yaw_local.moving) {
+                uint32_t elapsed = now_ms - yaw_local.move_start_ms;
+                if (elapsed >= yaw_local.move_duration_ms) {
+                    new_yaw_current = yaw_local.target_deg;
+                    new_yaw_moving = false;
+                } else {
+                    int delta = yaw_local.target_deg - yaw_local.start_deg;
+                    new_yaw_current = yaw_local.start_deg +
+                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / yaw_local.move_duration_ms);
+                }
+            }
+
+            int new_pitch_current = pitch_local.current_deg;
+            bool new_pitch_moving = pitch_local.moving;
+            if (pitch_local.moving) {
+                uint32_t elapsed = now_ms - pitch_local.move_start_ms;
+                if (elapsed >= pitch_local.move_duration_ms) {
+                    new_pitch_current = pitch_local.target_deg;
+                    new_pitch_moving = false;
+                } else {
+                    int delta = pitch_local.target_deg - pitch_local.start_deg;
+                    new_pitch_current = pitch_local.start_deg +
+                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / pitch_local.move_duration_ms);
+                }
+            }
+
+            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            if (yaw_local.moving) {
+                int yaw_pos = 460 + new_yaw_current * 16 / 5;
+                if (yaw_pos < 0) yaw_pos = 0;
+                if (yaw_pos > 1000) yaw_pos = 1000;
+                int r = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, MOTION_PER_WRITE_TIME_MS, 0);
+                if (r <= 0) {
+                    ESP_LOGW(TAG, "Motion yaw WritePos failed: r=%d (deg=%d, pos=%d)",
+                             r, new_yaw_current, yaw_pos);
+                }
+            }
+            vTaskDelay(kInterFrameGap);
+            if (pitch_local.moving) {
+                int pitch_pos = 620 + new_pitch_current * 16 / 5;
+                if (pitch_pos < 0) pitch_pos = 0;
+                if (pitch_pos > 1000) pitch_pos = 1000;
+                int r = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, MOTION_PER_WRITE_TIME_MS, 0);
+                if (r <= 0) {
+                    ESP_LOGW(TAG, "Motion pitch WritePos failed: r=%d (deg=%d, pos=%d)",
+                             r, new_pitch_current, pitch_pos);
+                }
+            }
+            xSemaphoreGive(scs_bus_mutex_);
+
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            yaw_motion_.current_deg = new_yaw_current;
+            if (!new_yaw_moving && yaw_motion_.target_deg == yaw_local.target_deg
+                && yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
+                yaw_motion_.moving = false;
+            }
+            pitch_motion_.current_deg = new_pitch_current;
+            if (!new_pitch_moving && pitch_motion_.target_deg == pitch_local.target_deg
+                && pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
+                pitch_motion_.moving = false;
+            }
+            xSemaphoreGive(motion_mutex_);
+        }
     }
 
     // Schedule a single-shot revert to "idle" face REACTION_HOLD_MS later.
@@ -1284,18 +1438,24 @@ private:
                 if (yaw_pos > 1000) yaw_pos = 1000;
                 if (pitch_pos < 0) pitch_pos = 0;
                 if (pitch_pos > 1000) pitch_pos = 1000;
-                int r1 = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, 100, 0);
-                vTaskDelay(pdMS_TO_TICKS(10));  // SCS0009 inter-frame gap
-                int r2 = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, 100, 0);
-                ESP_LOGI(TAG, "set_head_angles: yaw=%d (pos=%d) r=%d, pitch=%d (pos=%d) r=%d, uart=%d, servo_ok=%d",
-                         yaw, yaw_pos, r1, pitch, pitch_pos, r2, (int)scs_bus_.uart_num, servo_ok_);
+                WriteHeadAngles(yaw, pitch);
+                bool yaw_motion_started = false;
+                bool pitch_motion_started = false;
+                if (motion_mutex_ != nullptr) {
+                    xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                    yaw_motion_started = yaw_motion_.moving;
+                    pitch_motion_started = pitch_motion_.moving;
+                    xSemaphoreGive(motion_mutex_);
+                }
+                ESP_LOGI(TAG, "set_head_angles: yaw=%d (pos=%d) motion_started=%d, pitch=%d (pos=%d) motion_started=%d, uart=%d, servo_ok=%d",
+                         yaw, yaw_pos, yaw_motion_started, pitch, pitch_pos, pitch_motion_started, (int)scs_bus_.uart_num, servo_ok_);
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddBoolToObject(root, "servo_init_ok", servo_ok_);
                 cJSON_AddNumberToObject(root, "uart_num", (int)scs_bus_.uart_num);
                 cJSON_AddNumberToObject(root, "yaw_pos", yaw_pos);
                 cJSON_AddNumberToObject(root, "pitch_pos", pitch_pos);
-                cJSON_AddNumberToObject(root, "write_yaw", r1);
-                cJSON_AddNumberToObject(root, "write_pitch", r2);
+                cJSON_AddNumberToObject(root, "yaw_motion_started", yaw_motion_started ? 1 : 0);
+                cJSON_AddNumberToObject(root, "pitch_motion_started", pitch_motion_started ? 1 : 0);
                 return root;
             });
 
@@ -1305,8 +1465,14 @@ private:
             "Get the current head angles (yaw, pitch) of the robot in degrees.",
             PropertyList(),
             [this](const PropertyList& properties) -> ReturnValue {
+                if (scs_bus_mutex_ != nullptr) {
+                    xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+                }
                 int yaw_pos = scs_bus_.ReadPos(SERVO_YAW_ID);
                 int pitch_pos = scs_bus_.ReadPos(SERVO_PITCH_ID);
+                if (scs_bus_mutex_ != nullptr) {
+                    xSemaphoreGive(scs_bus_mutex_);
+                }
                 int yaw = (yaw_pos - 460) * 5 / 16;
                 int pitch = (pitch_pos - 620) * 5 / 16;
                 cJSON* root = cJSON_CreateObject();


### PR DESCRIPTION
## Summary
Closes #1.

Large-angle reversals like `move_head(60, 0)` → `move_head(-60, 0)` could hang the SCS0009 bus, requiring a power cycle to recover. This PR adds a software interpolation task to `stackchan.cc` so the servo never receives a discontinuous jump command.

## Cause
`WriteHeadAngles()` previously issued `WritePos(id, pos, 100, 0)` — a "move to target in 100ms" command. SCS0009 needs longer than 100ms to physically complete a 120° travel, so the second servo's frame collided with the first servo's still-in-progress motion, desyncing the bus.

## Approach
A dedicated FreeRTOS servo task ticks every 20ms, snapshots axis state under a `motion_mutex_`, computes new positions via linear interpolation, then issues short (30ms) `WritePos` commands under a separate `scs_bus_mutex_` (serializes UART access against `get_head_angles` MCP tool which also reads from the same bus). The servo always receives small, completable jumps — bus collisions become impossible.

- `WriteHeadAngles(yaw, pitch, duration_ms = 600)` becomes non-blocking (sets target, kicks the task, returns)
- Existing wobble path passes `SERVO_WOBBLE_STEP_MS` so wobble keeps its punchy timing (slightly slower but still expressive)
- `current_deg` is restored from actual servo position via `ReadPos()` in `InitializeServo()` to prevent unintended initial-jump after boot or manual repositioning
- `WritePos` return values are now logged on failure (no silent drops)

## Breaking change for external MCP clients
The `set_head_angles` MCP tool response renames two fields to reflect that motion is now async:

| Old field | New field | Type change |
|---|---|---|
| `write_yaw` | `yaw_motion_started` | WritePos return code → 0/1 motion-started flag |
| `write_pitch` | `pitch_motion_started` | WritePos return code → 0/1 motion-started flag |

**No known clients consume these fields today** (verified via grep across this repo, including `gateway/`, tests, and docs). However, if any external MCP client outside this repo reads these fields, it will need updating. The new flag indicates whether the servo task accepted the target (always `1` when `servo_ok_`), not the result of the actual physical motion (which now completes asynchronously over `duration_ms`).

## Verified on real hardware (M5Stack CoreS3 + StackChan kit)

### Initial verification (commit 830e311)
- `move_head(60, 0)` → `move_head(-60, 0)` 10/10 times without hang
- `check_vm_en` reports VM EN HIGH throughout
- Wobble (head-stroke reaction) still works without regression — slightly slower (~114°/s vs old ~200°/s) but still expressive
- Boot log was not captured this round (early boot output flushes before serial monitor opens — tracked separately as #20)

### Re-verification after review feedback (commit 2f758a8)
After applying the codex adversarial review feedback, the device was re-flashed and re-tested via MCP:
- `check_vm_en` (before): `vm_en_high: true`, `i2c_read_ok: true`
- 10× `move_head` requests fired in **parallel** (5× yaw=60, 5× yaw=-60, interleaved): all 10 returned `servo_init_ok: true` and `yaw_motion_started: 1`, no hang. Returned positions match the expected math (yaw=60 → pos=652, yaw=-60 → pos=268, both within [0, 1000]).
- `check_vm_en` (after): `vm_en_high: true` — servo power maintained throughout the burst. The new race guard on `current_deg` (Should-fix #1) and the `scs_bus_mutex_` serialization both held under concurrent target updates.

## Changes after review (2026-05-02)
codex adversarial review (see commit 2f758a8) flagged one critical issue and three should-fix items. All addressed in this PR:

### Critical
- **mutex/task creation failure handling**: `xSemaphoreCreateMutex()` NULL return and `xTaskCreate()` non-`pdPASS` are now caught explicitly. On failure the partially created handles are released and `servo_ok_` is forced to `false`, so subsequent MCP calls don't dereference NULL handles or update targets that no one will interpolate.

### Should-fix
- **Race on `current_deg` re-target**: the servo task's writeback of `current_deg` and the `moving=false` flag are now gated on `move_start_ms == yaw_local.move_start_ms` (and pitch equivalent). This prevents a stale snapshot from a previous tick clobbering the freshly-set start position when `WriteHeadAngles()` is called mid-motion.
- **`uart_diag` MCP tool was bypassing `scs_bus_mutex_`**: the diagnostic tool issues raw `uart_write_bytes` on the same UART as the motion task. Now wrapped in `xSemaphoreTake(scs_bus_mutex_)` and gated on `servo_ok_`.

### Nice-to-have
- **Lifecycle TODO comment**: added a comment near `AxisMotion` noting that `motion_mutex_` / `scs_bus_mutex_` / `servo_task_handle_` have no destroy path; this is fine because the board is a `DECLARE_BOARD` singleton, but the asymmetry is now documented.
- **`YawDegToPos` / `PitchDegToPos` static helpers**: extracted the duplicated `460 + deg * 16 / 5` (and pitch equivalent) clamp-to-[0,1000] math into named helpers used by both the servo task and the `set_head_angles` MCP handler.

## Test plan (for reviewers)
- [x] `python ./scripts/release.py stackchan` succeeds (build verified locally, `merged-binary.bin` and `releases/v2.2.6_stackchan.zip` produced; `xiaozhi.bin` 17% free; CI #21 (#24) now also runs this on every PR)
- [x] Device boots without crash (move_head and wobble succeed → boot completed; explicit boot-log capture deferred to #20)
- [x] `move_head(60, 0)` → `move_head(-60, 0)` repeatable 10×+ without hang
- [x] VM EN remains HIGH throughout
- [x] Wobble (head-stroke reaction) still works without regression
- [x] **Re-tested after review-feedback commit (2f758a8): 10× parallel move_head burst, all succeeded, VM EN held HIGH**

🤖 Generated with [Claude Code](https://claude.com/claude-code)