### PR TITLE
housekeeping: add local sdkconfig defaults override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv/
 .env
 .env.local
 *.local
+AGENTS.md
 
 # Captures (user photos)
 captures/
@@ -37,6 +38,7 @@ firmware/managed_components/
 firmware/dependencies.lock
 firmware/sdkconfig
 firmware/sdkconfig.old
+firmware/sdkconfig.defaults.local
 
 # uv lockfile is OK to commit
 # (allow-listed by absence of uv.lock entry above)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for helping improve `stackchan-mcp`.
+
+This repository contains both the Python MCP gateway and the ESP32 firmware
+used by the M5Stack official StackChan kit.
+
+## Development Flow
+
+For most changes, please work on a topic branch:
+
+```bash
+git switch main
+git pull
+git switch -c issue-123-short-description
+# edit files
+git status
+git diff
+```
+
+Then run the relevant checks, commit, push the branch, and open a pull request.
+Link the related issue in the PR body when there is one.
+
+## Gateway Checks
+
+```bash
+cd gateway
+uv sync
+uv run pytest
+uv run ruff check .
+```
+
+Add tests under `gateway/tests/` for behavior changes.
+
+## Firmware Checks
+
+Firmware changes do not yet have a full automated hardware test flow. At
+minimum, build the StackChan firmware through the board-aware release script:
+
+```bash
+cd firmware
+docker run --rm -v "$PWD":/project -w /project espressif/idf:v5.5.2 \
+  python ./scripts/release.py stackchan
+```
+
+Avoid using a plain `idf.py build` as proof that the StackChan target works; it
+may build a different board configuration.
+
+## Do Not Commit Local Secrets
+
+Please keep private or local machine state out of commits:
+
+- `.env` files
+- tokens, passwords, WiFi credentials
+- private LAN IP addresses
+- captured photos or user media
+- local `firmware/sdkconfig`
+- temporary build settings that force a personal gateway URL/token
+
+Use placeholder examples in documentation instead. Firmware developers can put
+personal Kconfig overrides in `firmware/sdkconfig.defaults.local`; it is ignored
+by git and loaded by the firmware build.
+
+## License Notes
+
+Most of this repository is MIT licensed. The SCServo-lib-derived files under
+`firmware/main/boards/stackchan/` are GPL-3.0. Please preserve the existing
+license headers and avoid moving GPL-derived code into unrelated MIT-only
+areas.

--- a/README.ja.md
+++ b/README.ja.md
@@ -110,6 +110,25 @@ NVS を全消去 (WiFi 認証も飛ぶ) せずにこれを回避するには、f
 
 スイッチは opt-in なので、ランタイムで設定するエンドユーザーデバイスは NVS-priority のままです。
 
+#### 開発者ローカル設定 — `sdkconfig.defaults.local`
+
+ローカル実機テスト用の個人 gateway URL や token は、追跡対象の
+`firmware/sdkconfig.defaults` には入れないでください。代わりに gitignore
+済みのローカルファイルを作ります:
+
+```bash
+cd firmware
+cat > sdkconfig.defaults.local <<'EOF'
+CONFIG_DEFAULT_WEBSOCKET_URL="ws://<your-lan-ip>:8765/"
+CONFIG_DEFAULT_WEBSOCKET_TOKEN="<your-dev-token>"
+CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y
+EOF
+```
+
+このファイルが存在する場合、`python ./scripts/release.py <board>` と通常の
+`idf.py build` の両方で読み込まれます。gitignore 済みなので、`git add -A`
+で個人設定を誤って追加する事故を防げます。
+
 ### 2. ゲートウェイ起動
 
 ```bash
@@ -183,3 +202,5 @@ PNG → RGB565 配列の変換スクリプトは LVGL 公式の [Online Image Co
 ## コントリビューション
 
 Issue / PR 歓迎です。StackChan コミュニティで使える形を目指しています。
+
+開発手順は [`CONTRIBUTING.md`](CONTRIBUTING.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ images to a known gateway URL.
 The switch is opt-in so end-user devices configured at runtime keep their
 NVS-priority semantics.
 
+#### Developer-local overrides — `sdkconfig.defaults.local`
+
+For local hardware testing, do not put personal gateway URLs or tokens in the
+tracked `firmware/sdkconfig.defaults`. Instead, create a gitignored local file:
+
+```bash
+cd firmware
+cat > sdkconfig.defaults.local <<'EOF'
+CONFIG_DEFAULT_WEBSOCKET_URL="ws://<your-lan-ip>:8765/"
+CONFIG_DEFAULT_WEBSOCKET_TOKEN="<your-dev-token>"
+CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y
+EOF
+```
+
+Both `python ./scripts/release.py <board>` and plain `idf.py build` will read
+this file when it exists. The file is ignored by git, so personal settings
+cannot be added accidentally with `git add -A`.
+
 ### 2. Start the gateway
 
 ```bash
