### PR TITLE
docs: add PR template and contribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,20 +6,22 @@
 
 ### Code-level
 
-<!-- CI runs these where applicable. Check the ones you ran locally, or explain why not. -->
+<!-- Check what you ran locally. It is OK to leave boxes unchecked if CI will cover them or they do not apply. -->
 
 - [ ] gateway: `uv run pytest`
 - [ ] gateway: `uv run ruff check .`
 - [ ] firmware: `python ./scripts/release.py stackchan`
+- [ ] Not applicable / not run: <!-- why -->
 
 ### Hardware
 
-<!-- Required for firmware changes. Write "N/A - gateway/docs only" when hardware is not affected. -->
+<!-- For firmware changes, describe any real-device testing. If you do not have hardware, say so clearly so a maintainer can help verify before merge. -->
 
 - [ ] Device boots without crash
 - [ ] Existing MCP tools still work where affected: `move_head`, `take_photo`, `set_volume`, `get_head_angles`
 - [ ] Existing touch/servo behavior still works where affected: tap, stroke, wobble
 - [ ] New behavior verified on real hardware: <!-- details -->
+- [ ] Not applicable / hardware not available: <!-- why -->
 
 ## Breaking changes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What changed and why? Keep this focused on the public technical context. -->
+
+## Test plan
+
+### Code-level
+
+<!-- CI runs these where applicable. Check the ones you ran locally, or explain why not. -->
+
+- [ ] gateway: `uv run pytest`
+- [ ] gateway: `uv run ruff check .`
+- [ ] firmware: `python ./scripts/release.py stackchan`
+
+### Hardware
+
+<!-- Required for firmware changes. Write "N/A - gateway/docs only" when hardware is not affected. -->
+
+- [ ] Device boots without crash
+- [ ] Existing MCP tools still work where affected: `move_head`, `take_photo`, `set_volume`, `get_head_angles`
+- [ ] Existing touch/servo behavior still works where affected: tap, stroke, wobble
+- [ ] New behavior verified on real hardware: <!-- details -->
+
+## Breaking changes
+
+<!-- MCP tool API changes, NVS schema changes, build flag changes, or "None". -->
+
+## Related issues
+
+<!-- Closes #N / Refs #N -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,9 @@ Link the related issue in the PR body when there is one.
 
 ## Pull Requests
 
-Use the pull request template in `.github/PULL_REQUEST_TEMPLATE.md`. Fill it in
-rather than deleting sections. A good PR should include:
+Use the pull request template in `.github/PULL_REQUEST_TEMPLATE.md`. It is a
+guide, not a gate. Fill in what you know, leave boxes unchecked when they do
+not apply, and explain anything you could not test.
 
 - Summary: what changed and why
 - Test plan: checks that passed, plus any checks intentionally skipped
@@ -65,8 +66,9 @@ pushes to `main`. It currently verifies:
   `espressif/idf:v5.5.2`
 - Gateway: `uv sync --frozen`, `uv run ruff check .`, and `uv run pytest`
 
-CI is the shared baseline, but it does not replace real hardware testing for
-firmware changes.
+CI is the shared baseline. For firmware changes, real hardware testing is still
+needed before merge, but contributors without hardware are welcome to open PRs
+and ask for maintainer verification.
 
 ## Gateway Checks
 
@@ -99,9 +101,14 @@ may build a different board configuration.
 
 ## Hardware Test Requirement
 
-Any pull request that changes `firmware/` must be flashed to and verified on
-real StackChan hardware before it is ready for review. Building without
-flashing is useful, but it is not sufficient for firmware behavior changes.
+Firmware changes should be flashed to and verified on real StackChan hardware
+before merge. Building without flashing is useful, but it is not sufficient as
+the final verification for firmware behavior changes.
+
+If you do not have hardware, you can still open a PR. Mark the Hardware section
+as not available and describe the code-level checks you did run. A maintainer
+can help decide whether to verify it on a device, keep it as a draft, or split
+out a smaller change.
 
 In the PR template's Hardware section, document what you verified. At minimum:
 
@@ -109,8 +116,8 @@ In the PR template's Hardware section, document what you verified. At minimum:
 - Existing MCP tools still work for the affected area
 - New firmware behavior is tested on the real device
 
-Gateway-only and documentation-only PRs do not require hardware testing. Write
-`N/A - gateway/docs only` in the Hardware section.
+Gateway-only and documentation-only PRs do not require hardware testing. Mark
+the Hardware section as not applicable.
 
 ## Do Not Commit Local Secrets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,32 @@
 Thanks for helping improve `stackchan-mcp`.
 
 This repository contains both the Python MCP gateway and the ESP32 firmware
-used by the M5Stack official StackChan kit.
+used by the M5Stack official StackChan kit. The goal is to keep the public
+project easy to reproduce: issues, pull requests, commits, and documentation
+should contain technical context that is useful to other builders.
+
+## Setup
+
+Install the tools needed for the part of the repository you are changing:
+
+- Firmware: Docker or a compatible container runtime that can run
+  `espressif/idf:v5.5.2`
+- Gateway: Python managed with `uv`
+- Hardware testing: M5Stack CoreS3 + official StackChan kit
+
+For gateway development:
+
+```bash
+cd gateway
+uv sync
+```
+
+For firmware development, use the board-aware release script shown below. It
+sets the StackChan board configuration before building.
 
 ## Development Flow
 
