### PR TITLE
fix(ci): pin setup-uv to v8.1.0 and add workflow_dispatch dry-run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+  # Allow maintainers to manually run the build/test pipeline without
+  # cutting a tag — useful for verifying the workflow itself or
+  # dry-running a CI change. The publish job is skipped when the
+  # workflow is invoked this way, so this cannot accidentally release.
+  workflow_dispatch:
 
 # Default permissions: nothing. Each job opts in to what it needs.
 permissions: {}
@@ -31,6 +36,9 @@ jobs:
           persist-credentials: false
 
       - name: Verify tag commit is on origin/main
+        # Tag-only check. workflow_dispatch dry-runs skip this so they
+        # can validate the build/test pipeline from any branch.
+        if: github.event_name == 'push'
         run: |
           set -euo pipefail
           git fetch origin main
@@ -43,11 +51,17 @@ jobs:
           echo "Tag commit verified to be on origin/main."
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        # `astral-sh/setup-uv` ships immutable releases starting with
+        # v8 — no `@v8` alias exists, so a full version pin is required.
+        # See CONTRIBUTING.md "Pinning policy for the publish workflow".
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
       - name: Verify tag matches gateway/pyproject.toml version (PEP 440)
+        # Tag-only check. workflow_dispatch dry-runs skip this since
+        # there is no tag to compare against.
+        if: github.event_name == 'push'
         working-directory: gateway
         run: |
           set -euo pipefail
@@ -114,6 +128,12 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build
+    # Only publish on tag pushes. workflow_dispatch invocations stop at
+    # the build job above, so manual runs cannot release. The
+    # `startsWith(github.ref, 'refs/tags/v')` guard makes the intent
+    # explicit and survives future trigger additions (e.g. push to
+    # branches).
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     # Trusted Publishing — short-lived OIDC token, no API secret needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,10 +245,24 @@ it, and ship the fix under the next version.
 
 ### Pinning policy for the publish workflow
 
-`pypa/gh-action-pypi-publish` is pinned to a specific minor.patch tag
-because it has direct upload access to PyPI; supporting actions
-(`actions/checkout`, `astral-sh/setup-uv`) are pinned to a major-version
-tag. Bumping the publish action's pin should be done in its own PR.
+`pypa/gh-action-pypi-publish` is pinned to a specific `minor.patch` tag
+because it has direct upload access to PyPI. Supporting actions are
+pinned to the most stable form their upstream maintains:
+
+- `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`:
+  major-version tag (e.g. `@v4`). Upstream maintains `v4`, `v5`, ... as
+  moving aliases.
+- `astral-sh/setup-uv`: full `vX.Y.Z` tag. Starting with v8 the upstream
+  ships immutable releases only and does not maintain a moving major-
+  version alias, so `@v8` does not exist. Bump to a new full version in
+  its own PR.
+
+Bumping the publish action's pin should be done in its own PR.
+
+The publish workflow also supports `workflow_dispatch` so that
+maintainers can verify the build pipeline (lint / test / build)
+without cutting a tag. The publish job is gated on `push` events, so
+manual runs cannot release.
 
 ## Communication
 


### PR DESCRIPTION
## Summary

Hotfix for the v0.1.0 publish workflow run, which failed at the action-resolution step because `astral-sh/setup-uv@v8` does not exist (setup-uv switched to immutable releases starting with v8 and does not maintain a `v8` moving alias). This PR pins to `v8.1.0` and adds dry-run support so the same kind of breakage can be caught before cutting a tag next time.

Changes:

- Pin `astral-sh/setup-uv@v8` → `astral-sh/setup-uv@v8.1.0`.
- Add `workflow_dispatch` to the publish workflow with tag-only steps gated on `github.event_name == 'push'`. Maintainers can now run lint/test/build from any branch as a true dry-run.
- Harden the `publish` job's gate: `if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')` so future trigger additions cannot accidentally release.
- Document the asymmetry between moving-alias actions (`actions/*`) and immutable-release actions (`astral-sh/setup-uv`) in `CONTRIBUTING.md`'s pinning policy section.

## Test plan

### Code-level

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` — valid YAML
- [x] gateway: `uv run pytest` (unaffected by this PR; rerun OK)
- [x] gateway: `uv run ruff check .` (unaffected by this PR; rerun OK)
- [ ] firmware: `python ./scripts/release.py stackchan`
- [x] Not applicable: gateway and firmware code untouched

After merge, the maintainer will trigger `workflow_dispatch` on `main` once to confirm the dry-run path reaches build/test (this is exactly the kind of breakage the previous attempt could not catch ahead of time).

### Hardware

- [x] Not applicable: CI / workflow-only change.

## Why the previous publish failed

The v0.1.0 release tag was created against the previous workflow which used `astral-sh/setup-uv@v8`. GitHub Actions could not resolve that tag, and the run failed at the "Set up job" step before any verification, build, or publish step ran. PyPI received nothing, so `v0.1.0` is still available and will be re-cut on the post-merge `main` HEAD.

## Breaking changes

None.

## Related issues

Refs #11.