### PR TITLE
feat(firmware): add CONFIG_DEFAULT_WEBSOCKET_URL Kconfig fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
 
 WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う (xiaozhi-esp32 標準フロー)。
 
+### Configuring the WebSocket gateway URL
+
+The firmware reads the gateway URL from NVS key `websocket.url`. For
+development, there are three practical ways to provide it:
+
+1. **Build-time default via Kconfig (recommended for developers)**:
+   run `idf.py menuconfig`, then open `Component config` → `Xiaozhi Assistant`
+   → `Default WebSocket gateway URL (fallback when NVS is empty)` and enter a
+   URL such as `ws://192.168.1.100:8765/`. This sets
+   `CONFIG_DEFAULT_WEBSOCKET_URL` in the build. If NVS `websocket.url` is
+   empty, the firmware automatically falls back to this value.
+2. **Write `websocket.url` directly to NVS**: this is the intended persistent
+   runtime configuration path, eventually via the WiFi config UI. The UI field
+   is not implemented yet and is tracked as a follow-up to Issue #17.
+3. **Temporary source hardcode (not recommended)**: editing
+   `websocket_protocol.cc` can unblock local experiments, but keep it out of
+   commits.
+
 ### 2. ゲートウェイ起動
 
 ```bash

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -6,6 +6,21 @@ config OTA_URL
     help
         The application will access this URL to check for new firmwares and server address.
 
+config DEFAULT_WEBSOCKET_URL
+    string "Default WebSocket gateway URL (fallback when NVS is empty)"
+    default ""
+    help
+        WebSocket URL used when NVS websocket.url is empty (typically the
+        case on a freshly flashed device that has not been configured via
+        the WiFi config UI). Set this via `idf.py menuconfig` to bake a
+        default URL into the firmware so the device can connect to your
+        local stackchan-mcp gateway out of the box.
+
+        Example: ws://192.168.1.100:8765/
+
+        Leave empty to require explicit NVS configuration (the original
+        behavior).
+
 choice
     prompt "Flash Assets"
     default FLASH_DEFAULT_ASSETS if !USE_EMOTE_MESSAGE_STYLE

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -87,6 +87,14 @@ bool WebsocketProtocol::OpenAudioChannel() {
     // legacy OTA-config code path is disabled in application.cc by design —
     // this firmware always speaks to a stackchan-mcp gateway directly.
     std::string url = settings.GetString("url");
+#ifdef CONFIG_DEFAULT_WEBSOCKET_URL
+    if (url.empty()) {
+        url = CONFIG_DEFAULT_WEBSOCKET_URL;
+        if (!url.empty()) {
+            ESP_LOGI(TAG, "NVS websocket.url empty; using build-time default from Kconfig: %s", url.c_str());
+        }
+    }
+#endif
     std::string token = settings.GetString("token");
     int version = settings.GetInt("version");
     if (version != 0) {


### PR DESCRIPTION
## Summary
Closes #17 (approach 2 only — approaches 1 and 3 are tracked independently in #25 and #26).

Adds a build-time fallback for the WebSocket gateway URL so developers no longer need to edit \`websocket_protocol.cc\` and rebuild every time NVS is empty (which is the common case on a freshly flashed device or after intentional NVS clears during testing).

## Why

Today, \`WebsocketProtocol::OpenAudioChannel()\` reads \`websocket.url\` from NVS. If NVS is empty, the firmware tries to connect to whatever stale URL might be there (often the upstream xiaozhi-esp32 default \`wss://api.tenclass.net/...\`), which is never our local gateway. The current workaround during development is to hardcode the URL in \`websocket_protocol.cc\`, rebuild, flash, test, then \`git checkout\` to revert — easy to forget, easy to accidentally commit. Painful enough that we hit it again while testing PR #16.

## What changes

### \`firmware/main/Kconfig.projbuild\`
New string option \`CONFIG_DEFAULT_WEBSOCKET_URL\` (default empty), placed next to the existing \`OTA_URL\`:

\`\`\`kconfig
config DEFAULT_WEBSOCKET_URL
    string \"Default WebSocket gateway URL (fallback when NVS is empty)\"
    default \"\"
    help
        WebSocket URL used when NVS websocket.url is empty ...
        Example: ws://192.168.1.100:8765/
\`\`\`

### \`firmware/main/protocols/websocket_protocol.cc\`
Fallback inserted right after the existing NVS read (no changes to the NVS-priority behavior):

\`\`\`cpp
std::string url = settings.GetString(\"url\");
#ifdef CONFIG_DEFAULT_WEBSOCKET_URL
    if (url.empty()) {
        url = CONFIG_DEFAULT_WEBSOCKET_URL;
        if (!url.empty()) {
            ESP_LOGI(TAG, \"NVS websocket.url empty; using build-time default from Kconfig: %s\", url.c_str());
        }
    }
#endif
\`\`\`

The \`#ifdef\` guard is defensive — ESP-IDF normally always defines \`CONFIG_DEFAULT_WEBSOCKET_URL\` (as \`\"\"\` if unset) via auto-generated \`sdkconfig.h\`, but the guard makes the change safe even if the Kconfig generation fails for some reason.

### \`README.md\`
New section \"Configuring the WebSocket gateway URL\" documenting the three practical paths:
1. **Kconfig fallback (recommended for developers)** — this PR
2. **NVS direct write** — eventually via WiFi config UI (#25)
3. **Source hardcode** — last resort, do not commit

## Resolution order (after this PR)

1. NVS \`websocket.url\` (highest priority — explicit user setting)
2. \`CONFIG_DEFAULT_WEBSOCKET_URL\` from Kconfig (this PR)
3. Empty (firmware fails to connect, logs \`Failed to connect to websocket server\`)

mDNS auto-discovery (#26) would slot in between 1 and 2 when implemented.

## Backward compatibility

- Devices with non-empty NVS \`websocket.url\` are unaffected (NVS still wins)
- Devices with empty NVS and no Kconfig value → behave exactly as before (no URL → connect attempt fails → log)
- Devices with empty NVS and Kconfig value → connect to the Kconfig URL (the new behavior)

## Test plan
- [x] \`python ./scripts/release.py stackchan\` succeeds (built locally with default empty Kconfig — the change compiles cleanly, \`build/merged-binary.bin\` and \`releases/v2.2.6_stackchan.zip\` produced as expected)
- [x] \`git diff --check\` clean (no whitespace errors)
- [x] Scope confined to the 3 files listed above
- [ ] CI (#21) build passes (will run on this PR)
- [ ] Manual: set \`CONFIG_DEFAULT_WEBSOCKET_URL\` to a working gateway URL via \`idf.py menuconfig\`, flash to a device with empty NVS, observe \`NVS websocket.url empty; using build-time default from Kconfig: ...\` in serial log and successful WS connect

## Out of scope (split issues)
- **#25**: Add WS URL field to WiFi config UI (approach 1 — for end users with pre-built binaries)
- **#26**: mDNS auto-discovery (approach 3 — zero-config LAN setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)