### PR TITLE
chore: ignore CLAUDE.md alongside AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 .env.local
 *.local
 AGENTS.md
+CLAUDE.md
 
 # Captures (user photos)
 captures/


### PR DESCRIPTION
## Summary

Add `CLAUDE.md` to `.gitignore` so it is treated the same way as `AGENTS.md`. Both files are local agent rule files (AGENTS.md for Codex, CLAUDE.md for Claude Code) and should not be tracked in this public repository.

This lets contributors keep their own agent-specific notes (e.g. a `CLAUDE.md` symlinked to `AGENTS.md`, or a separate file) without risk of accidentally committing them.

## Test plan

### Code-level

- [x] Not applicable / not run: gitignore-only change, no code path touched.

### Hardware

- [x] Not applicable / hardware not available: gitignore-only change.

## Breaking changes

None.

## Related issues

None.