### PR TITLE
feat(firmware): force-override mode for default WS URL/token (Kconfig)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,185 @@
+[English](README.md) | **日本語**
+
+# stackchan-mcp
+
+**M5Stack 公式 [StackChan](https://docs.m5stack.com/ja/StackChan)** (2025年 Kickstarter 出荷キット) を任意の LLM クライアントから操作するための MCP (Model Context Protocol) ブリッジ。
+
+> オリジナルの [stack-chan プロジェクト (タカヲさん)](https://github.com/mongonta0716/stack-chan) のコミュニティから生まれ、M5Stack 公式が製品化した StackChan キットを対象としています。
+
+```
+┌─────────────┐     stdio MCP      ┌──────────────┐    WebSocket MCP    ┌──────────────┐
+│ MCP client  │ ─────────────────▶ │   gateway    │ ──────────────────▶ │ ESP32 (CoreS3│
+│ (Claude等)  │ ◀───────────────── │  (Python)    │ ◀────────────────── │  +StackChan) │
+└─────────────┘                    │              │                     └──────────────┘
+                                   │  /capture    │ ◀── HTTP POST (JPEG) ──┘
+                                   └──────────────┘
+```
+
+任意の MCP クライアント (Claude Code / Claude Desktop / 他) から、首振り・カメラ撮影・タッチセンサ・アバター表情切替などの StackChan 操作を呼び出せる。
+
+## 構成
+
+このリポジトリはモノレポ。
+
+| ディレクトリ | 内容 |
+|---|---|
+| `firmware/` | [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) フォーク全体（git subtree）。StackChan 用カスタムボードは `firmware/main/boards/stackchan/` に配置 |
+| `gateway/` | Python MCP ゲートウェイ。stdio MCP サーバー (LLM側) + WebSocket MCP クライアント (ESP32側) + HTTP capture サーバー |
+| `docs/` | [`architecture.md`](docs/architecture.md): 全体構成図・ツール名マッピング・写真フロー・認証・Phase ロードマップ |
+
+## 想定ハードウェア
+
+**M5Stack 公式 [StackChan キット](https://docs.m5stack.com/ja/StackChan)** (Kickstarter 2025 出荷版)。公式ドキュメントの[出荷時ファームウェア](https://docs.m5stack.com/ja/StackChan#%E5%87%BA%E8%8D%B7%E6%99%82%E3%83%95%E3%82%A1%E3%83%BC%E3%83%A0%E3%82%A6%E3%82%A7%E3%82%A2)を本リポジトリの firmware で置き換える形で動作します。
+
+| 部品 | 仕様 |
+|---|---|
+| **本体** | M5Stack CoreS3 (ESP32-S3, 16MB Flash, 8MB PSRAM) |
+| **首サーボ** | SCS0009 ×2 (yaw + pitch、シリアルバス、TX=GPIO6, RX=GPIO7) |
+| **カメラ** | GC0308 (DVP, 320×240) |
+| **タッチ** | FT6336 / Si12T |
+| **ディスプレイ** | ILI9342 (SPI, 320×240) |
+
+> 自作の stack-chan (タカヲさん版オリジナル設計) でも、上記のピンアサイン・I2C アドレスが一致していれば動く可能性があります。動作報告・修正 PR 歓迎です。
+
+## ツール一覧 (gateway 経由で MCP クライアントが呼べる)
+
+| ツール | 説明 | 状態 |
+|---|---|---|
+| `get_status` | ゲートウェイ接続状態 | ✅ |
+| `get_device_info` | ESP32 デバイス状態 (バッテリー/音量/WiFi 等) | ✅ |
+| `take_photo(question?)` | カメラ撮影 → JPEG 保存 → パス返す | ✅ |
+| `set_volume(volume)` | スピーカー音量 (0-100) | ✅ |
+| `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
+| `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ) | ✅ |
+| `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
+| `set_avatar(face)` | アバター表情切替 (neutral/happy/sad 等 6種) | ✅ |
+| `set_blink(state)` | 瞬き ON/OFF | ✅ |
+| `set_mouth(state)` | 口開閉 | ✅ |
+| `check_vm_en` | サーボ電源 (VM EN HIGH) 状態確認 | ✅ |
+
+詳細スキーマは `gateway/README.md` 参照。
+
+## クイックスタート
+
+### 1. ファームウェア書き込み (CoreS3)
+
+```bash
+cd firmware
+docker run --rm -v $PWD:/project -w /project espressif/idf:v5.5.2 \
+  python ./scripts/release.py stackchan
+# → releases/v2.2.6_stackchan.zip
+
+# フラッシュ (CoreS3 を USB 接続後)
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+  write_flash 0x0 build/merged-binary.bin
+```
+
+WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う (xiaozhi-esp32 標準フロー)。
+
+### WebSocket gateway URL と認証トークンの設定
+
+ファームウェアはゲートウェイ接続のために 2 つの NVS キーを参照します:
+
+- `websocket.url` — ゲートウェイ WebSocket URL (例: `ws://192.168.1.100:8765/`)
+- `websocket.token` — `Authorization: Bearer <token>` で送信される bearer トークン。ゲートウェイ側の `STACKCHAN_TOKEN` / `BEARER_TOKEN` と照合される (両方空にすれば認証スキップ)
+
+設定方法は実用的に 3 つ:
+
+1. **Kconfig によるビルド時デフォルト (開発者推奨)**: `idf.py menuconfig` → `Component config` → `Xiaozhi Assistant` を開き、以下を設定:
+   - `Default WebSocket gateway URL (fallback when NVS is empty)` →
+     `CONFIG_DEFAULT_WEBSOCKET_URL` (例: `ws://192.168.1.100:8765/`)
+   - `Default WebSocket auth token (fallback when NVS is empty)` →
+     `CONFIG_DEFAULT_WEBSOCKET_TOKEN` (ゲートウェイが認証不要なら空のままで OK)
+
+   デフォルトでは、対応する NVS キーが空のときだけこの値が使われます。新規デバイスへの初回フラッシュではちょうど期待通りに動作します。
+
+2. **NVS に直接 `websocket.url` / `websocket.token` を書き込む**: ランタイムでの永続設定の本来のパス。最終的には WiFi 設定 UI から行う想定ですが、現時点で UI フィールドは未実装で Issue #17 のフォローアップとして追跡しています。
+
+3. **一時的なソース hardcode (非推奨)**: `websocket_protocol.cc` を編集すればローカル実験はアンブロックできますが、commit には残さないようにしてください。
+
+#### 既存デバイス (古い NVS) — `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL`
+
+以前に上流の xiaozhi-esp32 ファームウェアが書き込まれたことがあるデバイスにフラッシュする場合、NVS には上流の OTA-config パスが書き込んだ `websocket.url=wss://api.tenclass.net/...` が既に存在します。この場合、上記オプション 1 の empty-NVS fallback は **発動せず**、デバイスはローカルゲートウェイではなく tenclass を呼び続けます。現時点で `websocket` NVS namespace を選択的にクリアするランタイムツールはありません。
+
+NVS を全消去 (WiFi 認証も飛ぶ) せずにこれを回避するには、force-override スイッチを有効化します:
+
+- `Force CONFIG_DEFAULT_WEBSOCKET_URL/TOKEN to override NVS` →
+  `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y`
+
+有効化すると、**非空** の Kconfig URL/トークンが NVS の値を上書きします。空の Kconfig 値は引き続き NVS にフォールバックするため、たとえばトークン用 Kconfig を空のままにすれば NVS に保存されたトークンがそのまま使われ続けます。boot ログに `FORCE: overriding NVS websocket.url with Kconfig: NVS=... -> ...` と出るので、override が効いたことを確認できます。このスイッチは、xiaozhi 出身のハードウェアをローカル stackchan-mcp ゲートウェイに引き寄せる、または CI/dev イメージを既知のゲートウェイ URL に固定するための、最も推奨される手段です。
+
+スイッチは opt-in なので、ランタイムで設定するエンドユーザーデバイスは NVS-priority のままです。
+
+### 2. ゲートウェイ起動
+
+```bash
+cd gateway
+cp .env.example .env       # STACKCHAN_TOKEN / VISION_HOST を設定
+uv sync
+uv run python -m stackchan_mcp
+```
+
+### 3. MCP クライアント登録 (Claude Code 例)
+
+`~/.claude.json` に追加:
+
+```json
+{
+  "mcpServers": {
+    "stackchan-mcp": {
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "run", "--directory", "/path/to/stackchan-mcp/gateway",
+        "python", "-m", "stackchan_mcp"
+      ]
+    }
+  }
+}
+```
+
+詳細は `gateway/README.md` 参照。
+
+## アバター画像について
+
+`firmware/main/boards/stackchan/avatar_images.cc` は **真っ黒 RGB565 のプレースホルダ** です。ビルドは通りますが、画面には何も表示されません。実際にアバターを表示するには、自分の PNG 画像 (160×120) から `avatar_images.cc` を再生成してください。
+
+シンボル一覧 (`avatar_images.h` 参照):
+- 表情系 (6): `avatar_idle`, `avatar_happy`, `avatar_thinking`, `avatar_sad`, `avatar_surprised`, `avatar_embarrassed`
+- 目 (3): `avatar_eyes_open`, `avatar_eyes_half`, `avatar_eyes_closed`
+- 口 (5): `avatar_mouth_closed`, `avatar_mouth_half`, `avatar_mouth_open`, `avatar_mouth_e`, `avatar_mouth_u`
+
+PNG → RGB565 配列の変換スクリプトは LVGL 公式の [Online Image Converter](https://lvgl.io/tools/imageconverter) などが使えます。
+
+## 既知の課題
+
+- 大角度急逆転 (±60° → -60° 等) でサーボハングする場合あり (Motion::update_task の補間移植で改善予定)
+- タッチセンサ (Si12T) のぽん判定取りこぼし (感度レジスタ調整余地)
+
+## ライセンス
+
+このリポジトリはデュアルライセンス構成です。
+
+| 範囲 | ライセンス |
+|---|---|
+| 全体 (`gateway/`, トップレベル, `firmware/` の大部分) | **MIT License** (`LICENSE` 参照) |
+| `firmware/main/boards/stackchan/` 内の **SCServo_lib 由来ファイル** (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) | **GNU GPL-3.0** (`firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt` 参照) |
+
+これは Feetech の SCServo SDK が GPL-3.0 で配布されているための制約です。SCServo_lib を静的リンクする **firmware バイナリ全体は実質 GPL-3.0** として配布されることになります。
+
+一方、`gateway/` は独立した Python プロセスで、ESP32 とはネットワーク経由 (WebSocket) でしか通信しないため、**MIT License** のまま利用・派生できます。
+
+### upstream
+
+`firmware/` は [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) のフォーク ([kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32)) を git subtree で取り込んでいます。SCServo_lib は公式 [stack-chan](https://github.com/mongonta0716/stack-chan) (タカヲさん) から移植したファームウェアコンポーネントです。
+
+## 関連プロジェクト
+
+- [M5Stack 公式 StackChan ドキュメント](https://docs.m5stack.com/ja/StackChan) — 想定ハードウェアの公式ドキュメント (出荷時ファーム / 配線図 / API リファレンス等)
+- [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) — ベースとなる ESP32 LLM クライアントファームウェア
+- [stack-chan](https://github.com/mongonta0716/stack-chan) — オリジナルの StackChan プロジェクト (タカヲさん)
+- [Model Context Protocol](https://modelcontextprotocol.io) — MCP プロトコル仕様
+
+## コントリビューション
+
+Issue / PR 歓迎です。StackChan コミュニティで使える形を目指しています。

--- a/README.md
+++ b/README.md
@@ -74,23 +74,61 @@ esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
 
 WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う (xiaozhi-esp32 標準フロー)。
 
-### Configuring the WebSocket gateway URL
+### Configuring the WebSocket gateway URL and auth token
 
-The firmware reads the gateway URL from NVS key `websocket.url`. For
-development, there are three practical ways to provide it:
+The firmware reads two NVS keys for gateway connection:
 
-1. **Build-time default via Kconfig (recommended for developers)**:
-   run `idf.py menuconfig`, then open `Component config` → `Xiaozhi Assistant`
-   → `Default WebSocket gateway URL (fallback when NVS is empty)` and enter a
-   URL such as `ws://192.168.1.100:8765/`. This sets
-   `CONFIG_DEFAULT_WEBSOCKET_URL` in the build. If NVS `websocket.url` is
-   empty, the firmware automatically falls back to this value.
-2. **Write `websocket.url` directly to NVS**: this is the intended persistent
-   runtime configuration path, eventually via the WiFi config UI. The UI field
-   is not implemented yet and is tracked as a follow-up to Issue #17.
+- `websocket.url` — the gateway WebSocket URL (e.g. `ws://192.168.1.100:8765/`)
+- `websocket.token` — the bearer token sent as `Authorization: Bearer <token>`,
+  matched against `STACKCHAN_TOKEN` / `BEARER_TOKEN` on the gateway side
+  (leave both empty to skip authentication entirely)
+
+There are three practical ways to provide them:
+
+1. **Build-time defaults via Kconfig (recommended for developers)**: run
+   `idf.py menuconfig` → `Component config` → `Xiaozhi Assistant`, and set:
+   - `Default WebSocket gateway URL (fallback when NVS is empty)` →
+     `CONFIG_DEFAULT_WEBSOCKET_URL` (e.g. `ws://192.168.1.100:8765/`)
+   - `Default WebSocket auth token (fallback when NVS is empty)` →
+     `CONFIG_DEFAULT_WEBSOCKET_TOKEN` (leave empty if your gateway accepts
+     unauthenticated connections)
+
+   By default these only apply when the corresponding NVS key is empty.
+   For first-time flashes onto a fresh device this is exactly what you want.
+
+2. **Write `websocket.url` / `websocket.token` directly to NVS**: this is the
+   intended persistent runtime configuration path, eventually via the WiFi
+   config UI. The UI fields are not implemented yet and are tracked under
+   Issue #17 follow-ups.
+
 3. **Temporary source hardcode (not recommended)**: editing
    `websocket_protocol.cc` can unblock local experiments, but keep it out of
    commits.
+
+#### Existing devices with stale NVS — `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL`
+
+If you are flashing onto a device that previously ran upstream xiaozhi-esp32
+firmware, NVS will already contain `websocket.url=wss://api.tenclass.net/...`
+written by the upstream OTA-config path. In this case the empty-NVS fallback
+in option 1 above will **not** trigger, and the device will keep trying to
+talk to tenclass instead of your local gateway. There is currently no
+runtime tool to clear the `websocket` NVS namespace selectively.
+
+To work around this without erasing all of NVS (which would also drop WiFi
+credentials), enable the force-override switch:
+
+- `Force CONFIG_DEFAULT_WEBSOCKET_URL/TOKEN to override NVS` →
+  `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y`
+
+When set, the build-time Kconfig URL/token always win over whatever NVS
+holds. The boot log will show
+`FORCE: overriding NVS websocket.url with Kconfig: NVS=... -> ...` so you
+can verify the override fired. This switch is the recommended way to bring
+ex-xiaozhi hardware onto a local stackchan-mcp gateway, and to lock CI/dev
+images to a known gateway URL.
+
+The switch is opt-in so end-user devices configured at runtime keep their
+NVS-priority semantics.
 
 ### 2. ゲートウェイ起動
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,67 @@
+**English** | [日本語](README.ja.md)
+
 # stackchan-mcp
 
-**M5Stack 公式 [StackChan](https://docs.m5stack.com/ja/StackChan)** (2025年 Kickstarter 出荷キット) を任意の LLM クライアントから操作するための MCP (Model Context Protocol) ブリッジ。
+An MCP (Model Context Protocol) bridge for the **M5Stack official [StackChan](https://docs.m5stack.com/ja/StackChan)** (2025 Kickstarter shipping kit), letting any LLM client drive the device.
 
-> オリジナルの [stack-chan プロジェクト (タカヲさん)](https://github.com/mongonta0716/stack-chan) のコミュニティから生まれ、M5Stack 公式が製品化した StackChan キットを対象としています。
+> Born out of the [stack-chan project](https://github.com/mongonta0716/stack-chan) community (originated by Takawo-san). This repository targets the M5Stack official StackChan kit that grew out of that lineage.
 
 ```
 ┌─────────────┐     stdio MCP      ┌──────────────┐    WebSocket MCP    ┌──────────────┐
 │ MCP client  │ ─────────────────▶ │   gateway    │ ──────────────────▶ │ ESP32 (CoreS3│
-│ (Claude等)  │ ◀───────────────── │  (Python)    │ ◀────────────────── │  +StackChan) │
+│ (e.g.Claude)│ ◀───────────────── │  (Python)    │ ◀────────────────── │  +StackChan) │
 └─────────────┘                    │              │                     └──────────────┘
                                    │  /capture    │ ◀── HTTP POST (JPEG) ──┘
                                    └──────────────┘
 ```
 
-任意の MCP クライアント (Claude Code / Claude Desktop / 他) から、首振り・カメラ撮影・タッチセンサ・アバター表情切替などの StackChan 操作を呼び出せる。
+From any MCP client (Claude Code / Claude Desktop / others) you can call StackChan operations such as head movement, camera capture, touch sensor reads, and avatar expression switches.
 
-## 構成
+## Repository layout
 
-このリポジトリはモノレポ。
+This repository is a monorepo.
 
-| ディレクトリ | 内容 |
+| Directory | Contents |
 |---|---|
-| `firmware/` | [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) フォーク全体（git subtree）。StackChan 用カスタムボードは `firmware/main/boards/stackchan/` に配置 |
-| `gateway/` | Python MCP ゲートウェイ。stdio MCP サーバー (LLM側) + WebSocket MCP クライアント (ESP32側) + HTTP capture サーバー |
-| `docs/` | [`architecture.md`](docs/architecture.md): 全体構成図・ツール名マッピング・写真フロー・認証・Phase ロードマップ |
+| `firmware/` | Full git subtree of [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32). The custom StackChan board lives at `firmware/main/boards/stackchan/`. |
+| `gateway/` | Python MCP gateway. stdio MCP server (LLM side) + WebSocket MCP client (ESP32 side) + HTTP capture server. |
+| `docs/` | [`architecture.md`](docs/architecture.md): full component diagram, tool name mapping, photo flow, auth, phase roadmap. |
 
-## 想定ハードウェア
+## Target hardware
 
-**M5Stack 公式 [StackChan キット](https://docs.m5stack.com/ja/StackChan)** (Kickstarter 2025 出荷版)。公式ドキュメントの[出荷時ファームウェア](https://docs.m5stack.com/ja/StackChan#%E5%87%BA%E8%8D%B7%E6%99%82%E3%83%95%E3%82%A1%E3%83%BC%E3%83%A0%E3%82%A6%E3%82%A7%E3%82%A2)を本リポジトリの firmware で置き換える形で動作します。
+**M5Stack official [StackChan kit](https://docs.m5stack.com/ja/StackChan)** (Kickstarter 2025 shipping version). The firmware in this repository is meant to replace the kit's [factory firmware](https://docs.m5stack.com/ja/StackChan#%E5%87%BA%E8%8D%B7%E6%99%82%E3%83%95%E3%82%A1%E3%83%BC%E3%83%A0%E3%82%A6%E3%82%A7%E3%82%A2).
 
-| 部品 | 仕様 |
+| Part | Spec |
 |---|---|
-| **本体** | M5Stack CoreS3 (ESP32-S3, 16MB Flash, 8MB PSRAM) |
-| **首サーボ** | SCS0009 ×2 (yaw + pitch、シリアルバス、TX=GPIO6, RX=GPIO7) |
-| **カメラ** | GC0308 (DVP, 320×240 YUV422) |
-| **タッチ** | FT6336 / Si12T |
-| **ディスプレイ** | ILI9342 (SPI, 320×240) |
+| **Body** | M5Stack CoreS3 (ESP32-S3, 16MB Flash, 8MB PSRAM) |
+| **Neck servos** | SCS0009 ×2 (yaw + pitch, serial bus, TX=GPIO6, RX=GPIO7) |
+| **Camera** | GC0308 (DVP, 320×240) |
+| **Touch** | FT6336 / Si12T |
+| **Display** | ILI9342 (SPI, 320×240) |
 
-> 自作の stack-chan (タカヲさん版オリジナル設計) でも、上記のピンアサイン・I2C アドレスが一致していれば動く可能性があります。動作報告・修正 PR 歓迎です。
+> A self-built stack-chan (Takawo-san's original design) may also work as long as the pin assignments and I2C addresses match. Reports and PRs welcome.
 
-## ツール一覧 (gateway 経由で MCP クライアントが呼べる)
+## Tools (callable by MCP clients via the gateway)
 
-| ツール | 説明 | 状態 |
+| Tool | Description | Status |
 |---|---|---|
-| `get_status` | ゲートウェイ接続状態 | ✅ |
-| `get_device_info` | ESP32 デバイス状態 (バッテリー/音量/WiFi 等) | ✅ |
-| `take_photo(question?)` | カメラ撮影 → JPEG 保存 → パス返す | ✅ |
-| `set_volume(volume)` | スピーカー音量 (0-100) | ✅ |
-| `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
-| `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ) | ✅ |
-| `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
-| `set_avatar(face)` | アバター表情切替 (neutral/happy/sad 等 6種) | ✅ |
-| `set_blink(state)` | 瞬き ON/OFF | ✅ |
-| `set_mouth(state)` | 口開閉 | ✅ |
-| `check_vm_en` | サーボ電源 (VM EN HIGH) 状態確認 | ✅ |
+| `get_status` | Gateway connection state | ✅ |
+| `get_device_info` | ESP32 device state (battery / volume / WiFi / etc.) | ✅ |
+| `take_photo(question?)` | Capture a frame, save as JPEG, return the path | ✅ |
+| `set_volume(volume)` | Speaker volume (0-100) | ✅ |
+| `set_brightness(brightness)` | Screen brightness (0-100) | ✅ |
+| `move_head(yaw, pitch, speed?)` | Move the neck (servos) | ✅ |
+| `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
+| `set_avatar(face)` | Switch avatar expression (neutral / happy / sad / etc., 6 total) | ✅ |
+| `set_blink(state)` | Blink on/off | ✅ |
+| `set_mouth(state)` | Mouth open/close | ✅ |
+| `check_vm_en` | Check servo power supply (VM EN HIGH) state | ✅ |
 
-詳細スキーマは `gateway/README.md` 参照。
+See `gateway/README.md` for full schemas.
 
-## クイックスタート
+## Quick start
 
-### 1. ファームウェア書き込み (CoreS3)
+### 1. Flash the firmware (CoreS3)
 
 ```bash
 cd firmware
@@ -67,16 +69,16 @@ docker run --rm -v $PWD:/project -w /project espressif/idf:v5.5.2 \
   python ./scripts/release.py stackchan
 # → releases/v2.2.6_stackchan.zip
 
-# フラッシュ (CoreS3 を USB 接続後)
+# Flash (after USB-connecting the CoreS3)
 esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 build/merged-binary.bin
 ```
 
-WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う (xiaozhi-esp32 標準フロー)。
+WiFi configuration happens after the ESP32 boots — connect from a smartphone to its setup UI (the xiaozhi-esp32 standard flow).
 
 ### Configuring the WebSocket gateway URL and auth token
 
-The firmware reads two NVS keys for gateway connection:
+The firmware reads two NVS keys for the gateway connection:
 
 - `websocket.url` — the gateway WebSocket URL (e.g. `ws://192.168.1.100:8765/`)
 - `websocket.token` — the bearer token sent as `Authorization: Bearer <token>`,
@@ -120,9 +122,10 @@ credentials), enable the force-override switch:
 - `Force CONFIG_DEFAULT_WEBSOCKET_URL/TOKEN to override NVS` →
   `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y`
 
-When set, the build-time Kconfig URL/token always win over whatever NVS
-holds. The boot log will show
-`FORCE: overriding NVS websocket.url with Kconfig: NVS=... -> ...` so you
+When set, **non-empty** Kconfig URL/token values override whatever NVS holds.
+Empty Kconfig values still fall through to the NVS-based behaviour, so leaving
+the token Kconfig empty keeps any NVS-stored token in use. The boot log will
+show `FORCE: overriding NVS websocket.url with Kconfig: NVS=... -> ...` so you
 can verify the override fired. This switch is the recommended way to bring
 ex-xiaozhi hardware onto a local stackchan-mcp gateway, and to lock CI/dev
 images to a known gateway URL.
@@ -130,18 +133,18 @@ images to a known gateway URL.
 The switch is opt-in so end-user devices configured at runtime keep their
 NVS-priority semantics.
 
-### 2. ゲートウェイ起動
+### 2. Start the gateway
 
 ```bash
 cd gateway
-cp .env.example .env       # STACKCHAN_TOKEN / VISION_HOST を設定
+cp .env.example .env       # set STACKCHAN_TOKEN / VISION_HOST
 uv sync
 uv run python -m stackchan_mcp
 ```
 
-### 3. MCP クライアント登録 (Claude Code 例)
+### 3. Register as an MCP client (Claude Code example)
 
-`~/.claude.json` に追加:
+Add to `~/.claude.json`:
 
 ```json
 {
@@ -158,48 +161,48 @@ uv run python -m stackchan_mcp
 }
 ```
 
-詳細は `gateway/README.md` 参照。
+See `gateway/README.md` for details.
 
-## アバター画像について
+## About the avatar images
 
-`firmware/main/boards/stackchan/avatar_images.cc` は **真っ黒 RGB565 のプレースホルダ** です。ビルドは通りますが、画面には何も表示されません。実際にアバターを表示するには、自分の PNG 画像 (160×120) から `avatar_images.cc` を再生成してください。
+`firmware/main/boards/stackchan/avatar_images.cc` is a **pure black RGB565 placeholder**. The firmware builds and runs, but the screen will display nothing. To show an actual avatar, regenerate `avatar_images.cc` from your own PNG images (160×120).
 
-シンボル一覧 (`avatar_images.h` 参照):
-- 表情系 (6): `avatar_idle`, `avatar_happy`, `avatar_thinking`, `avatar_sad`, `avatar_surprised`, `avatar_embarrassed`
-- 目 (3): `avatar_eyes_open`, `avatar_eyes_half`, `avatar_eyes_closed`
-- 口 (5): `avatar_mouth_closed`, `avatar_mouth_half`, `avatar_mouth_open`, `avatar_mouth_e`, `avatar_mouth_u`
+Symbol list (see `avatar_images.h`):
+- Expressions (6): `avatar_idle`, `avatar_happy`, `avatar_thinking`, `avatar_sad`, `avatar_surprised`, `avatar_embarrassed`
+- Eyes (3): `avatar_eyes_open`, `avatar_eyes_half`, `avatar_eyes_closed`
+- Mouth (5): `avatar_mouth_closed`, `avatar_mouth_half`, `avatar_mouth_open`, `avatar_mouth_e`, `avatar_mouth_u`
 
-PNG → RGB565 配列の変換スクリプトは LVGL 公式の [Online Image Converter](https://lvgl.io/tools/imageconverter) などが使えます。
+For the PNG → RGB565 array conversion, tools like LVGL's official [Online Image Converter](https://lvgl.io/tools/imageconverter) work well.
 
-## 既知の課題
+## Known issues
 
-- 大角度急逆転 (±60° → -60° 等) でサーボハングする場合あり (Motion::update_task の補間移植で改善予定)
-- タッチセンサ (Si12T) のぽん判定取りこぼし (感度レジスタ調整余地)
+- The servo bus may hang on large-angle abrupt reversals (e.g. +60° → -60°). A fix is in progress via Motion::update_task interpolation.
+- The touch sensor (Si12T) occasionally drops tap events. Sensitivity register tuning has room to improve here.
 
-## ライセンス
+## License
 
-このリポジトリはデュアルライセンス構成です。
+This repository is dual-licensed.
 
-| 範囲 | ライセンス |
+| Scope | License |
 |---|---|
-| 全体 (`gateway/`, トップレベル, `firmware/` の大部分) | **MIT License** (`LICENSE` 参照) |
-| `firmware/main/boards/stackchan/` 内の **SCServo_lib 由来ファイル** (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) | **GNU GPL-3.0** (`firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt` 参照) |
+| All (`gateway/`, top-level, most of `firmware/`) | **MIT License** (see `LICENSE`) |
+| **SCServo_lib-derived files** under `firmware/main/boards/stackchan/` (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) | **GNU GPL-3.0** (see `firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt`) |
 
-これは Feetech の SCServo SDK が GPL-3.0 で配布されているための制約です。SCServo_lib を静的リンクする **firmware バイナリ全体は実質 GPL-3.0** として配布されることになります。
+This split exists because Feetech's SCServo SDK is distributed under GPL-3.0. The **firmware binary as a whole**, which statically links SCServo_lib, is therefore **effectively distributed under GPL-3.0**.
 
-一方、`gateway/` は独立した Python プロセスで、ESP32 とはネットワーク経由 (WebSocket) でしか通信しないため、**MIT License** のまま利用・派生できます。
+The `gateway/` runs as an independent Python process and only talks to the ESP32 over the network (WebSocket), so it stays usable and derivable under the **MIT License**.
 
 ### upstream
 
-`firmware/` は [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) のフォーク ([kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32)) を git subtree で取り込んでいます。SCServo_lib は公式 [stack-chan](https://github.com/mongonta0716/stack-chan) (タカヲさん) から移植したファームウェアコンポーネントです。
+`firmware/` is taken in via git subtree from [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) — specifically the [kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32) fork. SCServo_lib is a firmware component ported from the official [stack-chan](https://github.com/mongonta0716/stack-chan) (Takawo-san) repository.
 
-## 関連プロジェクト
+## Related projects
 
-- [M5Stack 公式 StackChan ドキュメント](https://docs.m5stack.com/ja/StackChan) — 想定ハードウェアの公式ドキュメント (出荷時ファーム / 配線図 / API リファレンス等)
-- [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) — ベースとなる ESP32 LLM クライアントファームウェア
-- [stack-chan](https://github.com/mongonta0716/stack-chan) — オリジナルの StackChan プロジェクト (タカヲさん)
-- [Model Context Protocol](https://modelcontextprotocol.io) — MCP プロトコル仕様
+- [M5Stack official StackChan documentation](https://docs.m5stack.com/ja/StackChan) — official documentation for the target hardware (factory firmware / wiring / API reference / etc.)
+- [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) — the base ESP32 LLM client firmware
+- [stack-chan](https://github.com/mongonta0716/stack-chan) — the original StackChan project (Takawo-san)
+- [Model Context Protocol](https://modelcontextprotocol.io) — the MCP protocol specification
 
-## コントリビューション
+## Contributing
 
-Issue / PR 歓迎です。StackChan コミュニティで使える形を目指しています。
+Issues and PRs are welcome. We aim to provide something the StackChan community can use as-is.

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -21,6 +21,37 @@ config DEFAULT_WEBSOCKET_URL
         Leave empty to require explicit NVS configuration (the original
         behavior).
 
+config DEFAULT_WEBSOCKET_TOKEN
+    string "Default WebSocket auth token (fallback when NVS is empty)"
+    default ""
+    help
+        Bearer token used when NVS websocket.token is empty. Set this if
+        your stackchan-mcp gateway requires authentication
+        (STACKCHAN_TOKEN / BEARER_TOKEN env var on the gateway side).
+        Leave empty if your gateway accepts unauthenticated connections.
+
+        The same precedence rules as CONFIG_DEFAULT_WEBSOCKET_URL apply:
+        NVS websocket.token wins by default, unless
+        CONFIG_FORCE_DEFAULT_WEBSOCKET_URL forces the Kconfig values.
+
+config FORCE_DEFAULT_WEBSOCKET_URL
+    bool "Force CONFIG_DEFAULT_WEBSOCKET_URL/TOKEN to override NVS"
+    default n
+    help
+        When enabled, the Kconfig defaults
+        (CONFIG_DEFAULT_WEBSOCKET_URL / CONFIG_DEFAULT_WEBSOCKET_TOKEN)
+        always take priority over the NVS websocket.url / websocket.token
+        values. Useful when:
+
+        - The device's NVS still contains a stale upstream xiaozhi URL
+          (e.g., wss://api.tenclass.net/...) from prior use, and there
+          is currently no runtime tool to clear that namespace
+        - You want the firmware to always talk to the same gateway
+          regardless of NVS state (common for development / CI builds)
+
+        Default disabled to preserve NVS-priority semantics for end users
+        who configure the URL/token via runtime tooling.
+
 choice
     prompt "Flash Assets"
     default FLASH_DEFAULT_ASSETS if !USE_EMOTE_MESSAGE_STYLE

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -32,16 +32,18 @@ config DEFAULT_WEBSOCKET_TOKEN
 
         The same precedence rules as CONFIG_DEFAULT_WEBSOCKET_URL apply:
         NVS websocket.token wins by default, unless
-        CONFIG_FORCE_DEFAULT_WEBSOCKET_URL forces the Kconfig values.
+        CONFIG_FORCE_DEFAULT_WEBSOCKET_URL forces the (non-empty) Kconfig
+        value to override NVS.
 
 config FORCE_DEFAULT_WEBSOCKET_URL
     bool "Force CONFIG_DEFAULT_WEBSOCKET_URL/TOKEN to override NVS"
     default n
     help
-        When enabled, the Kconfig defaults
+        When enabled, non-empty Kconfig defaults
         (CONFIG_DEFAULT_WEBSOCKET_URL / CONFIG_DEFAULT_WEBSOCKET_TOKEN)
-        always take priority over the NVS websocket.url / websocket.token
-        values. Useful when:
+        override the NVS websocket.url / websocket.token values. Empty
+        Kconfig values still fall through to NVS, so leaving the token
+        Kconfig empty keeps any NVS-stored token in use. Useful when:
 
         - The device's NVS still contains a stale upstream xiaozhi URL
           (e.g., wss://api.tenclass.net/...) from prior use, and there

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -88,6 +88,22 @@ bool WebsocketProtocol::OpenAudioChannel() {
     // this firmware always speaks to a stackchan-mcp gateway directly.
     std::string url = settings.GetString("url");
 #ifdef CONFIG_DEFAULT_WEBSOCKET_URL
+#ifdef CONFIG_FORCE_DEFAULT_WEBSOCKET_URL
+    // Force mode: Kconfig URL always wins over NVS. Used when NVS contains
+    // a stale upstream URL (e.g. wss://api.tenclass.net/...) that no
+    // runtime tool can currently overwrite. Only forces when the Kconfig
+    // value is non-empty so an unset Kconfig still falls through to NVS.
+    if (CONFIG_DEFAULT_WEBSOCKET_URL[0] != '\0') {
+        if (!url.empty() && url != CONFIG_DEFAULT_WEBSOCKET_URL) {
+            ESP_LOGI(TAG,
+                     "FORCE: overriding NVS websocket.url with Kconfig: NVS=%s -> %s",
+                     url.c_str(), CONFIG_DEFAULT_WEBSOCKET_URL);
+        } else if (url.empty()) {
+            ESP_LOGI(TAG, "FORCE: using Kconfig websocket URL: %s", CONFIG_DEFAULT_WEBSOCKET_URL);
+        }
+        url = CONFIG_DEFAULT_WEBSOCKET_URL;
+    }
+#else
     if (url.empty()) {
         url = CONFIG_DEFAULT_WEBSOCKET_URL;
         if (!url.empty()) {
@@ -95,7 +111,29 @@ bool WebsocketProtocol::OpenAudioChannel() {
         }
     }
 #endif
+#endif
     std::string token = settings.GetString("token");
+#ifdef CONFIG_DEFAULT_WEBSOCKET_TOKEN
+#ifdef CONFIG_FORCE_DEFAULT_WEBSOCKET_URL
+    // Same force-mode treatment for the token (same Kconfig switch
+    // controls both, since URL and token are typically configured together).
+    if (CONFIG_DEFAULT_WEBSOCKET_TOKEN[0] != '\0') {
+        if (!token.empty() && token != CONFIG_DEFAULT_WEBSOCKET_TOKEN) {
+            ESP_LOGI(TAG, "FORCE: overriding NVS websocket.token with Kconfig value");
+        } else if (token.empty()) {
+            ESP_LOGI(TAG, "FORCE: using Kconfig websocket token");
+        }
+        token = CONFIG_DEFAULT_WEBSOCKET_TOKEN;
+    }
+#else
+    if (token.empty()) {
+        token = CONFIG_DEFAULT_WEBSOCKET_TOKEN;
+        if (!token.empty()) {
+            ESP_LOGI(TAG, "NVS websocket.token empty; using build-time default from Kconfig");
+        }
+    }
+#endif
+#endif
     int version = settings.GetInt("version");
     if (version != 0) {
         version_ = version;


### PR DESCRIPTION
## Summary

- Adds **CONFIG_DEFAULT_WEBSOCKET_TOKEN** (string) — Kconfig fallback for the bearer token, mirroring CONFIG_DEFAULT_WEBSOCKET_URL added in #27.
- Adds **CONFIG_FORCE_DEFAULT_WEBSOCKET_URL** (bool) — when set, the Kconfig URL/token win over NVS, so devices with stale upstream xiaozhi NVS values can be redirected to a local stackchan-mcp gateway without erasing all NVS (which would also drop WiFi credentials).

## Why

#27 made it possible to bake a default URL into the firmware, but the fallback only fires when NVS \`websocket.url\` is empty. In practice this misses two common cases:

1. Hardware that previously ran upstream xiaozhi-esp32 firmware. The OTA-config path (\`ota.cc:167-186\`) writes the upstream URL (\`wss://api.tenclass.net/xiaozhi/v1/\`) into NVS, so the empty-NVS fallback never fires and the device keeps trying to talk to tenclass.
2. Authentication. \`websocket_protocol.cc\` reads \`websocket.token\` from NVS only, with no Kconfig escape hatch comparable to the URL.

The current workaround for case 1 is to edit \`websocket_protocol.cc\` and rebuild — easy to forget, easy to accidentally commit (we hit this exact loop multiple times).

## Resolution order (after this PR)

URL:
1. \`CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y\` and Kconfig URL non-empty → Kconfig URL (overrides NVS)
2. NVS \`websocket.url\` non-empty → NVS (existing behavior)
3. NVS empty → Kconfig URL (existing #27 behavior)
4. Empty → connect attempt fails with the existing log

Token: same precedence, controlled by the same FORCE switch (URL and token are typically configured together).

## Backward compatibility

- \`CONFIG_FORCE_DEFAULT_WEBSOCKET_URL\` defaults to \`n\` → \`#ifdef\` guard skips the new code path → existing behavior preserved 1:1.
- \`CONFIG_DEFAULT_WEBSOCKET_TOKEN\` defaults to \`\"\"\` → \`if (token.empty()) { token = \"\"; }\` is a no-op for current users.
- Users who configure URL/token via NVS see no behavior change unless they explicitly opt into FORCE mode.

## Files changed

- \`firmware/main/Kconfig.projbuild\` — two new Kconfig options under \`Component config\` → \`Xiaozhi Assistant\`
- \`firmware/main/protocols/websocket_protocol.cc\` — guarded force-mode branch + token fallback (mirrors existing URL fallback structure)
- \`README.md\` — \"Configuring the WebSocket gateway URL\" rewritten to cover the URL+token pair, plus a new \"Existing devices with stale NVS — \`CONFIG_FORCE_DEFAULT_WEBSOCKET_URL\`\" subsection

## Test plan

Verified end-to-end on M5Stack CoreS3 + StackChan that previously connected to tenclass (NVS contained \`wss://api.tenclass.net/xiaozhi/v1/\`):

- [x] \`python ./scripts/release.py stackchan\` builds clean (no new warnings on the changed files), \`build/xiaozhi.bin\` produced, \`releases/v2.2.6_stackchan.zip\` generated
- [x] sdkconfig.h reflects the values: \`CONFIG_DEFAULT_WEBSOCKET_URL\`, \`CONFIG_DEFAULT_WEBSOCKET_TOKEN\`, \`CONFIG_FORCE_DEFAULT_WEBSOCKET_URL 1\`
- [x] Boot log shows the FORCE override firing:
  \`\`\`
  WS: FORCE: overriding NVS websocket.url with Kconfig: NVS=wss://api.tenclass.net/xiaozhi/v1/ -> ws://<lan-ip>:8765/
  WS: FORCE: overriding NVS websocket.token with Kconfig value
  WS: Connecting to websocket server: ws://<lan-ip>:8765/
  WS: Session ID: <UUID>          # gateway response (tenclass returns short hex)
  StateMachine: connecting -> listening
  \`\`\`
- [x] gateway \`get_status\` returns \`connected=true\`, \`tools_count=14\` (all StackChan + base MCP tools)
- [x] \`set_avatar\`, \`set_blink\` invoked successfully (\`applied=1\` in firmware log)
- [x] Default-off path verified by reasoning + structure (FORCE \`#ifdef\` is a strict superset gate; the \`#else\` branch is the existing PR #27 code)
- [ ] CI build (#21) passes on this PR

## Out of scope / follow-ups

- Runtime tool to clear or write the \`websocket\` NVS namespace selectively (e.g., a WiFi config UI field, an MCP \`set_websocket_url\` tool, or selective \`erase_namespace\`). Tracked under #17 follow-ups (#25 covers the WiFi UI angle).
- mDNS auto-discovery (#26) would make the FORCE switch unnecessary in many LAN scenarios.