### PR TITLE
Add WebSocket gateway fallback support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,9 +78,10 @@ WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う 
 
 ### WebSocket gateway URL と認証トークンの設定
 
-ファームウェアはゲートウェイ接続のために 2 つの NVS キーを参照します:
+ファームウェアはゲートウェイ接続のために以下の NVS キーを参照します:
 
 - `websocket.url` — ゲートウェイ WebSocket URL (例: `ws://192.168.1.100:8765/`)
+- `websocket.fallback_url` — `websocket.url` に接続できない、または server hello が完了しない場合に試す 2 番目の gateway URL
 - `websocket.token` — `Authorization: Bearer <token>` で送信される bearer トークン。ゲートウェイ側の `STACKCHAN_TOKEN` / `BEARER_TOKEN` と照合される (両方空にすれば認証スキップ)
 
 設定方法は実用的に 3 つ:
@@ -88,14 +89,24 @@ WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う 
 1. **Kconfig によるビルド時デフォルト (開発者推奨)**: `idf.py menuconfig` → `Component config` → `Xiaozhi Assistant` を開き、以下を設定:
    - `Default WebSocket gateway URL (fallback when NVS is empty)` →
      `CONFIG_DEFAULT_WEBSOCKET_URL` (例: `ws://192.168.1.100:8765/`)
+   - `Fallback WebSocket gateway URL` →
+     `CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL`
    - `Default WebSocket auth token (fallback when NVS is empty)` →
      `CONFIG_DEFAULT_WEBSOCKET_TOKEN` (ゲートウェイが認証不要なら空のままで OK)
 
-   デフォルトでは、対応する NVS キーが空のときだけこの値が使われます。新規デバイスへの初回フラッシュではちょうど期待通りに動作します。
+   デフォルトでは、対応する NVS キーが空のときだけこの値が使われます。新規デバイスへの初回フラッシュではちょうど期待通りに動作します。primary と fallback の両方を設定した場合、ファームウェアは決まった順番で候補を試し、WebSocket の server hello まで完了した最初の候補を使います。
 
 2. **NVS に直接 `websocket.url` / `websocket.token` を書き込む**: ランタイムでの永続設定の本来のパス。最終的には WiFi 設定 UI から行う想定ですが、現時点で UI フィールドは未実装で Issue #17 のフォローアップとして追跡しています。
 
 3. **一時的なソース hardcode (非推奨)**: `websocket_protocol.cc` を編集すればローカル実験はアンブロックできますが、commit には残さないようにしてください。
+
+よく使う gateway URL 構成:
+
+| モード | Primary URL | Fallback URL |
+| --- | --- | --- |
+| ローカルのみ | `ws://<gateway-host>:8765/` | 空 |
+| Tailscale のみ | `wss://<node>.<tailnet>.ts.net/` | 空 |
+| ローカル優先 + リモート fallback | `ws://<gateway-host>:8765/` | `wss://<node>.<tailnet>.ts.net/` |
 
 #### 既存デバイス (古い NVS) — `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL`
 
@@ -120,6 +131,7 @@ NVS を全消去 (WiFi 認証も飛ぶ) せずにこれを回避するには、f
 cd firmware
 cat > sdkconfig.defaults.local <<'EOF'
 CONFIG_DEFAULT_WEBSOCKET_URL="ws://<your-lan-ip>:8765/"
+CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL="wss://<node>.<tailnet>.ts.net/"
 CONFIG_DEFAULT_WEBSOCKET_TOKEN="<your-dev-token>"
 CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y
 EOF

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ WiFi configuration happens after the ESP32 boots — connect from a smartphone t
 
 ### Configuring the WebSocket gateway URL and auth token
 
-The firmware reads two NVS keys for the gateway connection:
+The firmware reads these NVS keys for the gateway connection:
 
 - `websocket.url` — the gateway WebSocket URL (e.g. `ws://192.168.1.100:8765/`)
+- `websocket.fallback_url` — optional second gateway URL to try when
+  `websocket.url` cannot be reached or does not complete the server hello flow
 - `websocket.token` — the bearer token sent as `Authorization: Bearer <token>`,
   matched against `STACKCHAN_TOKEN` / `BEARER_TOKEN` on the gateway side
   (leave both empty to skip authentication entirely)