@@ -206,3 +224,5 @@ The `gateway/` runs as an independent Python process and only talks to the ESP32
 ## Contributing
 
 Issues and PRs are welcome. We aim to provide something the StackChan community can use as-is.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the development flow.

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -5,6 +5,16 @@ cmake_minimum_required(VERSION 3.16)
 # Add this line to disable the specific warning
 add_compile_options(-Wno-missing-field-initializers)
 
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/sdkconfig.defaults.local")
+    if(DEFINED SDKCONFIG_DEFAULTS)
+        list(APPEND SDKCONFIG_DEFAULTS "sdkconfig.defaults.local")
+    elseif(DEFINED ENV{SDKCONFIG_DEFAULTS} AND NOT "$ENV{SDKCONFIG_DEFAULTS}" STREQUAL "")
+        set(SDKCONFIG_DEFAULTS "$ENV{SDKCONFIG_DEFAULTS};sdkconfig.defaults.local")
+    else()
+        set(SDKCONFIG_DEFAULTS "sdkconfig.defaults;sdkconfig.defaults.local")
+    endif()
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # "Trim" the build. Include the minimal set of components, main, and anything it depends on.
 idf_build_set_property(MINIMAL_BUILD ON)

--- a/firmware/scripts/release.py
+++ b/firmware/scripts/release.py
@@ -290,6 +290,43 @@ def _apply_auto_selects(sdkconfig_append: list[str]) -> list[str]:
 
     return items
 
+
+def _read_local_sdkconfig_defaults(path: Path = Path("sdkconfig.defaults.local")) -> list[str]:
+    """Read gitignored local CONFIG_* overrides, if present."""
+    if not path.exists():
+        return []
+
+    lines: list[str] = []
+    with path.open(encoding="utf-8") as f:
+        for lineno, raw_line in enumerate(f, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if not line.startswith("CONFIG_") or "=" not in line:
+                print(
+                    f"[WARN] Ignoring {path}:{lineno}: expected CONFIG_* assignment",
+                    file=sys.stderr,
+                )
+                continue
+            lines.append(line)
+    return lines
+
+
+def _merge_sdkconfig_overrides(*groups: list[str]) -> list[str]:
+    """Merge sdkconfig entries, letting later groups override earlier keys."""
+    result: list[Optional[str]] = []
+    positions: dict[str, int] = {}
+
+    for group in groups:
+        for entry in group:
+            key = entry.split("=", 1)[0].strip()
+            if key in positions:
+                result[positions[key]] = None
+            positions[key] = len(result)
+            result.append(entry)
+
+    return [entry for entry in result if entry is not None]
+
 ################################################################################
 # Check board_type in CMakeLists
 ################################################################################
@@ -358,6 +395,8 @@ def release(board_type: str, config_filename: str = "config.json", *, filter_nam
             board_type_config = _resolve_board_config(board_type, target, build_sdkconfig_append)
             sdkconfig_append = [f"{board_type_config}=y"]
             sdkconfig_append.extend(build_sdkconfig_append)
+        local_sdkconfig_append = _read_local_sdkconfig_defaults()
+        sdkconfig_append = _merge_sdkconfig_overrides(sdkconfig_append, local_sdkconfig_append)
         sdkconfig_append = _apply_auto_selects(sdkconfig_append)
 
         print("-" * 80)
@@ -365,6 +404,8 @@ def release(board_type: str, config_filename: str = "config.json", *, filter_nam
         print(f"target: {target}")
         if manufacturer:
             print(f"manufacturer: {manufacturer}")
+        if local_sdkconfig_append:
+            print("local_sdkconfig_defaults: sdkconfig.defaults.local")
         for item in sdkconfig_append:
             print(f"sdkconfig_append: {item}")
 


### PR DESCRIPTION
## Summary

- Add a gitignored `firmware/sdkconfig.defaults.local` for personal firmware Kconfig overrides.
- Load the local defaults from both the board-aware `release.py` flow and plain ESP-IDF builds.
- Add a concise `CONTRIBUTING.md` for public contribution guidance.
- Document the local override workflow in both English and Japanese READMEs.

## Why

Personal gateway URLs, tokens, and `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y` are useful during local hardware testing, but they should not be committed to the tracked `firmware/sdkconfig.defaults`.

This gives developers a safe local-only place for those settings.

Closes #29

## Validation

- `git check-ignore --no-index AGENTS.md firmware/sdkconfig.defaults.local`
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/stackchan-pycache python3 -m py_compile firmware/scripts/release.py`

Full firmware build was not run in this pass.
