### PR TITLE
docs: add Tailscale remote access guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@
 |---|---|
 | `firmware/` | [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) フォーク全体（git subtree）。StackChan 用カスタムボードは `firmware/main/boards/stackchan/` に配置 |
 | `gateway/` | Python MCP ゲートウェイ。stdio MCP サーバー (LLM側) + WebSocket MCP クライアント (ESP32側) + HTTP capture サーバー |
-| `docs/` | [`architecture.md`](docs/architecture.md): 全体構成図・ツール名マッピング・写真フロー・認証・Phase ロードマップ。[`firmware-sync.md`](docs/firmware-sync.md): upstream xiaozhi-esp32 同期手順 |
+| `docs/` | [`architecture.md`](docs/architecture.md): 全体構成図・ツール名マッピング・写真フロー・認証・Phase ロードマップ。[`firmware-sync.md`](docs/firmware-sync.md): upstream xiaozhi-esp32 同期手順。[`remote-access.md`](docs/remote-access.md): Tailscale Funnel による非LAN接続手順 |
 
 ## 想定ハードウェア
 
@@ -141,6 +141,9 @@ uv run python -m stackchan_mcp
 ESP32 接続中にゲートウェイを再起動した場合、ファームウェアは idle 中に
 WebSocket 接続を自動再試行します。再試行間隔は 5 秒から始まり、最大 60 秒
 まで伸びます。デバイスが戻ったかどうかは `get_status` で確認できます。
+
+別ネットワークから使う場合は、Tailscale Funnel と `VISION_URL` による capture
+callback 設定を [`docs/remote-access.md`](docs/remote-access.md) にまとめています。
 
 ### 3. MCP クライアント登録 (Claude Code 例)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository is a monorepo.
 |---|---|
 | `firmware/` | Full git subtree of [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32). The custom StackChan board lives at `firmware/main/boards/stackchan/`. |
 | `gateway/` | Python MCP gateway. stdio MCP server (LLM side) + WebSocket MCP client (ESP32 side) + HTTP capture server. |
-| `docs/` | [`architecture.md`](docs/architecture.md): full component diagram, tool name mapping, photo flow, auth, phase roadmap. [`firmware-sync.md`](docs/firmware-sync.md): upstream xiaozhi-esp32 sync playbook. |
+| `docs/` | [`architecture.md`](docs/architecture.md): full component diagram, tool name mapping, photo flow, auth, phase roadmap. [`firmware-sync.md`](docs/firmware-sync.md): upstream xiaozhi-esp32 sync playbook. [`remote-access.md`](docs/remote-access.md): Tailscale Funnel setup for non-LAN use. |
 
 ## Target hardware
 
@@ -164,6 +164,9 @@ If the gateway is restarted while the ESP32 is already connected, the firmware
 automatically retries the WebSocket connection while idle. The retry delay starts
 at 5 seconds and backs off up to 60 seconds; use `get_status` to confirm that
 the device has reappeared.
