### PR TITLE
fix(firmware): reconnect websocket after gateway restart

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -138,6 +138,10 @@ uv sync
 uv run python -m stackchan_mcp
 ```
 
+ESP32 接続中にゲートウェイを再起動した場合、ファームウェアは idle 中に
+WebSocket 接続を自動再試行します。再試行間隔は 5 秒から始まり、最大 60 秒
+まで伸びます。デバイスが戻ったかどうかは `get_status` で確認できます。
+
 ### 3. MCP クライアント登録 (Claude Code 例)
 
 `~/.claude.json` に追加:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ uv sync
 uv run python -m stackchan_mcp
 ```
 
+If the gateway is restarted while the ESP32 is already connected, the firmware
+automatically retries the WebSocket connection while idle. The retry delay starts
+at 5 seconds and backs off up to 60 seconds; use `get_status` to confirm that
+the device has reappeared.
+
 ### 3. Register as an MCP client (Claude Code example)
 
 Add to `~/.claude.json`:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,16 @@ The token is set on both sides:
 - Gateway: `STACKCHAN_TOKEN` (or legacy `BEARER_TOKEN`) in `gateway/.env`
 - ESP32: configured via the xiaozhi-esp32 WiFi setup UI on first boot
 
+## Connection lifecycle
+
+The ESP32 is the WebSocket client and the gateway listens on port `8765`. If
+the gateway restarts, the existing socket drops. Firmware treats that as an
+audio-channel close, returns to idle, and retries the WebSocket connection in
+the background with bounded backoff from 5 seconds up to 60 seconds.
+
+Intentional device-side closes, such as ending a listening session, do not
+schedule this reconnect loop.
+
 ## Phase roadmap
 
 - **Phase 0**: stdio MCP shell, ESP32 WebSocket bridge, tool routing → done

--- a/firmware/docs/websocket.md
+++ b/firmware/docs/websocket.md
@@ -73,10 +73,15 @@ This document describes the WebSocket communication protocol between the device 
 
    - When the server or network drops, `OnDisconnected()` fires:
      - The device invokes `on_audio_channel_closed_()` and eventually returns to the idle state.
+     - If the socket was not closed intentionally, the firmware schedules a
+       background reconnect while the device is idle. Retries start after 5
+       seconds and back off up to 60 seconds.
 
 6. **Closing the WebSocket connection**
    - When the device wants to end the session, it calls `CloseAudioChannel()` to tear down the socket and returns to idle.
-   - The same callback chain runs if the server closes the socket first.
+   - Intentional closes do not schedule a reconnect. Server-initiated closes
+     and gateway restarts do schedule one, so MCP tools become available again
+     after the gateway comes back.
 
 ---
 

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -8,16 +8,50 @@
 #include <cJSON.h>
 #include <esp_log.h>
 #include <arpa/inet.h>
