### PR TITLE
feat: support PyPI distribution (`pip install stackchan-mcp`)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,138 @@
+name: Publish gateway to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Default permissions: nothing. Each job opts in to what it needs.
+permissions: {}
+
+# Only one publish run at a time per tag.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build, lint, and test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Need full history so the "is this tag on main?" check below
+          # can resolve origin/main.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag commit is on origin/main
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag commit $GITHUB_SHA is not an ancestor of origin/main."
+            echo "Refusing to publish from a non-main commit."
+            echo "Release tags must point at a commit that has been reviewed and merged into main."
+            exit 1
+          fi
+          echo "Tag commit verified to be on origin/main."
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Verify tag matches gateway/pyproject.toml version (PEP 440)
+        working-directory: gateway
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+            echo "::error::Release tags must start with 'v' (got: $GITHUB_REF)"
+            exit 1
+          fi
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+
+          PYPROJECT_VERSION=$(python3 -c "import tomllib, sys; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+
+          # Use packaging.version.Version for PEP 440 normalization, so that
+          # tags like v0.1.0-rc.1 / 0.1.0rc1 / 0.1.0a1 compare correctly
+          # against the version recorded in pyproject.toml.
+          python3 -m pip install --quiet --user "packaging>=24"
+
+          NORMALIZED_TAG=$(python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
+          NORMALIZED_PROJECT=$(python3 -c "from packaging.version import Version; print(Version('$PYPROJECT_VERSION'))")
+          echo "Tag (raw -> normalized):       $TAG_VERSION -> $NORMALIZED_TAG"
+          echo "Pyproject (raw -> normalized): $PYPROJECT_VERSION -> $NORMALIZED_PROJECT"
+          if [ "$NORMALIZED_TAG" != "$NORMALIZED_PROJECT" ]; then
+            echo "::error::Tag $TAG_VERSION does not match gateway/pyproject.toml version $PYPROJECT_VERSION"
+            exit 1
+          fi
+
+          # Reject local versions (e.g. 1.0+local) for public releases.
+          # Pre-release tags (rc / a / b) are intentionally allowed.
+          python3 - <<PY
+          from packaging.version import Version
+          v = Version("$NORMALIZED_TAG")
+          if v.local is not None:
+              raise SystemExit("::error::Local versions (e.g. 1.0+local) are not allowed for public releases")
+          print("Version policy: OK (pre-release allowed; local version rejected)")
+          PY
+
+      - name: Install gateway dependencies
+        working-directory: gateway
+        run: uv sync --frozen
+
+      - name: Run ruff
+        working-directory: gateway
+        run: uv run ruff check .
+
+      - name: Run pytest
+        working-directory: gateway
+        run: uv run pytest
+
+      - name: Build distributions
+        working-directory: gateway
+        run: uv build
+
+      - name: List built artifacts
+        working-directory: gateway
+        run: ls -la dist/
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: gateway/dist/
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    # Trusted Publishing — short-lived OIDC token, no API secret needed.
+    # The `pypi` environment must be configured on GitHub (Settings ->
+    # Environments) and the project must be registered as a Trusted
+    # Publisher on PyPI before this job can succeed.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stackchan-mcp
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,74 @@ Keep code comments, public issue descriptions, and pull request descriptions in
 English unless Japanese is needed for a hardware name, quoted source, or
 community-specific term.
 
+## Releasing the gateway to PyPI
+
+Maintainers publish the gateway to PyPI by tagging a release on `main`.
+The `.github/workflows/publish.yml` workflow runs on every tag matching
+`v*`, builds an sdist and a wheel from `gateway/`, and uploads them to
+PyPI via Trusted Publishing.
+
+### Release gates
+
+The publish workflow only succeeds if all of the following hold:
+
+- The tag commit is an ancestor of `origin/main` (no publishing from
+  feature branches or arbitrary commits).
+- The tag has a `v` prefix and matches the `project.version` field of
+  `gateway/pyproject.toml` after PEP 440 normalization, so `v0.1.0-rc.1`
+  matches a `pyproject.toml` version of `0.1.0rc1`, etc.
+- The version is not a PEP 440 local version (e.g. `1.0+local`).
+- `uv run ruff check .` and `uv run pytest` succeed inside `gateway/`.
+- The build produces a `dist/` containing both an sdist and a wheel.
+
+Pre-release tags (`v0.2.0a1`, `v1.0.0rc1`, etc.) are allowed.
+
+### One-time setup
+
+Already configured for the current maintainer; documented here so future
+maintainers can rebuild the chain:
+
+1. Register `stackchan-mcp` on PyPI as a Trusted Publisher pointing at
+   this repository, the `publish.yml` workflow file name, and the `pypi`
+   environment.
+2. Create a GitHub Environment named `pypi` on this repository
+   (Settings → Environments). Trusted Publishing uses short-lived OIDC
+   tokens, so no API secret needs to be stored. Adding required
+   reviewers on the `pypi` environment provides a manual gate before
+   each publish.
+3. Mark `v*` tags as protected (Settings → Tags → New protection rule)
+   so only maintainers can create or move release tags.
+
+### Per-release steps
+
+1. Bump the version in `gateway/pyproject.toml` (`project.version`) on a
+   topic branch and open a PR.
+2. After the PR is merged, tag the resulting commit on `main` with a
+   matching `vX.Y.Z` tag and push the tag:
+   ```bash
+   git switch main
+   git pull
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+3. The publish workflow validates the gates above, builds, and publishes
+   to PyPI. If any gate fails the workflow stops before the upload step.
+4. Confirm the new version on https://pypi.org/p/stackchan-mcp and try a
+   fresh `pipx install stackchan-mcp` (or `uv tool install stackchan-mcp`,
+   or `pip install stackchan-mcp` inside a virtualenv) in a clean
+   environment.
+
+PyPI does not allow re-uploading the same version. If a release goes out
+and you need to retract it, mark it yanked on PyPI rather than deleting
+it, and ship the fix under the next version.
+
+### Pinning policy for the publish workflow
+
+`pypa/gh-action-pypi-publish` is pinned to a specific minor.patch tag
+because it has direct upload access to PyPI; supporting actions
+(`actions/checkout`, `astral-sh/setup-uv`) are pinned to a major-version
+tag. Bumping the publish action's pin should be done in its own PR.
+
 ## Communication
 
 Be polite and concrete. This is a small hardware community, and clear technical

--- a/README.ja.md
+++ b/README.ja.md
@@ -143,6 +143,38 @@ EOF
 
 ### 2. ゲートウェイ起動
 
+ゲートウェイは PyPI で公開されているパッケージをインストールする方法
+(エンドユーザー向け) と、このリポジトリのチェックアウトから動かす方法
+(`main` を追いたいコントリビュータ向け) のどちらでも使えます。
+
+#### オプション A: ツールとしてインストール (エンドユーザー向け、推奨)
+
+システム Python や他の Python プロジェクトと衝突しない、隔離された
+インストールを行うには、以下のいずれかを使います:
+
+```bash
+uv tool install stackchan-mcp
+# または
+pipx install stackchan-mcp
+```
+
+ゲートウェイ起動:
+
+```bash
+stackchan-mcp
+```
+
+プロジェクト管理の virtualenv で動かしたい場合は、有効化した venv の中で
+`pip install stackchan-mcp` でも動きます。その venv 内では
+`python -m stackchan_mcp` も `stackchan-mcp` と同等です。ただしシステム
+Python に対して直接 `pip install` するのは避けてください (PEP 668)。
+
+[`gateway/README.md`](gateway/README.md#setup) に記載されている
+`STACKCHAN_TOKEN` / `VISION_HOST` 等の設定値は、環境変数・シェル・
+カレントディレクトリの `.env` ファイルのいずれからでも渡せます。
+
+#### オプション B: ソースから uv で起動 (コントリビュータ向け)
+
 ```bash
 cd gateway
 cp .env.example .env       # STACKCHAN_TOKEN / VISION_HOST を設定
@@ -159,7 +191,26 @@ callback 設定を [`docs/remote-access.md`](docs/remote-access.md) にまとめ
 
 ### 3. MCP クライアント登録 (Claude Code 例)
 
-`~/.claude.json` に追加:
+`~/.claude.json` に追加します。
+
+`pip install stackchan-mcp` でインストールした場合:
+
+```json
+{
+  "mcpServers": {
+    "stackchan-mcp": {
+      "type": "stdio",
+      "command": "stackchan-mcp",
+      "env": {
+        "STACKCHAN_TOKEN": "your-secret-token-here",
+        "VISION_HOST": "your.host.lan.ip"
+      }
+    }
+  }
+}
+```
+
+ソースから `uv` で動かす場合:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -169,6 +169,38 @@ cannot be added accidentally with `git add -A`.
 
 ### 2. Start the gateway
 
+The gateway can either be installed as the published PyPI package
+(recommended for end users) or run from this repository as a checkout
+(recommended for contributors who want to follow `main`).
+
+#### Option A: install as a tool (recommended for end users)
+
+For an isolated install that does not collide with your system Python or
+other Python projects, use one of:
+
+```bash
+uv tool install stackchan-mcp
+# or
+pipx install stackchan-mcp
+```
+
+Then run the gateway:
+
+```bash
+stackchan-mcp
+```
+
+If you prefer a project-managed virtualenv, `pip install stackchan-mcp`
+inside an active venv works as well, and `python -m stackchan_mcp`
+inside that venv is equivalent to `stackchan-mcp`. Just avoid
+`pip install` against the system Python (PEP 668).
+
+The `STACKCHAN_TOKEN`, `VISION_HOST`, and other settings documented in
+[`gateway/README.md`](gateway/README.md#setup) can be supplied via environment
+variables, the active shell, or a `.env` file in the working directory.
+
+#### Option B: from source via uv (contributors)
+
 ```bash
 cd gateway
 cp .env.example .env       # set STACKCHAN_TOKEN / VISION_HOST
@@ -186,7 +218,26 @@ Tailscale Funnel flow and the `VISION_URL` capture callback setting.
 
 ### 3. Register as an MCP client (Claude Code example)
 
-Add to `~/.claude.json`:
+Add to `~/.claude.json`.
+
+If you installed via `pip install stackchan-mcp`:
+
+```json
+{
+  "mcpServers": {
+    "stackchan-mcp": {
+      "type": "stdio",
+      "command": "stackchan-mcp",
+      "env": {
+        "STACKCHAN_TOKEN": "your-secret-token-here",
+        "VISION_HOST": "your.host.lan.ip"
+      }
+    }
+  }
+}
+```
+
+If you installed from source via `uv`:
 
 ```json
 {

--- a/gateway/LICENSE
+++ b/gateway/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2025 Shenzhen Xinzhi Future Technology Co., Ltd.
+Copyright (c) 2025 Project Contributors
+Copyright (c) 2026 kisaragi-mochi
+
+NOTE: This MIT License covers the repository as a whole **except** for the
+SCServo_lib files (Feetech serial bus servo SDK), which live in
+`firmware/main/boards/stackchan/` (files: SCS.{cc,h}, SCSCL.{cc,h},
+SCSerial.{cc,h}, INST.h, SCServo.h) and are licensed separately under the
+GNU General Public License v3.0. Their full license text is in
+`firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt`.
+
+Because the firmware binary statically links the SCServo_lib code, the
+combined firmware build is effectively distributed under GPL-3.0. The
+gateway/ Python package, which runs in a separate process and communicates
+with the device only over a network socket, remains under the MIT License
+above.
+
+---
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -15,6 +15,37 @@ The gateway exposes a clean stdio MCP server to the LLM client (left) while
 speaking the xiaozhi-esp32 WebSocket MCP dialect to the device (right). It
 also runs a small HTTP server (`/capture`) so the ESP32 can upload photos.
 
+The package name on PyPI, the installed CLI command, and the MCP server id
+in your client config are all `stackchan-mcp`.
+
+## Install (end users)
+
+The gateway is published to PyPI as `stackchan-mcp`. For end users, install
+it as an isolated CLI tool:
+
+```bash
+uv tool install stackchan-mcp
+# or
+pipx install stackchan-mcp
+```
+
+Then run:
+
+```bash
+stackchan-mcp
+```
+
+`stackchan-mcp` reads its configuration (`STACKCHAN_TOKEN`, `VISION_HOST`,
+etc.) from environment variables or a `.env` file in the working directory.
+See the [Setup](#setup) section below for the supported variables. For the
+firmware side (WebSocket gateway URL, auth token, NVS configuration), see
+[`../README.md`](../README.md#configuring-the-websocket-gateway-url-and-auth-token).
+
+If you prefer a project-managed virtualenv, `pip install stackchan-mcp`
+inside an active venv works as well, and `python -m stackchan_mcp` inside
+that venv is equivalent to `stackchan-mcp`. Just avoid `pip install`
+against the system Python (PEP 668).
+
 ## Setup
 
 ```bash
@@ -165,3 +196,12 @@ asyncio.run(smoke())
 - **Phase 2** (done): real servo / volume / brightness via ESP32
 - **Phase 3** (done): camera capture (JPEG over HTTP)
 - **Phase 4** (planned): Opus audio stream (STT/TTS pipeline)
+
+## License
+
+The gateway is distributed under the MIT License (see `LICENSE`). The
+parent monorepo's `firmware/` directory contains SCServo_lib code under
+GPL-3.0, but those files live only inside
+`firmware/main/boards/stackchan/` and never enter this package. The
+gateway and firmware communicate only over WebSocket, so the GPL/MIT
+boundary is preserved at the process level.

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -5,6 +5,7 @@ description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdi
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "kisaragi-mochi" },
 ]
@@ -35,6 +36,9 @@ dependencies = [
 Homepage = "https://github.com/kisaragi-mochi/stackchan-mcp"
 Repository = "https://github.com/kisaragi-mochi/stackchan-mcp"
 Issues = "https://github.com/kisaragi-mochi/stackchan-mcp/issues"
+
+[project.scripts]
+stackchan-mcp = "stackchan_mcp.cli:main"
 
 [dependency-groups]
 dev = [

--- a/gateway/stackchan_mcp/__main__.py
+++ b/gateway/stackchan_mcp/__main__.py
@@ -1,45 +1,12 @@
-"""Entry point: python -m stackchan_mcp
+"""Entry point: ``python -m stackchan_mcp``.
 
-Starts the two-faced gateway:
-- stdio MCP server (MCP client side)
-- WebSocket server (ESP32 side)
+The actual implementation lives in :mod:`stackchan_mcp.cli` so that the
+console script and ``python -m`` paths share a single side-effect-free
+import surface.
 """
 
-import asyncio
-import logging
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-)
-
-logger = logging.getLogger(__name__)
+from .cli import main
 
 
-async def _run() -> None:
-    """Start both the ESP32 WebSocket server and the stdio MCP server."""
-    from .gateway import get_gateway
-    from .stdio_server import run_stdio_server
-
-    gateway = get_gateway()
-
-    # Start ESP32 WebSocket server
-    await gateway.start()
-    logger.info("Gateway started, waiting for ESP32 connections...")
-
-    try:
-        # Run stdio MCP server (blocks until MCP client disconnects)
-        await run_stdio_server()
-    finally:
-        await gateway.stop()
-
-
-def main() -> None:
-    asyncio.run(_run())
-
-
-main()
+if __name__ == "__main__":
+    main()

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -1,0 +1,57 @@
+"""Console entry point for stackchan-mcp.
+
+This module exists so that `import stackchan_mcp` (or any of its
+submodules) does not trigger import-time side effects like
+`load_dotenv()` or logging configuration. All such side effects live
+inside :func:`main`, which is registered as the `stackchan-mcp`
+console script in ``pyproject.toml`` and is also re-exported through
+``stackchan_mcp.__main__`` so that ``python -m stackchan_mcp`` keeps
+working.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> None:
+    """Start both the ESP32 WebSocket server and the stdio MCP server."""
+    from .gateway import get_gateway
+    from .stdio_server import run_stdio_server
+
+    gateway = get_gateway()
+
+    await gateway.start()
+    logger.info("Gateway started, waiting for ESP32 connections...")
+
+    try:
+        # Run stdio MCP server (blocks until MCP client disconnects)
+        await run_stdio_server()
+    finally:
+        await gateway.stop()
+
+
+def main() -> None:
+    """Console-script entry point.
+
+    Loads ``.env``, configures logging, and starts the gateway. Side
+    effects are intentionally scoped to this function so that
+    ``import stackchan_mcp`` stays clean.
+    """
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Make the gateway installable from PyPI as `stackchan-mcp`, with a hardened publish pipeline. End users can now `pipx install stackchan-mcp` (or `uv tool install stackchan-mcp`) and run the gateway with a single `stackchan-mcp` command, instead of cloning the whole monorepo.

The publish pipeline (`.github/workflows/publish.yml`, tag-driven via Trusted Publishing) enforces:

- The tag commit must be an ancestor of `origin/main` (no publishing from feature branches).
- The tag must match `gateway/pyproject.toml` after PEP 440 normalization (so `v0.1.0-rc.1` matches `0.1.0rc1`).
- The tag must have a `v` prefix; local versions (`+local`) are rejected; pre-releases (`rc`/`a`/`b`) are allowed.
- `uv run ruff check .` and `uv run pytest` must pass before the build step.
- Top-level `permissions: {}` with per-job opt-in.
- `pypa/gh-action-pypi-publish` is pinned to a specific minor.patch tag; supporting actions are pinned to a major-version tag.

A small refactor splits the entry point into `stackchan_mcp.cli:main` so that `import stackchan_mcp` is now side-effect-free (no more `load_dotenv()` / `logging.basicConfig()` running at import time). `python -m stackchan_mcp` still works via a thin re-export in `__main__.py`.

`gateway/LICENSE` was added (with `license-files = ["LICENSE"]` in `pyproject.toml`) so the published wheel and sdist include the MIT license text per PEP 639.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (35 passed)
- [x] gateway: `uv run ruff check .` (All checks passed)
- [ ] firmware: `python ./scripts/release.py stackchan`
- [x] Not applicable / not run: firmware untouched in this PR (gateway-only change)

Additional local validation performed:

- `uv build` produces both an sdist and a wheel from `gateway/`.
- sdist contains `stackchan_mcp-0.1.0/LICENSE`.
- wheel contains `stackchan_mcp-0.1.0.dist-info/licenses/LICENSE` and `entry_points.txt` pointing at `stackchan_mcp.cli:main`.
- Isolated Python 3.12 venv: `pip install dist/*.whl` succeeds; `stackchan-mcp` starts and survives a 2-second liveness probe.
- `import stackchan_mcp`, `import stackchan_mcp.cli`, and `import stackchan_mcp.__main__` all add zero handlers to the root logger (verifies the side-effect-free import claim).
- `publish.yml` parses cleanly with `python3 -c "import yaml; yaml.safe_load(...)"`.
- PEP 440 normalization spot-checked locally with `packaging.version.Version`.

### Hardware

- [x] Not applicable / hardware not available: gateway-only change, firmware untouched

## Breaking changes

The console-script entry point moved from `stackchan_mcp.__main__:main` to `stackchan_mcp.cli:main` so that `import stackchan_mcp` no longer triggers `load_dotenv()` or `logging.basicConfig()`. `python -m stackchan_mcp` is preserved through a thin re-export in `__main__.py`. External MCP tool API is unchanged.

## Related issues

Closes #11.

Operational follow-ups (`CHANGELOG.md`, fork-friendly publishing path) are tracked in #45.

### Manual maintainer steps required after merge

These are documented in `CONTRIBUTING.md` but worth surfacing here:

1. Register `stackchan-mcp` on PyPI as a Trusted Publisher (Project name: `stackchan-mcp`, Owner: `kisaragi-mochi`, Repository: `stackchan-mcp`, Workflow: `publish.yml`, Environment: `pypi`).
2. Create a GitHub Environment named `pypi` on this repository (Settings → Environments). No secrets needed (Trusted Publishing uses OIDC). Adding required reviewers on the `pypi` environment provides a manual gate before each publish.
3. Mark `v*` tags as protected (Settings → Tags → New protection rule) so only maintainers can create release tags.
4. Then `git tag v0.1.0 && git push origin v0.1.0` for the first release.