+
+For non-LAN setups, see [`docs/remote-access.md`](docs/remote-access.md) for the
+Tailscale Funnel flow and the `VISION_URL` capture callback setting.
 
 ### 3. Register as an MCP client (Claude Code example)
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,0 +1,173 @@
+# Remote Access with Tailscale Funnel
+
+This guide explains how to make a `stackchan-mcp` gateway reachable when the
+StackChan device and gateway host are on different networks.
+
+The recommended first path is Tailscale Funnel:
+
+- no firmware feature work is required
+- the ESP32 connects to a public `wss://...ts.net` gateway URL
+- the gateway still verifies the ESP32 bearer token with `STACKCHAN_TOKEN`
+- photo uploads can use a second Funnel URL through `VISION_URL`
+
+Tailscale Funnel publishes local services on a device in your tailnet to the
+public internet over HTTPS. It requires Tailscale CLI support, MagicDNS, HTTPS
+certificates, and a Funnel node attribute in the tailnet policy. Funnel can
+listen only on `443`, `8443`, or `10000`, so this guide uses `443` for the
+WebSocket gateway and `8443` for the photo capture endpoint.
+
+Reference:
+
+- [Tailscale Funnel](https://tailscale.com/docs/features/tailscale-funnel)
+- [tailscale funnel command](https://tailscale.com/docs/reference/tailscale-cli/funnel)
+- [Tailscale Funnel examples](https://tailscale.com/docs/reference/examples/funnel)
+
+## Network Shape
+
+```
+ESP32 StackChan
+    │
+    │ wss://<node>.<tailnet>.ts.net/
+    ▼
+Tailscale Funnel :443
+    │
+    │ forwards to local TCP
+    ▼
+stackchan-mcp gateway WebSocket :8765
+
+ESP32 camera upload
+    │
+    │ https://<node>.<tailnet>.ts.net:8443/capture
+    ▼
+Tailscale Funnel :8443
+    │
+    │ forwards to local HTTP
+    ▼
+stackchan-mcp capture server :8766
+```
+
+## Security Notes
+
+Funnel makes the selected service public. Keep `STACKCHAN_TOKEN` set and use a
+strong token for the WebSocket gateway.
+
+The `/capture` endpoint is a separate HTTP upload endpoint and does not
+currently enforce the ESP32 bearer token by itself. If you expose it with
+Funnel, treat the capture URL as public while the Funnel listener is enabled,
+turn it off when it is not needed, and do not expose captured photos or other
+user data in git.
+
+Do not publish personal tokens, LAN IP addresses, WiFi credentials, `.env`
+files, captures, or local firmware override files.
+
+If you only need access from devices that already run Tailscale, use Tailscale
+Serve or a normal tailnet address instead of Funnel. The ESP32 firmware does
+not currently run a Tailscale client, so the StackChan device itself needs a
+public Funnel URL unless a separate network layer routes it into the tailnet.
+
+## Gateway Configuration
+
+In `gateway/.env`, keep the gateway listening locally and set both the ESP32
+auth token and the public capture URL:
+
+```bash
+STACKCHAN_TOKEN=<strong-shared-token>
+
+HOST=0.0.0.0
+WS_PORT=8765
+CAPTURE_PORT=8766
+
+VISION_URL=https://<node>.<tailnet>.ts.net:8443/capture
+```
+
+`VISION_URL` is the full URL sent to the ESP32 for `take_photo` uploads. Use it
+for remote tunnel setups. `VISION_HOST` remains useful for LAN-only setups where
+the capture URL is `http://<lan-ip>:8766/capture`.
+
+Start the gateway:
+
+```bash
+cd gateway
+uv run python -m stackchan_mcp
+```
+
+## Funnel Setup
+
+On the same host as the gateway, enable two Funnel listeners.
+
+Use port `443` for the WebSocket gateway:
+
+```bash
+tailscale funnel --bg --tls-terminated-tcp=443 tcp://localhost:8765
+```
+
+Use port `8443` for the HTTP capture server:
+
+```bash
+tailscale funnel --bg --https=8443 http://localhost:8766
+```
+
+Check the published URLs:
+
+```bash
+tailscale funnel status
+```
+
+The expected public endpoints are:
+
+- WebSocket: `wss://<node>.<tailnet>.ts.net/`
+- Capture: `https://<node>.<tailnet>.ts.net:8443/capture`
+
+To stop the listeners:
+
+```bash
+tailscale funnel --tls-terminated-tcp=443 tcp://localhost:8765 off
+tailscale funnel --https=8443 http://localhost:8766 off
+```
+
+## Device Configuration
+
+Configure the firmware's WebSocket URL and bearer token:
+
+```text
+websocket.url = wss://<node>.<tailnet>.ts.net/
+websocket.token = <strong-shared-token>
+```
+
+For developer builds, these can be provided through the existing Kconfig
+fallbacks:
+
+```text
+CONFIG_DEFAULT_WEBSOCKET_URL="wss://<node>.<tailnet>.ts.net/"
+CONFIG_DEFAULT_WEBSOCKET_TOKEN="<strong-shared-token>"
+```
+
+For existing devices with stale NVS values, use the documented
+`CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y` flow from the top-level README.
+
+## Validation
+
+After the gateway, Funnel, and device settings are in place:
+
+1. Start the gateway.
+2. Start both Funnel listeners.
+3. Reboot or reset the StackChan device.
+4. Call `get_status` from the MCP client and confirm `connected=true`.
+5. Call `get_device_info`.
+6. Call `take_photo` and confirm the capture reaches the gateway.
+
+If `get_status` works but `take_photo` fails, the WebSocket path is working but
+the capture callback URL is wrong. Re-check `VISION_URL`, the `8443` Funnel
+listener, and whether the capture URL ends with `/capture`.
+
+If `take_photo` is not needed for a remote session, leave the `8443` Funnel
+listener off and use only the WebSocket listener.
+
+## Limitations
+
+- Funnel bandwidth limits are managed by Tailscale and are not configurable.
+- Latency depends on the device WiFi, the gateway network, and Funnel relay path.
+- The future Opus audio stream may need lower and more stable latency than
+  simple control and photo capture.
+- A firmware-native WireGuard or Tailscale-style client would be a separate
+  follow-up feature, not part of this guide.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -158,9 +158,19 @@ After the gateway, Funnel, and device settings are in place:
 1. Start the gateway.
 2. Start both Funnel listeners.
 3. Reboot or reset the StackChan device.
-4. Call `get_status` from the MCP client and confirm `connected=true`.
-5. Call `get_device_info`.
-6. Call `take_photo` and confirm the capture reaches the gateway.
+4. Press the StackChan main button to start a chat session. The firmware opens
+   the WebSocket connection when a session starts; an idle device may not appear
+   in `get_status` immediately after boot.
+5. Call `get_status` from the MCP client and confirm `connected=true`.
+6. Call `get_device_info`.
+7. Call `take_photo` and confirm the capture reaches the gateway.
+
+If the device and gateway are on the same physical LAN during validation, this
+still verifies that the firmware uses the public Funnel `wss://` URL, bearer
+auth, MCP initialization, and the authenticated capture callback. It does not
+prove behavior across every remote network path. For a stronger end-to-end
+remote proof, place the StackChan device on a different network, such as a phone
+hotspot, while keeping the gateway host behind Funnel.
 
 If `get_status` works but `take_photo` fails, the WebSocket path is working but
 the capture callback URL is wrong. Re-check `VISION_URL`, the `8443` Funnel

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -104,7 +104,7 @@ On the same host as the gateway, enable two Funnel listeners.
 Use port `443` for the WebSocket gateway:
 
 ```bash
-tailscale funnel --bg --tls-terminated-tcp=443 tcp://localhost:8765
+tailscale funnel --bg --https=443 http://localhost:8765
 ```
 
 Use port `8443` for the HTTP capture server:
@@ -127,7 +127,7 @@ The expected public endpoints are:
 To stop the listeners:
 
 ```bash
-tailscale funnel --tls-terminated-tcp=443 tcp://localhost:8765 off
+tailscale funnel --https=443 off
 tailscale funnel --https=8443 http://localhost:8766 off
 ```
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -8,7 +8,8 @@ The recommended first path is Tailscale Funnel:
 - no firmware feature work is required
 - the ESP32 connects to a public `wss://...ts.net` gateway URL
 - the gateway still verifies the ESP32 bearer token with `STACKCHAN_TOKEN`
-- photo uploads can use a second Funnel URL through `VISION_URL`
+- photo uploads can use a second Funnel URL through `VISION_URL` and are
+  protected with `VISION_TOKEN` or, by default, `STACKCHAN_TOKEN`
 
 Tailscale Funnel publishes local services on a device in your tailnet to the
 public internet over HTTPS. It requires Tailscale CLI support, MagicDNS, HTTPS
@@ -51,11 +52,12 @@ stackchan-mcp capture server :8766
 Funnel makes the selected service public. Keep `STACKCHAN_TOKEN` set and use a
 strong token for the WebSocket gateway.
 
-The `/capture` endpoint is a separate HTTP upload endpoint and does not
-currently enforce the ESP32 bearer token by itself. If you expose it with
-Funnel, treat the capture URL as public while the Funnel listener is enabled,
-turn it off when it is not needed, and do not expose captured photos or other
-user data in git.
+The `/capture` endpoint is a separate HTTP upload endpoint. Keep
+`STACKCHAN_TOKEN` set so the gateway can pass a bearer token to the ESP32 for
+photo uploads, or set `VISION_TOKEN` if you want a separate capture token. If
+you expose capture with Funnel, still treat the URL as public while the Funnel
+listener is enabled, turn it off when it is not needed, and do not expose
+captured photos or other user data in git.
 
 Do not publish personal tokens, LAN IP addresses, WiFi credentials, `.env`
 files, captures, or local firmware override files.
@@ -78,11 +80,15 @@ WS_PORT=8765
 CAPTURE_PORT=8766
 
 VISION_URL=https://<node>.<tailnet>.ts.net:8443/capture
+# Optional: leave empty to reuse STACKCHAN_TOKEN.
+VISION_TOKEN=
 ```
 
 `VISION_URL` is the full URL sent to the ESP32 for `take_photo` uploads. Use it
-for remote tunnel setups. `VISION_HOST` remains useful for LAN-only setups where
-the capture URL is `http://<lan-ip>:8766/capture`.
+for remote tunnel setups. `VISION_TOKEN` is sent to the ESP32 as the capture
+upload bearer token; if it is empty, the gateway reuses `STACKCHAN_TOKEN`.
+`VISION_HOST` remains useful for LAN-only setups where the capture URL is
+`http://<lan-ip>:8766/capture`.
 
 Start the gateway:
 

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -16,9 +16,14 @@ WS_PORT=8765
 # --- HTTP capture server (ESP32 -> gateway, photo upload) ---
 CAPTURE_PORT=8766
 
+# Full public capture URL sent to the ESP32.
+# Use this for remote tunnel setups such as Tailscale Funnel.
+# Example: https://stackchan.example.ts.net:8443/capture
+VISION_URL=
+
 # LAN IP of THIS machine, as seen from the ESP32.
 # The gateway tells the ESP32 to POST captured photos to this address.
-# Required if you want take_photo to work.
+# Required if you want take_photo to work and VISION_URL is not set.
 # Example: something like 192.168.x.y on a typical home network
 # (run `ifconfig` / `ip addr` to find your host's LAN IP).
 VISION_HOST=

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -21,6 +21,10 @@ CAPTURE_PORT=8766
 # Example: https://stackchan.example.ts.net:8443/capture
 VISION_URL=
 
+# Optional separate bearer token for HTTP photo uploads to VISION_URL.
+# If empty, STACKCHAN_TOKEN is reused.
+VISION_TOKEN=
+
 # LAN IP of THIS machine, as seen from the ESP32.
 # The gateway tells the ESP32 to POST captured photos to this address.
 # Required if you want take_photo to work and VISION_URL is not set.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -27,6 +27,8 @@ Edit `.env`:
 - `STACKCHAN_TOKEN`: Bearer token for ESP32 auth (must match firmware setting)
 - `VISION_URL`: full public capture URL for remote access tunnels, such as
   `https://stackchan.example.ts.net:8443/capture`
+- `VISION_TOKEN`: optional separate Bearer token for capture uploads; if empty,
+  `STACKCHAN_TOKEN` is reused
 - `VISION_HOST`: LAN IP of this machine, as seen from the ESP32
   (something like `192.168.x.y` on a typical home network — run `ifconfig`
   or `ip addr` to find it). Required for `take_photo` when `VISION_URL` is not

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -25,9 +25,12 @@ uv sync
 
 Edit `.env`:
 - `STACKCHAN_TOKEN`: Bearer token for ESP32 auth (must match firmware setting)
+- `VISION_URL`: full public capture URL for remote access tunnels, such as
+  `https://stackchan.example.ts.net:8443/capture`
 - `VISION_HOST`: LAN IP of this machine, as seen from the ESP32
   (something like `192.168.x.y` on a typical home network — run `ifconfig`
-  or `ip addr` to find it). Required for `take_photo`.
+  or `ip addr` to find it). Required for `take_photo` when `VISION_URL` is not
+  set.
 
 ## Run
 
@@ -38,6 +41,9 @@ uv run python -m stackchan_mcp
 Default ports:
 - WebSocket (ESP32 -> gateway): `0.0.0.0:8765`
 - HTTP capture (ESP32 -> gateway): `0.0.0.0:8766`
+
+For non-LAN setups, see [`../docs/remote-access.md`](../docs/remote-access.md)
+for the Tailscale Funnel flow.
 
 When you restart the gateway during development, an already-connected ESP32
 will notice the dropped WebSocket and retry while idle. The retry delay starts

--- a/gateway/stackchan_mcp/capture_server.py
+++ b/gateway/stackchan_mcp/capture_server.py
@@ -20,10 +20,27 @@ from aiohttp import web
 logger = logging.getLogger(__name__)
 
 CAPTURE_DIR = os.path.expanduser("~/.stackchan/captures")
+CAPTURE_TOKEN_KEY = web.AppKey("capture_token", str)
+
+
+def _is_authorized(auth_header: str, expected_token: str) -> bool:
+    """Return whether the bearer auth header matches the expected token."""
+    return auth_header == f"Bearer {expected_token}"
 
 
 async def handle_capture(request: web.Request) -> web.Response:
     """Handle photo upload from ESP32."""
+    expected_token = request.app[CAPTURE_TOKEN_KEY]
+    if expected_token and not _is_authorized(
+        request.headers.get("Authorization", ""), expected_token
+    ):
+        logger.warning("Capture upload auth rejected")
+        return web.Response(
+            text='{"error": "Unauthorized"}',
+            status=401,
+            content_type="application/json",
+        )
+
     os.makedirs(CAPTURE_DIR, exist_ok=True)
 
     reader = await request.multipart()
@@ -66,8 +83,9 @@ async def handle_capture(request: web.Request) -> web.Response:
     )
 
 
-def create_capture_app() -> web.Application:
+def create_capture_app(capture_token: str = "") -> web.Application:
     """Create the HTTP capture application."""
     app = web.Application()
+    app[CAPTURE_TOKEN_KEY] = capture_token
     app.router.add_post("/capture", handle_capture)
     return app

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -76,11 +76,14 @@ class ESP32Connection:
             self._pending.pop(req_id, None)
             return None, {"code": -32000, "message": f"ESP32 communication error: {exc}"}
 
-    async def initialize(self, vision_url: str = "") -> bool:
+    async def initialize(self, vision_url: str = "", vision_token: str = "") -> bool:
         """Send MCP initialize to ESP32."""
         capabilities: dict[str, Any] = {}
         if vision_url:
-            capabilities["vision"] = {"url": vision_url}
+            vision: dict[str, Any] = {"url": vision_url}
+            if vision_token:
+                vision["token"] = vision_token
+            capabilities["vision"] = vision
         result, error = await self.send_mcp_request("initialize", {"capabilities": capabilities})
         if error:
             logger.error("ESP32 initialize failed: %s", error)
@@ -163,6 +166,7 @@ class ESP32Manager:
         self._lock = asyncio.Lock()
         self._init_tasks: list[asyncio.Task] = []
         self._vision_url: str = ""
+        self._vision_token: str = ""
 
     @property
     def device_connected(self) -> bool:
@@ -173,10 +177,15 @@ class ESP32Manager:
         return self._connection
 
     async def start(
-        self, host: str = "0.0.0.0", port: int = 8765, vision_url: str = ""
+        self,
+        host: str = "0.0.0.0",
+        port: int = 8765,
+        vision_url: str = "",
+        vision_token: str = "",
     ) -> None:
         """Start the WebSocket server for ESP32 connections."""
         self._vision_url = vision_url
+        self._vision_token = vision_token
         logger.info("ESP32 WebSocket server starting on ws://%s:%d", host, port)
         self._server = await websockets.serve(
             self._handler,
@@ -291,7 +300,10 @@ class ESP32Manager:
 
     async def _init_device(self, connection: ESP32Connection, device_id: str) -> None:
         """Initialize MCP session with a newly connected device."""
-        if await connection.initialize(vision_url=self._vision_url):
+        if await connection.initialize(
+            vision_url=self._vision_url,
+            vision_token=self._vision_token,
+        ):
             await connection.discover_tools()
             logger.info(
                 "ESP32 ready: device=%s tools=%d",

--- a/gateway/stackchan_mcp/gateway.py
+++ b/gateway/stackchan_mcp/gateway.py
@@ -59,6 +59,21 @@ class Gateway:
         port = int(os.getenv("CAPTURE_PORT", "8766"))
         return f"http://{host}:{port}/capture"
 
+    @property
+    def vision_token(self) -> str:
+        """Bearer token expected by the capture endpoint.
+
+        VISION_TOKEN can be set separately. By default, reuse the ESP32
+        WebSocket token so remote capture uploads are protected whenever the
+        gateway itself is protected.
+        """
+        return (
+            os.getenv("VISION_TOKEN")
+            or os.getenv("STACKCHAN_TOKEN")
+            or os.getenv("BEARER_TOKEN")
+            or ""
+        )
+
     async def start(self) -> None:
         """Start the ESP32 WebSocket server and HTTP capture server."""
         host = os.getenv("HOST", "0.0.0.0")
@@ -66,10 +81,15 @@ class Gateway:
         capture_port = int(os.getenv("CAPTURE_PORT", "8766"))
 
         # Start WebSocket server for ESP32
-        await self.esp32.start(host, ws_port, vision_url=self.vision_url)
+        await self.esp32.start(
+            host,
+            ws_port,
+            vision_url=self.vision_url,
+            vision_token=self.vision_token,
+        )
 
         # Start HTTP capture server
-        app = create_capture_app()
+        app = create_capture_app(capture_token=self.vision_token)
         self._http_runner = web.AppRunner(app)
         await self._http_runner.setup()
         site = web.TCPSite(self._http_runner, host, capture_port)

--- a/gateway/stackchan_mcp/gateway.py
+++ b/gateway/stackchan_mcp/gateway.py
@@ -36,18 +36,24 @@ class Gateway:
     def vision_url(self) -> str:
         """URL for ESP32 to POST captured photos to.
 
-        VISION_HOST should be the LAN IP of the host running this gateway,
-        as seen from the ESP32 (e.g. something like 192.168.x.y on a typical
-        home network). Falls back to "127.0.0.1" with a warning if unset; in
-        that case the ESP32 will not be able to reach the capture endpoint
-        over the network.
+        VISION_URL can be set to a complete public capture URL for remote
+        access setups such as Tailscale Funnel. Otherwise VISION_HOST should
+        be the LAN IP of the host running this gateway, as seen from the ESP32
+        (e.g. something like 192.168.x.y on a typical home network). Falls
+        back to "127.0.0.1" with a warning if unset; in that case the ESP32
+        will not be able to reach the capture endpoint over the network.
         """
+        explicit_url = os.getenv("VISION_URL")
+        if explicit_url:
+            return explicit_url
+
         host = os.getenv("VISION_HOST")
         if not host:
             logger.warning(
-                "VISION_HOST not set; defaulting to 127.0.0.1. "
+                "VISION_URL/VISION_HOST not set; defaulting to 127.0.0.1. "
                 "ESP32 will not reach the capture endpoint unless "
-                "VISION_HOST is set to this host's LAN IP."
+                "VISION_HOST is set to this host's LAN IP or VISION_URL is "
+                "set to a full capture URL."
             )
             host = "127.0.0.1"
         port = int(os.getenv("CAPTURE_PORT", "8766"))

--- a/gateway/tests/test_capture_server.py
+++ b/gateway/tests/test_capture_server.py
@@ -1,0 +1,25 @@
+"""Tests for HTTP capture upload helpers."""
+
+from stackchan_mcp.capture_server import (
+    CAPTURE_TOKEN_KEY,
+    _is_authorized,
+    create_capture_app,
+)
+
+
+def test_capture_app_stores_capture_token():
+    """Capture app keeps the expected bearer token in app state."""
+    app = create_capture_app(capture_token="capture-token")
+
+    assert app[CAPTURE_TOKEN_KEY] == "capture-token"
+
+
+def test_is_authorized_accepts_matching_bearer():
+    """Bearer auth must match exactly."""
+    assert _is_authorized("Bearer capture-token", "capture-token") is True
+
+
+def test_is_authorized_rejects_missing_or_wrong_bearer():
+    """Missing or mismatched bearer auth is rejected."""
+    assert _is_authorized("", "capture-token") is False
+    assert _is_authorized("Bearer wrong-token", "capture-token") is False

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -41,6 +41,27 @@ def test_vision_url_uses_lan_host(monkeypatch):
     assert gw.vision_url == "http://192.0.2.10:8766/capture"
 
 
+def test_vision_token_prefers_explicit_token(monkeypatch):
+    """VISION_TOKEN can be separated from the WebSocket token."""
+    monkeypatch.setenv("VISION_TOKEN", "capture-token")
+    monkeypatch.setenv("STACKCHAN_TOKEN", "ws-token")
+
+    gw = Gateway()
+
+    assert gw.vision_token == "capture-token"
+
+
+def test_vision_token_falls_back_to_stackchan_token(monkeypatch):
+    """Capture uploads use the gateway token by default."""
+    monkeypatch.delenv("VISION_TOKEN", raising=False)
+    monkeypatch.setenv("STACKCHAN_TOKEN", "ws-token")
+    monkeypatch.setenv("BEARER_TOKEN", "legacy-token")
+
+    gw = Gateway()
+
+    assert gw.vision_token == "ws-token"
+
+
 @pytest.mark.asyncio
 async def test_gateway_start_stop(monkeypatch):
     """Gateway can start and stop."""

--- a/gateway/tests/test_gateway.py
+++ b/gateway/tests/test_gateway.py
@@ -19,11 +19,33 @@ def test_get_gateway_singleton():
     gw_mod._gateway = None
 
 
+def test_vision_url_uses_explicit_url(monkeypatch):
+    """VISION_URL overrides host/port construction for remote tunnels."""
+    monkeypatch.setenv("VISION_URL", "https://stackchan.example.ts.net:8443/capture")
+    monkeypatch.setenv("VISION_HOST", "192.0.2.10")
+    monkeypatch.setenv("CAPTURE_PORT", "8766")
+
+    gw = Gateway()
+
+    assert gw.vision_url == "https://stackchan.example.ts.net:8443/capture"
+
+
+def test_vision_url_uses_lan_host(monkeypatch):
+    """VISION_HOST and CAPTURE_PORT still build the default LAN capture URL."""
+    monkeypatch.delenv("VISION_URL", raising=False)
+    monkeypatch.setenv("VISION_HOST", "192.0.2.10")
+    monkeypatch.setenv("CAPTURE_PORT", "8766")
+
+    gw = Gateway()
+
+    assert gw.vision_url == "http://192.0.2.10:8766/capture"
+
+
 @pytest.mark.asyncio
-async def test_gateway_start_stop():
+async def test_gateway_start_stop(monkeypatch):
     """Gateway can start and stop."""
-    import os
-    os.environ["WS_PORT"] = "0"  # Random port
+    monkeypatch.setenv("WS_PORT", "0")  # Random port
+    monkeypatch.setenv("CAPTURE_PORT", "0")  # Random port
 
     gw = Gateway()
     await gw.start()
@@ -32,6 +54,3 @@ async def test_gateway_start_stop():
 
     await gw.stop()
     assert gw._running is False
-
-    if "WS_PORT" in os.environ:
-        del os.environ["WS_PORT"]


### PR DESCRIPTION
## Summary

- Add `docs/remote-access.md` for the Tailscale Funnel remote-access path
- Add `VISION_URL` so the gateway can send a full public capture callback URL to the ESP32
- Protect remote capture uploads with bearer auth via `VISION_TOKEN` or the existing gateway token
- Document the Tailscale WebSocket and capture Funnel listeners in README, gateway README, and `.env.example`

## Test plan

### Code-level

- [x] gateway: `uv run pytest`
- [x] gateway: `uv run ruff check .`
- [x] whitespace: `git diff --check`
- [x] firmware: `python ./scripts/release.py stackchan`

### Network

- [x] Tailscale Funnel WebSocket path accepts an authenticated simulated ESP32 client
- [x] Tailscale Funnel capture path rejects unauthenticated uploads with `401`
- [x] Tailscale Funnel capture path accepts uploads with bearer auth
- [x] Tailscale Funnel listeners were stopped after validation

### Hardware

- [x] Flashed StackChan with app-only write to `0x20000` to preserve NVS
- [x] Device boots without crash
- [x] Device connects through the Tailscale Funnel WebSocket path after starting chat
- [x] Gateway initializes the ESP32 MCP session and discovers 14 device tools
- [x] Existing MCP status tool returns device status
- [x] Existing camera tool uploads a captured photo through the authenticated remote capture path

## Breaking changes

None. `VISION_URL` and `VISION_TOKEN` are optional. Existing `VISION_HOST` / `CAPTURE_PORT` behavior remains available, and capture auth reuses the existing gateway token when a separate `VISION_TOKEN` is not set.

## Related issues

Closes #14