+#include <algorithm>
 #include "assets/lang_config.h"
 
 #define TAG "WS"
 
 WebsocketProtocol::WebsocketProtocol() {
     event_group_handle_ = xEventGroupCreate();
+
+    esp_timer_create_args_t reconnect_timer_args = {
+        .callback = [](void* arg) {
+            auto protocol = static_cast<WebsocketProtocol*>(arg);
+            auto alive = protocol->alive_;
+            Application::GetInstance().Schedule([protocol, alive]() {
+                if (!*alive || !protocol->auto_reconnect_enabled_.load()) {
+                    return;
+                }
+
+                auto& app = Application::GetInstance();
+                if (app.GetDeviceState() != kDeviceStateIdle) {
+                    protocol->ScheduleReconnect();
+                    return;
+                }
+
+                ESP_LOGI(TAG, "Reconnecting to websocket server");
+                if (!protocol->OpenAudioChannelInternal(false)) {
+                    protocol->ScheduleReconnect();
+                }
+            });
+        },
+        .arg = this,
+    };
+    esp_timer_create(&reconnect_timer_args, &reconnect_timer_);
 }
 
 WebsocketProtocol::~WebsocketProtocol() {
-    vEventGroupDelete(event_group_handle_);
+    *alive_ = false;
+    StopReconnectTimer();
+    if (reconnect_timer_ != nullptr) {
+        esp_timer_delete(reconnect_timer_);
+    }
+    websocket_.reset();
+    if (event_group_handle_ != nullptr) {
+        vEventGroupDelete(event_group_handle_);
+    }
 }
 
 bool WebsocketProtocol::Start() {
@@ -77,10 +111,24 @@ bool WebsocketProtocol::IsAudioChannelOpened() const {
 
 void WebsocketProtocol::CloseAudioChannel(bool send_goodbye) {
     (void)send_goodbye;  // Websocket doesn't need to send goodbye message
+    auto_reconnect_enabled_.store(false);
+    StopReconnectTimer();
     websocket_.reset();
 }
 
 bool WebsocketProtocol::OpenAudioChannel() {
+    return OpenAudioChannelInternal(true);
+}
+
+bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
+    bool reconnect_was_enabled = auto_reconnect_enabled_.load();
+    auto_reconnect_enabled_.store(false);
+    StopReconnectTimer();
+    websocket_.reset();
+    auto_reconnect_enabled_.store(reconnect_was_enabled);
+    session_id_ = "";
+    xEventGroupClearBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
+
     Settings settings("websocket", false);
     // Read the gateway URL from NVS (set via the WiFi config UI's "websocket
     // url" field on first boot, e.g. "ws://<your-gateway-lan-ip>:8765"). The
@@ -216,17 +264,29 @@ bool WebsocketProtocol::OpenAudioChannel() {
     });
 
     websocket_->OnDisconnected([this]() {
+        if (on_disconnected_ != nullptr) {
+            on_disconnected_();
+        }
         ESP_LOGI(TAG, "Websocket disconnected");
         if (on_audio_channel_closed_ != nullptr) {
             on_audio_channel_closed_();
+        }
+        if (auto_reconnect_enabled_.load()) {
+            ScheduleReconnect();
         }
     });
 
     ESP_LOGI(TAG, "Connecting to websocket server: %s with version: %d", url.c_str(), version_);
     if (!websocket_->Connect(url.c_str())) {
         ESP_LOGE(TAG, "Failed to connect to websocket server, code=%d", websocket_->GetLastError());
-        SetError(Lang::Strings::SERVER_NOT_CONNECTED);
+        if (report_error) {
+            SetError(Lang::Strings::SERVER_NOT_CONNECTED);
+        }
         return false;
+    }
+
+    if (on_connected_ != nullptr) {
+        on_connected_();
     }
 
     // Send hello message to describe the client
@@ -239,15 +299,38 @@ bool WebsocketProtocol::OpenAudioChannel() {
     EventBits_t bits = xEventGroupWaitBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT, pdTRUE, pdFALSE, pdMS_TO_TICKS(10000));
     if (!(bits & WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT)) {
         ESP_LOGE(TAG, "Failed to receive server hello");
-        SetError(Lang::Strings::SERVER_TIMEOUT);
+        if (report_error) {
+            SetError(Lang::Strings::SERVER_TIMEOUT);
+        }
         return false;
     }
+
+    auto_reconnect_enabled_.store(true);
+    reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
+    StopReconnectTimer();
 
     if (on_audio_channel_opened_ != nullptr) {
         on_audio_channel_opened_();
     }
 
     return true;
+}
+
+void WebsocketProtocol::ScheduleReconnect() {
+    if (reconnect_timer_ == nullptr || !auto_reconnect_enabled_.load()) {
+        return;
+    }
+
+    StopReconnectTimer();
+    ESP_LOGI(TAG, "Schedule websocket reconnect in %d seconds", reconnect_interval_ms_ / 1000);
+    esp_timer_start_once(reconnect_timer_, reconnect_interval_ms_ * 1000);
+    reconnect_interval_ms_ = std::min(reconnect_interval_ms_ * 2, WEBSOCKET_RECONNECT_MAX_INTERVAL_MS);
+}
+
+void WebsocketProtocol::StopReconnectTimer() {
+    if (reconnect_timer_ != nullptr) {
+        esp_timer_stop(reconnect_timer_);
+    }
 }
 
 std::string WebsocketProtocol::GetHelloMessage() {

--- a/firmware/main/protocols/websocket_protocol.h
+++ b/firmware/main/protocols/websocket_protocol.h
@@ -7,8 +7,14 @@
 #include <web_socket.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
+#include <esp_timer.h>
+
+#include <atomic>
+#include <memory>
 
 #define WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT (1 << 0)
+#define WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS 5000
+#define WEBSOCKET_RECONNECT_MAX_INTERVAL_MS 60000
 
 class WebsocketProtocol : public Protocol {
 public:
@@ -22,13 +28,20 @@ public:
     bool IsAudioChannelOpened() const override;
 
 private:
+    std::shared_ptr<std::atomic<bool>> alive_ = std::make_shared<std::atomic<bool>>(true);
     EventGroupHandle_t event_group_handle_;
     std::unique_ptr<WebSocket> websocket_;
+    esp_timer_handle_t reconnect_timer_ = nullptr;
+    std::atomic<bool> auto_reconnect_enabled_ = false;
+    int reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
     int version_ = 1;
 
     void ParseServerHello(const cJSON* root);
     bool SendText(const std::string& text) override;
     std::string GetHelloMessage();
+    bool OpenAudioChannelInternal(bool report_error);
+    void ScheduleReconnect();
+    void StopReconnectTimer();
 };
 
 #endif

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -39,6 +39,11 @@ Default ports:
 - WebSocket (ESP32 -> gateway): `0.0.0.0:8765`
 - HTTP capture (ESP32 -> gateway): `0.0.0.0:8766`
 
+When you restart the gateway during development, an already-connected ESP32
+will notice the dropped WebSocket and retry while idle. The retry delay starts
+at 5 seconds and backs off up to 60 seconds. After the gateway is listening
+again, check `get_status` from the stdio MCP side to confirm the device is back.
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- Add bounded WebSocket reconnect backoff for unexpected gateway disconnects.
- Keep intentional audio channel closes from auto-reconnecting.
- Document gateway restart recovery behavior in firmware and gateway docs.

## Why
Issue #33 reported that StackChan required user action after the local gateway restarted. The firmware now schedules reconnect attempts while idle so the device can recover once the gateway comes back.

## Validation
- From firmware/: docker run --rm -v "<firmware-dir>":/project -w /project espressif/idf:v5.5.2 python ./scripts/release.py stackchan
- Flashed only build/xiaozhi.bin to 0x20000 on ESP32-S3 StackChan, preserving NVS.
- Confirmed on hardware that local ignored sdkconfig.defaults.local overrides the old NVS WebSocket URL.
- Confirmed gateway connection registers the ESP32 and discovers 14 tools.
- Stopped the gateway and observed firmware schedule reconnects with 5s, 10s, then 20s backoff.
- Restarted the gateway and confirmed the next reconnect attempt restored the ESP32 connection automatically.

Closes #33