### PR TITLE
Expose get_head_angles gateway tool

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -86,6 +86,7 @@ Same shape, under `mcpServers`.
 | `set_volume(volume)` | Speaker volume 0-100 |
 | `set_brightness(brightness)` | Screen brightness 0-100 |
 | `move_head(yaw, pitch, speed?)` | Drive yaw + pitch servos |
+| `get_head_angles` | Read current yaw + pitch servo angles |
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`) |
 | `set_blink(state)` | Blink animation on/off |

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -120,6 +120,14 @@ def create_server() -> Server:
                 },
             ),
             Tool(
+                name="get_head_angles",
+                description="Get the robot's current head angles: yaw and pitch in degrees.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {},
+                },
+            ),
+            Tool(
                 name="gpio_test",
                 description="Test GPIO6 pin by toggling HIGH/LOW 5 times. Check if servo reacts.",
                 inputSchema={"type": "object", "properties": {}},
@@ -254,6 +262,10 @@ def create_server() -> Server:
             "move_head": (
                 "self.robot.set_head_angles",
                 arguments,
+            ),
+            "get_head_angles": (
+                "self.robot.get_head_angles",
+                {},
             ),
             "gpio_test": (
                 "self.robot.gpio_test",

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -1,5 +1,10 @@
 """Tests for stdio MCP server tool definitions."""
 
+import json
+
+import pytest
+from mcp.types import CallToolRequest, ListToolsRequest
+
 from stackchan_mcp.stdio_server import create_server
 
 
@@ -8,3 +13,54 @@ def test_create_server():
     server = create_server()
     assert server is not None
     assert server.name == "stackchan-mcp"
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_get_head_angles():
+    """get_head_angles is exposed to MCP clients."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tool_names = [tool.name for tool in result.root.tools]
+    assert "get_head_angles" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_get_head_angles_relays_to_esp32(monkeypatch):
+    """get_head_angles maps to the ESP32 self.robot.get_head_angles tool."""
+    calls = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"yaw": 12, "pitch": -3}),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "get_head_angles", "arguments": {}},
+        )
+    )
+
+    assert calls == [("self.robot.get_head_angles", {})]
+    assert json.loads(result.root.content[0].text) == {"yaw": 12, "pitch": -3}


### PR DESCRIPTION
## Summary

- Expose `get_head_angles` as a stdio MCP client tool.
- Relay `get_head_angles` to the ESP32-side `self.robot.get_head_angles` tool.
- Add stdio-server tests and document the tool in `gateway/README.md`.

## Why

`set_head_angles` is now asynchronous on the device side, but MCP clients could not query the current servo angles through the gateway. Exposing this read tool lets clients confirm the current head position after motion commands.

Closes #18.
Refs #33 for the separate WebSocket reconnect behavior observed during hardware validation.

## Validation

- `cd gateway && uv run pytest tests/test_stdio_server.py`
- `cd gateway && CAPTURE_PORT=0 uv run pytest`
- `cd gateway && uv run ruff check .`
- Hardware smoke test with a connected StackChan:
  - restarted the gateway on this branch
  - confirmed the ESP32 exposed `self.robot.get_head_angles`
  - called gateway `get_head_angles`
  - observed response: `{"yaw":1,"pitch":0}`