-For most changes, please work on a topic branch:
+For most changes, work on a topic branch:
 
 ```bash
 git switch main
@@ -21,7 +42,35 @@ git diff
 Then run the relevant checks, commit, push the branch, and open a pull request.
 Link the related issue in the PR body when there is one.
 
+## Pull Requests
+
+Use the pull request template in `.github/PULL_REQUEST_TEMPLATE.md`. Fill it in
+rather than deleting sections. A good PR should include:
+
+- Summary: what changed and why
+- Test plan: checks that passed, plus any checks intentionally skipped
+- Hardware notes: required for firmware changes
+- Breaking changes: MCP tool API, NVS schema, build flags, or `None`
+- Related issues: `Closes #N` or `Refs #N` when applicable
+
+Small, focused PRs are easier to review. Prefer one issue per PR, or one small
+maintenance purpose per PR.
+
+## CI
+
+The build workflow in `.github/workflows/build.yml` runs on pull requests and
+pushes to `main`. It currently verifies:
+
+- Firmware: `python ./scripts/release.py stackchan` inside
+  `espressif/idf:v5.5.2`
+- Gateway: `uv sync --frozen`, `uv run ruff check .`, and `uv run pytest`
+
+CI is the shared baseline, but it does not replace real hardware testing for
+firmware changes.
+
 ## Gateway Checks
+
+Run these for gateway changes:
 
 ```bash
 cd gateway
@@ -34,8 +83,7 @@ Add tests under `gateway/tests/` for behavior changes.
 
 ## Firmware Checks
 
-Firmware changes do not yet have a full automated hardware test flow. At
-minimum, build the StackChan firmware through the board-aware release script:
+Build the StackChan firmware through the board-aware release script:
 
 ```bash
 cd firmware
@@ -43,8 +91,26 @@ docker run --rm -v "$PWD":/project -w /project espressif/idf:v5.5.2 \
   python ./scripts/release.py stackchan
 ```
 
+This produces `build/merged-binary.bin` and
+`releases/v2.2.6_stackchan.zip`.
+
 Avoid using a plain `idf.py build` as proof that the StackChan target works; it
 may build a different board configuration.
+
+## Hardware Test Requirement
+
+Any pull request that changes `firmware/` must be flashed to and verified on
+real StackChan hardware before it is ready for review. Building without
+flashing is useful, but it is not sufficient for firmware behavior changes.
+
+In the PR template's Hardware section, document what you verified. At minimum:
+
+- Device boots without crash
+- Existing MCP tools still work for the affected area
+- New firmware behavior is tested on the real device
+
+Gateway-only and documentation-only PRs do not require hardware testing. Write
+`N/A - gateway/docs only` in the Hardware section.
 
 ## Do Not Commit Local Secrets
 
@@ -61,9 +127,44 @@ Use placeholder examples in documentation instead. Firmware developers can put
 personal Kconfig overrides in `firmware/sdkconfig.defaults.local`; it is ignored
 by git and loaded by the firmware build.
 
-## License Notes
+## License Boundary
 
 Most of this repository is MIT licensed. The SCServo-lib-derived files under
-`firmware/main/boards/stackchan/` are GPL-3.0. Please preserve the existing
-license headers and avoid moving GPL-derived code into unrelated MIT-only
-areas.
+`firmware/main/boards/stackchan/` are GPL-3.0:
+
+- `INST.h`
+- `SCS.cc`
+- `SCS.h`
+- `SCSCL.cc`
+- `SCSCL.h`
+- `SCSerial.cc`
+- `SCSerial.h`
+- `SCServo.h`
+
+Preserve the existing GPL-3.0 license headers in those files. Avoid moving
+GPL-derived code into unrelated MIT-only areas, and do not include MIT-only
+project headers from outside `firmware/main/boards/stackchan/` into the
+GPL-derived files unless the licensing impact has been reviewed.
+
+The gateway runs as an independent Python process and communicates with the
+firmware over WebSocket, so the process boundary keeps the gateway side usable
+under the MIT license.
+
+## Review Process
+
+Maintainer review is required before merge. Squash merge is preferred so each
+PR lands as one coherent change on `main`.
+
+Significant firmware changes should receive especially careful review for race
+conditions, resource lifetime, boot behavior, NVS compatibility, and hardware
+failure modes.
+
+## Communication
+
+Issue and PR descriptions should use English as the baseline. Japanese mixed
+in is fine where it helps the StackChan community, but public technical context
+should remain understandable to international contributors. Code comments
+should be in English.
+
+Be polite and concrete. This is a small hardware community, and clear technical
+notes help the next person reproduce what happened.


### PR DESCRIPTION
## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` with Summary, Test plan, Hardware, Breaking changes, and Related issues sections.
- Expand `CONTRIBUTING.md` with setup, CI baseline, PR process, firmware hardware-test requirements, license-boundary policy, review process, and communication guidance.

## Why

PRs should consistently document what changed, what was tested, whether hardware validation is required, and whether there are breaking changes. The contributing guide also needs to make the firmware hardware-test and SCServo GPL boundary explicit for external contributors.

## Validation

- `git diff --check`
- `git diff --check HEAD~1..HEAD`

Docs-only change; gateway tests, ruff, and firmware build were not run.

Closes #22
Closes #23