### PR TITLE
docs(release): add CHANGELOG and fork-friendly publishing notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to this repository are documented here.
+
+The format is based on
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Version tags (`vX.Y.Z`) track the **Python MCP gateway** published to PyPI
+as `stackchan-mcp`. The ESP32 firmware lives in the same repository but is
+built and distributed separately through `firmware/scripts/release.py` and
+the upstream xiaozhi-esp32 firmware version (currently `v2.2.6`); when a
+tagged gateway release also requires a coordinated firmware change, that
+change is called out under a `Firmware` subsection of the release entry.
+
+## [Unreleased]
+
+(no entries yet)
+
+## [0.1.0] - 2026-05-07
+
+Initial PyPI release of the gateway. End users can now install the MCP
+server without cloning the monorepo:
+
+```bash
+pipx install stackchan-mcp
+# or
+uv tool install stackchan-mcp
+```
+
+### Added
+
+- Publish the gateway to PyPI as `stackchan-mcp`. A single
+  `stackchan-mcp` console script starts the gateway. ([#11], [#46])
+- Tag-driven publish workflow (`.github/workflows/publish.yml`) using
+  PyPI Trusted Publishing. The workflow refuses to publish unless the
+  tag commit is on `origin/main`, the tag has a `v` prefix and matches
+  `gateway/pyproject.toml` after PEP 440 normalization, the version is
+  not a PEP 440 local version, and `uv run ruff check .` plus
+  `uv run pytest` succeed inside `gateway/`. ([#46])
+- `workflow_dispatch` dry-run support for `publish.yml` so maintainers
+  can verify lint, test, and build without cutting a tag; the publish
+  job is gated on `push` so manual runs cannot release. ([#47])
+- Bundle the MIT `LICENSE` in both the published wheel and sdist via
+  `license-files = ["LICENSE"]` (PEP 639). ([#46])
+
+### Changed
+
+- Split the gateway entry point into `stackchan_mcp.cli:main` so that
+  `import stackchan_mcp` is side-effect-free (no `load_dotenv()` or
+  `logging.basicConfig()` at import time). `python -m stackchan_mcp`
+  continues to work through a thin re-export in `__main__.py`. ([#46])
+
+### Fixed
+
+- Pin `astral-sh/setup-uv` to a full `vX.Y.Z` tag (`v8.1.0`) in the
+  publish workflow. Starting with v8 the upstream ships immutable
+  releases only and does not maintain a moving `@v8` major-version
+  alias, so the previous floating pin no longer resolved. ([#47])
+
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.1.0
+
+[#11]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/11
+[#46]: https://github.com/kisaragi-mochi/stackchan-mcp/pull/46
+[#47]: https://github.com/kisaragi-mochi/stackchan-mcp/pull/47

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,8 +222,13 @@ maintainers can rebuild the chain:
 
 ### Per-release steps
 
-1. Bump the version in `gateway/pyproject.toml` (`project.version`) on a
-   topic branch and open a PR.
+1. On a topic branch, bump the version in `gateway/pyproject.toml`
+   (`project.version`) and update `CHANGELOG.md`: rename the
+   `## [Unreleased]` section to `## [X.Y.Z] - YYYY-MM-DD`, add a fresh
+   empty `## [Unreleased]` above it, and update the comparison links at
+   the bottom of the file (`[Unreleased]` should compare the new tag to
+   `HEAD`, and a new `[X.Y.Z]` link should point at the release tag).
+   Open a PR with these changes.
 2. After the PR is merged, tag the resulting commit on `main` with a
    matching `vX.Y.Z` tag and push the tag:
    ```bash
@@ -263,6 +268,45 @@ The publish workflow also supports `workflow_dispatch` so that
 maintainers can verify the build pipeline (lint / test / build)
 without cutting a tag. The publish job is gated on `push` events, so
 manual runs cannot release.
+
+### Fork-friendly publishing
+
+The Trusted Publisher and `pypi` GitHub Environment described above are
+reserved for the canonical `stackchan-mcp` project on PyPI, owned by
+`kisaragi-mochi/stackchan-mcp`. A fork that wants to publish its own
+builds should not reuse the upstream PyPI project name or assume the
+upstream `pypi` environment is reachable from the fork. PRs against
+this repository should leave the existing `publish.yml` and `pypi`
+environment configuration alone.
+
+Forks that want to ship under a different name (for example,
+`yourhandle-stackchan-mcp` on PyPI) have two practical paths:
+
+1. **Trusted Publishing on the fork.** Pick a different PyPI project
+   name, change `project.name` in `gateway/pyproject.toml` (and review
+   `project.urls` and the `[project.scripts]` console-script name if
+   the fork wants its own CLI command, plus the user-facing references
+   in `gateway/README.md`) to match, register the fork's
+   `<owner>/<repo>` and `publish.yml` against the new PyPI project
+   name as a Trusted Publisher, and recreate a `pypi` GitHub
+   Environment in the fork. Tag/version gates in `publish.yml` keep
+   working as-is because they only check the local repo and
+   `pyproject.toml`. This keeps the OIDC-based, no-API-token flow.
+2. **PyPI API token in the fork.** If Trusted Publishing is not an
+   option (publishing from a non-GitHub CI, an internal index, or
+   ad-hoc local releases), generate a project-scoped PyPI API token
+   for the fork's PyPI project and store it as a secret in the fork.
+   Replace the OIDC publish step in the fork's `publish.yml` (or the
+   equivalent step in the alternate CI) with a token-based upload such
+   as `twine upload --username __token__ --password $PYPI_API_TOKEN
+   dist/*`. Keep the publish job in a protected environment so the
+   secret is only exposed to the publish step, and prefer a
+   project-scoped token over a user-scoped one.
+
+In either case, do not push fork-only credentials, fork-only project
+names, or token-based upload steps back to upstream. The upstream
+pipeline is intentionally strict about the canonical project name and
+the OIDC-only path.
 
 ## Communication
 


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the initial PyPI publishing work
(#11 / #46) and the publish workflow hotfix (#47). Closes #45.

- Add a top-level `CHANGELOG.md` in Keep-a-Changelog 1.1.0 style with
  `[Unreleased]` and `[0.1.0] - 2026-05-07` sections. The `0.1.0`
  entry summarizes #46 (PyPI distribution, side-effect-free import,
  PEP 639 license bundling) and #47 (`astral-sh/setup-uv` full-tag
  pin, `workflow_dispatch` dry-run).
- In `CONTRIBUTING.md`:
  - Fold a CHANGELOG update step into the per-release procedure:
    bumping `gateway/pyproject.toml` now also requires moving entries
    out of `[Unreleased]` into a dated section and refreshing the
    comparison links at the bottom of the file.
  - Add a `Fork-friendly publishing` subsection to the existing
    `Releasing the gateway to PyPI` section. It clarifies that the
    upstream Trusted Publisher and the `pypi` GitHub Environment are
    reserved for the canonical `stackchan-mcp` project, and offers
    two practical paths for forks: Trusted Publishing under a
    different PyPI project name, or a project-scoped PyPI API token
    for non-GitHub-CI or alternate-index publishing.

## Test plan

### Code-level

- [x] Not applicable / not run: documentation only — no gateway or
      firmware code changes, no workflow/Kconfig changes.

### Hardware

- [x] Not applicable / hardware not available: documentation only.

## Breaking changes

None. Documentation only. No MCP tool API, NVS schema, or build flag
changes.

## Related issues

Closes #45.
Refs #11, #46, #47.