@@ -91,12 +93,17 @@ There are three practical ways to provide them:
    `idf.py menuconfig` → `Component config` → `Xiaozhi Assistant`, and set:
    - `Default WebSocket gateway URL (fallback when NVS is empty)` →
      `CONFIG_DEFAULT_WEBSOCKET_URL` (e.g. `ws://192.168.1.100:8765/`)
+   - `Fallback WebSocket gateway URL` →
+     `CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL`
    - `Default WebSocket auth token (fallback when NVS is empty)` →
      `CONFIG_DEFAULT_WEBSOCKET_TOKEN` (leave empty if your gateway accepts
      unauthenticated connections)
 
    By default these only apply when the corresponding NVS key is empty.
    For first-time flashes onto a fresh device this is exactly what you want.
+   If both a primary and fallback URL are configured, the firmware tries them
+   in deterministic order and keeps the first candidate that completes the
+   WebSocket server hello flow.
 
 2. **Write `websocket.url` / `websocket.token` directly to NVS**: this is the
    intended persistent runtime configuration path, eventually via the WiFi
@@ -106,6 +113,14 @@ There are three practical ways to provide them:
 3. **Temporary source hardcode (not recommended)**: editing
    `websocket_protocol.cc` can unblock local experiments, but keep it out of
    commits.
+
+Common gateway URL setups:
+
+| Mode | Primary URL | Fallback URL |
+| --- | --- | --- |
+| Local only | `ws://<gateway-host>:8765/` | empty |
+| Tailscale only | `wss://<node>.<tailnet>.ts.net/` | empty |
+| Local with remote fallback | `ws://<gateway-host>:8765/` | `wss://<node>.<tailnet>.ts.net/` |
 
 #### Existing devices with stale NVS — `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL`
 
@@ -142,6 +157,7 @@ tracked `firmware/sdkconfig.defaults`. Instead, create a gitignored local file:
 cd firmware
 cat > sdkconfig.defaults.local <<'EOF'
 CONFIG_DEFAULT_WEBSOCKET_URL="ws://<your-lan-ip>:8765/"
+CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL="wss://<node>.<tailnet>.ts.net/"
 CONFIG_DEFAULT_WEBSOCKET_TOKEN="<your-dev-token>"
 CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y
 EOF

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -148,6 +148,21 @@ CONFIG_DEFAULT_WEBSOCKET_URL="wss://<node>.<tailnet>.ts.net/"
 CONFIG_DEFAULT_WEBSOCKET_TOKEN="<strong-shared-token>"
 ```
 
+To prefer a LAN gateway when the StackChan and gateway host are on the same
+network, while still keeping a remote Funnel path for travel, configure the
+local URL as primary and the Funnel URL as fallback:
+
+```text
+CONFIG_DEFAULT_WEBSOCKET_URL="ws://<gateway-host>:8765/"
+CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL="wss://<node>.<tailnet>.ts.net/"
+CONFIG_DEFAULT_WEBSOCKET_TOKEN="<strong-shared-token>"
+```
+
+At runtime the firmware tries the primary URL first. If the TCP/WebSocket
+connection fails, or if the stackchan-mcp server hello does not complete, it
+tries the fallback URL next. Leave the fallback empty for local-only or
+Tailscale-only setups.
+
 For existing devices with stale NVS values, use the documented
 `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y` flow from the top-level README.
 

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -21,6 +21,20 @@ config DEFAULT_WEBSOCKET_URL
         Leave empty to require explicit NVS configuration (the original
         behavior).
 
+config DEFAULT_WEBSOCKET_FALLBACK_URL
+    string "Fallback WebSocket gateway URL"
+    default ""
+    help
+        Optional second WebSocket URL to try when the primary gateway URL
+        cannot be reached or does not complete the server hello flow.
+
+        This is useful for builds that should prefer a local LAN gateway
+        such as ws://<gateway-host>:8765/ but fall back to a remote tunnel
+        such as wss://<node>.<tailnet>.ts.net/ when the local gateway is
+        unavailable.
+
+        Leave empty to keep the original single-URL behavior.
+
 config DEFAULT_WEBSOCKET_TOKEN
     string "Default WebSocket auth token (fallback when NVS is empty)"
     default ""
@@ -36,14 +50,16 @@ config DEFAULT_WEBSOCKET_TOKEN
         value to override NVS.
 
 config FORCE_DEFAULT_WEBSOCKET_URL
-    bool "Force CONFIG_DEFAULT_WEBSOCKET_URL/TOKEN to override NVS"
+    bool "Force Kconfig WebSocket URL/TOKEN values to override NVS"
     default n
     help
         When enabled, non-empty Kconfig defaults
-        (CONFIG_DEFAULT_WEBSOCKET_URL / CONFIG_DEFAULT_WEBSOCKET_TOKEN)
-        override the NVS websocket.url / websocket.token values. Empty
-        Kconfig values still fall through to NVS, so leaving the token
-        Kconfig empty keeps any NVS-stored token in use. Useful when:
+        (CONFIG_DEFAULT_WEBSOCKET_URL,
+        CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL, and
+        CONFIG_DEFAULT_WEBSOCKET_TOKEN) override the corresponding NVS
+        websocket.url / websocket.fallback_url / websocket.token values.
+        Empty Kconfig values still fall through to NVS, so leaving the
+        token Kconfig empty keeps any NVS-stored token in use. Useful when:
 
         - The device's NVS still contains a stale upstream xiaozhi URL
           (e.g., wss://api.tenclass.net/...) from prior use, and there

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -9,9 +9,26 @@
 #include <esp_log.h>
 #include <arpa/inet.h>
 #include <algorithm>
+#include <vector>
 #include "assets/lang_config.h"
 
 #define TAG "WS"
+
+namespace {
+
+void AddGatewayCandidate(std::vector<std::string>& candidates, const std::string& url, const char* source) {
+    if (url.empty()) {
+        return;
+    }
+    if (std::find(candidates.begin(), candidates.end(), url) != candidates.end()) {
+        ESP_LOGI(TAG, "Skipping duplicate websocket gateway candidate from %s: %s", source, url.c_str());
+        return;
+    }
+    ESP_LOGI(TAG, "Adding websocket gateway candidate from %s: %s", source, url.c_str());
+    candidates.push_back(url);
+}
+
+} // namespace
 
 WebsocketProtocol::WebsocketProtocol() {
     event_group_handle_ = xEventGroupCreate();
@@ -160,6 +177,35 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
     }
 #endif
 #endif
+    std::vector<std::string> gateway_candidates;
+    AddGatewayCandidate(gateway_candidates, url, "websocket.url");
+
+    std::string fallback_url = settings.GetString("fallback_url");
+#ifdef CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL
+#ifdef CONFIG_FORCE_DEFAULT_WEBSOCKET_URL
+    if (CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL[0] != '\0') {
+        if (!fallback_url.empty() && fallback_url != CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL) {
+            ESP_LOGI(TAG,
+                     "FORCE: overriding NVS websocket.fallback_url with Kconfig: NVS=%s -> %s",
+                     fallback_url.c_str(), CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL);
+        } else if (fallback_url.empty()) {
+            ESP_LOGI(TAG, "FORCE: using Kconfig fallback websocket URL: %s",
+                     CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL);
+        }
+        fallback_url = CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL;
+    }
+#else
+    if (fallback_url.empty()) {
+        fallback_url = CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL;
+        if (!fallback_url.empty()) {
+            ESP_LOGI(TAG, "NVS websocket.fallback_url empty; using build-time fallback from Kconfig: %s",
+                     fallback_url.c_str());
+        }
+    }
+#endif
+#endif
+    AddGatewayCandidate(gateway_candidates, fallback_url, "websocket.fallback_url");
+
     std::string token = settings.GetString("token");
 #ifdef CONFIG_DEFAULT_WEBSOCKET_TOKEN
 #ifdef CONFIG_FORCE_DEFAULT_WEBSOCKET_URL
@@ -190,130 +236,164 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
     error_occurred_ = false;
 
     auto network = Board::GetInstance().GetNetwork();
-    websocket_ = network->CreateWebSocket(1);
-    if (websocket_ == nullptr) {
-        ESP_LOGE(TAG, "Failed to create websocket");
-        return false;
-    }
-
-    if (!token.empty()) {
-        // If token not has a space, add "Bearer " prefix
-        if (token.find(" ") == std::string::npos) {
-            token = "Bearer " + token;
-        }
-        websocket_->SetHeader("Authorization", token.c_str());
-    }
-    websocket_->SetHeader("Protocol-Version", std::to_string(version_).c_str());
-    websocket_->SetHeader("Device-Id", SystemInfo::GetMacAddress().c_str());
-    websocket_->SetHeader("Client-Id", Board::GetInstance().GetUuid().c_str());
-
-    websocket_->OnData([this](const char* data, size_t len, bool binary) {
-        if (binary) {
-            if (on_incoming_audio_ != nullptr) {
-                if (version_ == 2) {
-                    BinaryProtocol2* bp2 = (BinaryProtocol2*)data;
-                    bp2->version = ntohs(bp2->version);
-                    bp2->type = ntohs(bp2->type);
-                    bp2->timestamp = ntohl(bp2->timestamp);
-                    bp2->payload_size = ntohl(bp2->payload_size);
-                    auto payload = (uint8_t*)bp2->payload;
-                    on_incoming_audio_(std::make_unique<AudioStreamPacket>(AudioStreamPacket{
-                        .sample_rate = server_sample_rate_,
-                        .frame_duration = server_frame_duration_,
-                        .timestamp = bp2->timestamp,
-                        .payload = std::vector<uint8_t>(payload, payload + bp2->payload_size)
-                    }));
-                } else if (version_ == 3) {
-                    BinaryProtocol3* bp3 = (BinaryProtocol3*)data;
-                    bp3->type = bp3->type;
-                    bp3->payload_size = ntohs(bp3->payload_size);
-                    auto payload = (uint8_t*)bp3->payload;
-                    on_incoming_audio_(std::make_unique<AudioStreamPacket>(AudioStreamPacket{
-                        .sample_rate = server_sample_rate_,
-                        .frame_duration = server_frame_duration_,
-                        .timestamp = 0,
-                        .payload = std::vector<uint8_t>(payload, payload + bp3->payload_size)
-                    }));
-                } else {
-                    on_incoming_audio_(std::make_unique<AudioStreamPacket>(AudioStreamPacket{
-                        .sample_rate = server_sample_rate_,
-                        .frame_duration = server_frame_duration_,
-                        .timestamp = 0,
-                        .payload = std::vector<uint8_t>((uint8_t*)data, (uint8_t*)data + len)
-                    }));
-                }
-            }
-        } else {
-            // Parse JSON data
-            auto root = cJSON_ParseWithLength(data, len);
-            auto type = cJSON_GetObjectItem(root, "type");
-            if (cJSON_IsString(type)) {
-                if (strcmp(type->valuestring, "hello") == 0) {
-                    ParseServerHello(root);
-                } else {
-                    if (on_incoming_json_ != nullptr) {
-                        on_incoming_json_(root);
-                    }
-                }
-            } else {
-                ESP_LOGE(TAG, "Missing message type, data: %s", std::string(data, len).c_str());
-            }
-            cJSON_Delete(root);
-        }
-        last_incoming_time_ = std::chrono::steady_clock::now();
-    });
-
-    websocket_->OnDisconnected([this]() {
-        if (on_disconnected_ != nullptr) {
-            on_disconnected_();
-        }
-        ESP_LOGI(TAG, "Websocket disconnected");
-        if (on_audio_channel_closed_ != nullptr) {
-            on_audio_channel_closed_();
-        }
-        if (auto_reconnect_enabled_.load()) {
-            ScheduleReconnect();
-        }
-    });
-
-    ESP_LOGI(TAG, "Connecting to websocket server: %s with version: %d", url.c_str(), version_);
-    if (!websocket_->Connect(url.c_str())) {
-        ESP_LOGE(TAG, "Failed to connect to websocket server, code=%d", websocket_->GetLastError());
+    if (gateway_candidates.empty()) {
+        ESP_LOGE(TAG, "No websocket gateway URL configured");
         if (report_error) {
             SetError(Lang::Strings::SERVER_NOT_CONNECTED);
         }
         return false;
     }
 
-    if (on_connected_ != nullptr) {
-        on_connected_();
+    if (!token.empty() && token.find(" ") == std::string::npos) {
+        token = "Bearer " + token;
     }
 
-    // Send hello message to describe the client
-    auto message = GetHelloMessage();
-    if (!SendText(message)) {
-        return false;
-    }
+    bool server_hello_timed_out = false;
+    for (size_t i = 0; i < gateway_candidates.size(); ++i) {
+        const auto& candidate_url = gateway_candidates[i];
 
-    // Wait for server hello
-    EventBits_t bits = xEventGroupWaitBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT, pdTRUE, pdFALSE, pdMS_TO_TICKS(10000));
-    if (!(bits & WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT)) {
-        ESP_LOGE(TAG, "Failed to receive server hello");
-        if (report_error) {
-            SetError(Lang::Strings::SERVER_TIMEOUT);
+        xEventGroupClearBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
+        websocket_ = network->CreateWebSocket(1);
+        if (websocket_ == nullptr) {
+            ESP_LOGE(TAG, "Failed to create websocket");
+            continue;
         }
-        return false;
+        auto notify_disconnect = std::make_shared<bool>(false);
+
+        if (!token.empty()) {
+            websocket_->SetHeader("Authorization", token.c_str());
+        }
+        websocket_->SetHeader("Protocol-Version", std::to_string(version_).c_str());
+        websocket_->SetHeader("Device-Id", SystemInfo::GetMacAddress().c_str());
+        websocket_->SetHeader("Client-Id", Board::GetInstance().GetUuid().c_str());
+
+        websocket_->OnData([this](const char* data, size_t len, bool binary) {
+            if (binary) {
+                if (on_incoming_audio_ != nullptr) {
+                    if (version_ == 2) {
+                        BinaryProtocol2* bp2 = (BinaryProtocol2*)data;
+                        bp2->version = ntohs(bp2->version);
+                        bp2->type = ntohs(bp2->type);
+                        bp2->timestamp = ntohl(bp2->timestamp);
+                        bp2->payload_size = ntohl(bp2->payload_size);
+                        auto payload = (uint8_t*)bp2->payload;
+                        on_incoming_audio_(std::make_unique<AudioStreamPacket>(AudioStreamPacket{
+                            .sample_rate = server_sample_rate_,
+                            .frame_duration = server_frame_duration_,
+                            .timestamp = bp2->timestamp,
+                            .payload = std::vector<uint8_t>(payload, payload + bp2->payload_size)
+                        }));
+                    } else if (version_ == 3) {
+                        BinaryProtocol3* bp3 = (BinaryProtocol3*)data;
+                        bp3->type = bp3->type;
+                        bp3->payload_size = ntohs(bp3->payload_size);
+                        auto payload = (uint8_t*)bp3->payload;
+                        on_incoming_audio_(std::make_unique<AudioStreamPacket>(AudioStreamPacket{
+                            .sample_rate = server_sample_rate_,
+                            .frame_duration = server_frame_duration_,
+                            .timestamp = 0,
+                            .payload = std::vector<uint8_t>(payload, payload + bp3->payload_size)
+                        }));
+                    } else {
+                        on_incoming_audio_(std::make_unique<AudioStreamPacket>(AudioStreamPacket{
+                            .sample_rate = server_sample_rate_,
+                            .frame_duration = server_frame_duration_,
+                            .timestamp = 0,
+                            .payload = std::vector<uint8_t>((uint8_t*)data, (uint8_t*)data + len)
+                        }));
+                    }
+                }
+            } else {
+                // Parse JSON data
+                auto root = cJSON_ParseWithLength(data, len);
+                auto type = cJSON_GetObjectItem(root, "type");
+                if (cJSON_IsString(type)) {
+                    if (strcmp(type->valuestring, "hello") == 0) {
+                        ParseServerHello(root);
+                    } else {
+                        if (on_incoming_json_ != nullptr) {
+                            on_incoming_json_(root);
+                        }
+                    }
+                } else {
+                    ESP_LOGE(TAG, "Missing message type, data: %s", std::string(data, len).c_str());
+                }
+                cJSON_Delete(root);
+            }
+            last_incoming_time_ = std::chrono::steady_clock::now();
+        });
+
+        websocket_->OnDisconnected([this, notify_disconnect]() {
+            if (!*notify_disconnect) {
+                ESP_LOGI(TAG, "Websocket candidate disconnected before server hello");
+                return;
+            }
+            if (on_disconnected_ != nullptr) {
+                on_disconnected_();
+            }
+            ESP_LOGI(TAG, "Websocket disconnected");
+            if (on_audio_channel_closed_ != nullptr) {
+                on_audio_channel_closed_();
+            }
+            if (auto_reconnect_enabled_.load()) {
+                ScheduleReconnect();
+            }
+        });
+
+        ESP_LOGI(TAG, "Connecting to websocket server candidate %d/%d: %s with version: %d",
+                 static_cast<int>(i + 1), static_cast<int>(gateway_candidates.size()), candidate_url.c_str(), version_);
+        if (!websocket_->Connect(candidate_url.c_str())) {
+            ESP_LOGE(TAG, "Failed to connect to websocket server candidate %d/%d, code=%d",
+                     static_cast<int>(i + 1), static_cast<int>(gateway_candidates.size()), websocket_->GetLastError());
+            websocket_.reset();
+            continue;
+        }
+
+        // Send hello message to describe the client
+        auto message = GetHelloMessage();
+        if (!websocket_->Send(message)) {
+            ESP_LOGE(TAG, "Failed to send hello to websocket server candidate %d/%d",
+                     static_cast<int>(i + 1), static_cast<int>(gateway_candidates.size()));
+            websocket_.reset();
+            continue;
+        }
+
+        // Wait for server hello
+        EventBits_t bits = xEventGroupWaitBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT, pdTRUE, pdFALSE, pdMS_TO_TICKS(10000));
+        if (!(bits & WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT)) {
+            ESP_LOGE(TAG, "Failed to receive server hello from websocket server candidate %d/%d",
+                     static_cast<int>(i + 1), static_cast<int>(gateway_candidates.size()));
+            server_hello_timed_out = true;
+            websocket_.reset();
+            continue;
+        }
+
+        *notify_disconnect = true;
+        auto_reconnect_enabled_.store(true);
+        reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
+        StopReconnectTimer();
+
+        if (on_connected_ != nullptr) {
+            on_connected_();
+        }
+
+        if (on_audio_channel_opened_ != nullptr) {
+            on_audio_channel_opened_();
+        }
+
+        ESP_LOGI(TAG, "Connected to websocket server candidate %d/%d: %s",
+                 static_cast<int>(i + 1), static_cast<int>(gateway_candidates.size()), candidate_url.c_str());
+        return true;
     }
 
-    auto_reconnect_enabled_.store(true);
-    reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
-    StopReconnectTimer();
-
-    if (on_audio_channel_opened_ != nullptr) {
-        on_audio_channel_opened_();
+    if (report_error) {
+        if (server_hello_timed_out) {
+            SetError(Lang::Strings::SERVER_TIMEOUT);
+        } else {
+            SetError(Lang::Strings::SERVER_NOT_CONNECTED);
+        }
     }
-
-    return true;
+    return false;
 }
 
 void WebsocketProtocol::ScheduleReconnect() {


### PR DESCRIPTION
## Summary
- add a second firmware WebSocket gateway candidate via `websocket.fallback_url` / `CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL`
- try gateway candidates in deterministic order and keep the first one that completes the stackchan-mcp server hello flow
- document local-only, Tailscale-only, and local-with-remote-fallback setups

## Why
This lets a StackChan build prefer a LAN gateway when available while falling back to a remote Tailscale Funnel URL when the local path is unavailable.

Closes #41

## Validation
- `docker run --rm -v "$PWD/firmware":/project -w /project espressif/idf:v5.5.2 idf.py reconfigure build`
- Confirmed `CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL` is generated in the build config
- Flashed the app image only to a StackChan device, preserving NVS Wi-Fi credentials
- Confirmed the device connects through the first local gateway candidate when the primary Wi-Fi path is available
- Confirmed the device can recover through the second local gateway candidate after the primary Wi-Fi path is made unavailable
- Confirmed local-to-remote fallback on device: the first LAN gateway candidate failed when the device was on a separate Wi-Fi network, then the remote `wss://` gateway candidate completed TLS validation, server hello, and reached `listening`
- `git diff --check`
- Reviewed the public diff for personal paths, tokens, and real tailnet/LAN values
