### PR TITLE
docs: clarify repository language policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,12 +166,23 @@ Significant firmware changes should receive especially careful review for race
 conditions, resource lifetime, boot behavior, NVS compatibility, and hardware
 failure modes.
 
-## Communication
+## Documentation Language
 
-Issue and PR descriptions should use English as the baseline. Japanese mixed
-in is fine where it helps the StackChan community, but public technical context
-should remain understandable to international contributors. Code comments
-should be in English.
+The top-level user guide is maintained in both English and Japanese:
+
+- `README.md`: English entry point for international contributors
+- `README.ja.md`: Japanese entry point for the StackChan community
+
+Developer-facing subdocuments such as `gateway/README.md`, `docs/*.md`, issue
+templates, and pull request templates should use English as the baseline. Add a
+Japanese companion file only when a document has clear end-user value for the
+Japanese community and can be kept reasonably in sync.
+
+Keep code comments, public issue descriptions, and pull request descriptions in
+English unless Japanese is needed for a hardware name, quoted source, or
+community-specific term.
+
+## Communication
 
 Be polite and concrete. This is a small hardware community, and clear technical
 notes help the next person reproduce what happened.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Target hardware: **M5Stack 公式 [StackChan](https://docs.m5stack.com/ja/StackChan)** kit (Kickstarter 2025 出荷版). The diagrams below describe how this repo's gateway and firmware bridge an MCP client to that kit.
+Target hardware: **M5Stack official [StackChan](https://docs.m5stack.com/ja/StackChan)** kit (2025 Kickstarter shipping version). The diagrams below describe how this repo's gateway and firmware bridge an MCP client to that kit.
 
 ## Component overview
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,11 +1,11 @@
 # gateway
 
-Python "two-faced" MCP gateway for the **M5Stack 公式 [StackChan](https://docs.m5stack.com/ja/StackChan)** kit (custom [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) firmware in [`../firmware/main/boards/stackchan/`](../firmware/main/boards/stackchan/)).
+Python "two-faced" MCP gateway for the **M5Stack official [StackChan](https://docs.m5stack.com/ja/StackChan)** kit (custom [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) firmware in [`../firmware/main/boards/stackchan/`](../firmware/main/boards/stackchan/)).
 
 ```
 ┌─────────────┐  stdio MCP  ┌──────────────┐  WebSocket MCP  ┌──────────┐
 │ MCP client  │ ──────────▶ │   gateway    │ ──────────────▶ │  ESP32   │
-│ (Claude等)  │ ◀────────── │  (this dir)  │ ◀────────────── │ StackChan│
+│ (Claude...) │ ◀────────── │  (this dir)  │ ◀────────────── │ StackChan│
 └─────────────┘             │              │                 └──────────┘
                             │  /capture    │ ◀─ HTTP POST ──┘  (JPEG)
                             └──────────────┘


### PR DESCRIPTION
## Summary

- Document the repo language policy in CONTRIBUTING.md
- Keep the top-level README pair as the English/Japanese user entry points
- Clean up stray Japanese text in English developer docs

## Test plan

### Code-level

- [ ] gateway: `uv run pytest`
- [ ] gateway: `uv run ruff check .`
- [ ] firmware: `python ./scripts/release.py stackchan`
- [x] Not applicable / not run: documentation-only change; ran `git diff --check`

### Hardware

- [ ] Device boots without crash
- [ ] Existing MCP tools still work where affected: `move_head`, `take_photo`, `set_volume`, `get_head_angles`
- [ ] Existing touch/servo behavior still works where affected: tap, stroke, wobble
- [ ] New behavior verified on real hardware: N/A
- [x] Not applicable / hardware not available: documentation-only change

## Breaking changes

None.

## Related issues

Closes #30