### PR TITLE
feat(avatar): add set_avatar("off") to hide avatar and disable blink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
-(no entries yet)
+### Added
+
+- `set_avatar` now accepts `"off"` as a face value. When called with
+  `"off"`, the avatar layer is hidden and autonomous blinking is
+  disabled so the underlying xiaozhi-esp32 screens (WiFi config UI,
+  OTA, settings) become visible on the LCD without erasing NVS.
+  Calling `set_avatar` with any other face brings the avatar back and
+  restores the previous blink state automatically. ([#3])
+
+[#3]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/3
 
 ## [0.1.0] - 2026-05-07
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,7 +52,7 @@
 | `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ) | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
-| `set_avatar(face)` | アバター表情切替 (neutral/happy/sad 等 6種) | ✅ |
+| `set_avatar(face)` | アバター表情切替 (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`)、または `off` でアバターを隠し blink も停止して下層の WiFi 設定 / OTA / 設定画面を露出。他 face を指定するとアバター + blink が復帰 | ✅ |
 | `set_blink(state)` | 瞬き ON/OFF | ✅ |
 | `set_mouth(state)` | 口開閉 | ✅ |
 | `check_vm_en` | サーボ電源 (VM EN HIGH) 状態確認 | ✅ |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This repository is a monorepo.
 | `set_brightness(brightness)` | Screen brightness (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | Move the neck (servos) | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
-| `set_avatar(face)` | Switch avatar expression (neutral / happy / sad / etc., 6 total) | ✅ |
+| `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying WiFi config / OTA / settings screens are visible. Any other face brings the avatar back and restores blink. | ✅ |
 | `set_blink(state)` | Blink on/off | ✅ |
 | `set_mouth(state)` | Mouth open/close | ✅ |
 | `check_vm_en` | Check servo power supply (VM EN HIGH) state | ✅ |

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -420,6 +420,10 @@ private:
     esp_timer_handle_t blink_step_timer_ = nullptr;
     BlinkState blink_state_ = BlinkState::IDLE;
     bool blink_enabled_ = false;
+    // Captures blink_enabled_ at the moment SetAvatarOff() runs, so that a
+    // later set_avatar(<other face>) can restore the previous blink state.
+    // Only meaningful while current_avatar_face_ == "off".
+    bool blink_enabled_before_off_ = false;
 
     // Phase 7: Si12T head-touch sensing.
     // Polling every TOUCH_POLL_MS samples Output1 (CH1..CH3 -> 3 head zones).
@@ -1041,10 +1045,12 @@ private:
     }
 
     // Schedule a single-shot revert to "idle" face REACTION_HOLD_MS later.
-    // Re-arming overwrites any pending revert.
+    // Re-arming overwrites any pending revert. Skipped while the avatar
+    // has been hidden via set_avatar("off"), so a stale revert timer
+    // does not re-cover the LCD after the user explicitly hid it.
     static void TouchRevertCb(void* arg) {
         StackChanBoard* self = static_cast<StackChanBoard*>(arg);
-        self->SetAvatarExpression("idle");
+        self->SetAvatarExpressionIfActive("idle");
     }
 
     void ScheduleIdleRevert() {
@@ -1069,7 +1075,9 @@ private:
                  last_output1_raw_);
         last_event_ = TouchEvent::TAP;
         last_event_us_ = esp_timer_get_time();
-        SetAvatarExpression("surprised");
+        // Use the IfActive variant so a tap during set_avatar("off") does
+        // not pop the avatar back over the WiFi config / settings screens.
+        SetAvatarExpressionIfActive("surprised");
         ScheduleIdleRevert();
     }
 
@@ -1079,7 +1087,7 @@ private:
                  (unsigned long long)duration_ms, last_output1_raw_);
         last_event_ = TouchEvent::STROKE;
         last_event_us_ = esp_timer_get_time();
-        SetAvatarExpression("embarrassed");
+        SetAvatarExpressionIfActive("embarrassed");
         StartServoWobble();
         ScheduleIdleRevert();
     }
@@ -1244,17 +1252,83 @@ private:
 
     // Public-style entry that takes the display lock. Used by the MCP tool
     // and by the deferred init timer. Always safe to call from any task.
+    //
+    // Also handles the "resume from off" path: if the previous face was
+    // "off" (avatar layer hidden), the layer is unhidden here, and if blink
+    // was enabled before SetAvatarOff() ran it is restored automatically.
     bool SetAvatarExpression(const char* face) {
         if (display_ == nullptr) {
             ESP_LOGW(TAG, "SetAvatarExpression('%s') ignored: display_ not ready", face);
             return false;
         }
-        DisplayLockGuard lock(display_);
-        bool ok = SetAvatarExpressionLocked(face);
+        bool was_off = (current_avatar_face_ == "off");
+        bool ok;
+        {
+            DisplayLockGuard lock(display_);
+            if (avatar_img_ != nullptr) {
+                // Restore visibility if a previous SetAvatarOff() hid the
+                // layer. Cheap no-op when the flag is already clear.
+                lv_obj_clear_flag(avatar_img_, LV_OBJ_FLAG_HIDDEN);
+            }
+            ok = SetAvatarExpressionLocked(face);
+        }
         if (!ok) {
             ESP_LOGW(TAG, "SetAvatarExpression('%s') deferred (face unknown or screen not ready)", face);
+            return ok;
         }
+        // Coming back from "off": if blink was on before going off, restart
+        // it so the user does not have to re-issue set_blink. The default
+        // experience is "blink follows the avatar".
+        if (was_off && blink_enabled_before_off_) {
+            StartBlinkTimer();
+            ESP_LOGI(TAG, "Blink restored after avatar resume from OFF");
+        }
+        blink_enabled_before_off_ = false;
         return ok;
+    }
+
+    // Hide the avatar layer and disable blink so the underlying
+    // xiaozhi-esp32 screens (WiFi config UI, OTA, settings) become visible.
+    // The avatar lv_obj is kept allocated so a subsequent
+    // SetAvatarExpression(<other face>) can re-show it cheaply, and the
+    // previous blink state is remembered for restoration.
+    bool SetAvatarOff() {
+        if (display_ == nullptr) {
+            ESP_LOGW(TAG, "SetAvatarOff() ignored: display_ not ready");
+            return false;
+        }
+        // Capture the previous blink state only on the first transition
+        // into "off". A repeated set_avatar("off") while already off must
+        // not overwrite the saved state with the post-off (always-false)
+        // blink_enabled_.
+        if (current_avatar_face_ != "off") {
+            blink_enabled_before_off_ = blink_enabled_;
+        }
+        // StopBlinkTimer() takes the display lock internally for the
+        // resting-face restore step, so call it before grabbing our lock.
+        StopBlinkTimer();
+        {
+            DisplayLockGuard lock(display_);
+            if (avatar_img_ != nullptr) {
+                lv_obj_add_flag(avatar_img_, LV_OBJ_FLAG_HIDDEN);
+            }
+        }
+        current_avatar_face_ = "off";
+        ESP_LOGI(TAG, "Avatar OFF: hidden + blink disabled (was %s)",
+                 blink_enabled_before_off_ ? "ON" : "OFF");
+        return true;
+    }
+
+    // Internal-only entry used by autonomous animations (touch reactions,
+    // idle revert, etc.). Skips the face change while the avatar is in
+    // the user-requested "off" state, so the underlying xiaozhi-esp32
+    // screens remain visible. Returns true if the face was applied.
+    bool SetAvatarExpressionIfActive(const char* face) {
+        if (current_avatar_face_ == "off") {
+            ESP_LOGD(TAG, "SetAvatarExpressionIfActive('%s') skipped: avatar is OFF", face);
+            return false;
+        }
+        return SetAvatarExpression(face);
     }
 
     // Schedule a one-shot/periodic timer that keeps trying to install the
@@ -1641,28 +1715,42 @@ private:
                 return root;
             });
 
-        // Set the avatar face (one of: idle, happy, thinking, sad, surprised, embarrassed).
+        // Set the avatar face (one of: idle, happy, thinking, sad, surprised,
+        // embarrassed, off).
         // The image is rendered as a 320x240 overlay on top of the chat UI's
         // emoji_label_ / emoji_image_; LVGL theme/Application emotion updates
         // will keep happening underneath but are visually masked.
+        // 'off' hides the avatar lv_obj and disables blink so the underlying
+        // xiaozhi-esp32 screens (WiFi config UI, OTA, settings) become visible.
+        // A subsequent set_avatar with any other face brings it back, and
+        // restores blink to whatever state it was in before going off.
         mcp_server.AddTool(
             "self.display.set_avatar",
             "Set the avatar face displayed on the LCD. face must be one of: "
-            "idle, happy, thinking, sad, surprised, embarrassed.",
+            "idle, happy, thinking, sad, surprised, embarrassed, off. "
+            "'off' hides the avatar and disables blink so the underlying "
+            "xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are "
+            "visible; calling set_avatar with another face brings the avatar "
+            "back and restores the previous blink state.",
             PropertyList({Property("face", kPropertyTypeString)}),
             [this](const PropertyList& properties) -> ReturnValue {
                 std::string face = properties["face"].value<std::string>();
-                bool valid = (AvatarImageFor(face.c_str()) != nullptr);
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddStringToObject(root, "face", face.c_str());
-                if (!valid) {
+
+                bool applied = false;
+                if (face == "off") {
+                    applied = SetAvatarOff();
+                } else if (AvatarImageFor(face.c_str()) != nullptr) {
+                    applied = SetAvatarExpression(face.c_str());
+                } else {
                     cJSON_AddBoolToObject(root, "ok", false);
                     cJSON_AddStringToObject(root, "error",
-                        "Unknown face. Allowed: idle, happy, thinking, sad, surprised, embarrassed.");
+                        "Unknown face. Allowed: idle, happy, thinking, sad, "
+                        "surprised, embarrassed, off.");
                     ESP_LOGW(TAG, "set_avatar rejected: unknown face '%s'", face.c_str());
                     return root;
                 }
-                bool applied = SetAvatarExpression(face.c_str());
                 cJSON_AddBoolToObject(root, "ok", applied);
                 if (!applied) {
                     cJSON_AddStringToObject(root, "error",

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -132,7 +132,7 @@ Same shape, under `mcpServers`.
 | `move_head(yaw, pitch, speed?)` | Drive yaw + pitch servos |
 | `get_head_angles` | Read current yaw + pitch servo angles |
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
-| `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`) |
+| `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are visible. A subsequent `set_avatar(<other face>)` brings it back and restores blink. |
 | `set_blink(state)` | Blink animation on/off |
 | `set_mouth(state)` | Mouth shape (`closed` / `half` / `open` / `e` / `u`) |
 | `check_vm_en` | Read PY32 VM EN GPIO state (servo power supply diagnostic) |

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -150,8 +150,11 @@ def create_server() -> Server:
                 name="set_avatar",
                 description=(
                     "Switch the avatar face shown on the LCD. "
-                    "Pick the face that fits the current emotional beat — this is "
-                    "the robot's actual visible expression, not just a label."
+                    "Choose one of the supported faces; this is the robot's "
+                    "actual visible expression, not just a label. "
+                    "Pass 'off' to hide the avatar and disable blink, exposing the "
+                    "underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings); "
+                    "any other face brings the avatar back and restores blink."
                 ),
                 inputSchema={
                     "type": "object",
@@ -165,8 +168,12 @@ def create_server() -> Server:
                                 "sad",
                                 "surprised",
                                 "embarrassed",
+                                "off",
                             ],
-                            "description": "One of: idle, happy, thinking, sad, surprised, embarrassed.",
+                            "description": (
+                                "One of: idle, happy, thinking, sad, surprised, "
+                                "embarrassed, off."
+                            ),
                         },
                     },
                     "required": ["face"],


### PR DESCRIPTION
## Summary

Closes #3.

Adds `"off"` as a new face value to the existing `set_avatar` MCP
tool. When called with `"off"`, the avatar layer is hidden and
autonomous blinking is disabled so the underlying xiaozhi-esp32
screens (WiFi config UI, OTA, settings) become visible on the LCD
without erasing NVS. Calling `set_avatar` with any other face brings
the avatar back and restores the previous blink state automatically,
so the default "blink follows the avatar" experience is preserved.

This unblocks #25 (adding a WebSocket gateway URL field to the WiFi
config UI), where the user has to actually see the device-side config
form during first-boot setup.

### Key design points

- **Blink follows the avatar.** If blink was enabled when the user
  called `set_avatar("off")`, it is automatically restarted when the
  user later calls `set_avatar(<other face>)`. The previous state is
  captured only on the first transition into `"off"` — re-entering
  `"off"` while already off must not overwrite the saved state with
  the post-off (always-false) `blink_enabled_`.
- **Autonomous animations respect "off".** Touch reactions
  (`HandleTap`, `HandleStroke`) and the touch idle-revert timer
  (`TouchRevertCb`) now go through a new
  `SetAvatarExpressionIfActive()` helper that skips the face change
  while `current_avatar_face_ == "off"`. Otherwise a tap or a stale
  revert timer would pop the avatar back over the WiFi config / OTA
  screens after the user explicitly hid it.
- **DisplayLockGuard ordering.** `SetAvatarOff()` calls
  `StopBlinkTimer()` (which itself briefly takes the display lock for
  the resting-face restore step) before taking its own
  `DisplayLockGuard`, to avoid lock nesting.
- **`avatar_img_` is kept allocated.** `"off"` only adds
  `LV_OBJ_FLAG_HIDDEN`; reactivation clears the flag and applies the
  new face image. Cheaper than tearing down and recreating the
  `lv_image`, and keeps `current_avatar_face_` semantics simple.

### Files

- `firmware/main/boards/stackchan/stackchan.cc`: new
  `blink_enabled_before_off_` member, `SetAvatarOff()`,
  `SetAvatarExpressionIfActive()`, updated `SetAvatarExpression()`,
  updated MCP tool registration.
- `gateway/stackchan_mcp/stdio_server.py`: add `"off"` to the
  `set_avatar` enum and refresh the tool description.
- `README.md`, `README.ja.md`, `gateway/README.md`: update the
  `set_avatar(face)` row.
- `CHANGELOG.md`: Added entry under `[Unreleased]`.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (35 passed)
- [x] gateway: `uv run ruff check .` (All checks passed)
- [x] firmware: `python ./scripts/release.py stackchan` (in
      `espressif/idf:v5.5.2` Docker image; produces
      `build/xiaozhi.bin` and `releases/v2.2.6_stackchan.zip`)

Additional code review: a `/codex:review`-equivalent pass at medium
effort flagged two real bugs that are now fixed in this PR (the
re-entry guard for `blink_enabled_before_off_` and the `"off"`-aware
path for touch reactions).

### Hardware

- [x] Device boots without crash: PSRAM mismatch boot loop did **not**
      occur. Free SRAM stayed at 128575 bytes (`SystemInfo: free sram:
      128575`), consistent with a healthy boot.
- [x] StackChanBoard initialization log shows PY32 IO expander, servo
      bus (SCS0009 UART1 baud=1000000), Si12T touch poll all OK.
- [x] `MCP: Add tool: self.display.set_avatar` and
      `self.display.set_blink` are logged at boot, confirming the
      updated registration code path runs on the device.
- [x] WiFi STA associates and runs (RSSI -59 dBm).
- [x] Existing local gateway (port 8765) and the device hold a TCP
      `ESTABLISHED` socket post-flash, so the device reconnects through
      the new firmware.
- [ ] Visual verification of `set_avatar("off")` LCD behavior on the
      device: **pending**, requires an MCP-side `tools/call` for
      `self.display.set_avatar`. The author's MCP-capable session does
      not currently have stackchan-mcp registered, and the partner
      session is in the middle of a host migration. Will be exercised
      after merge once an MCP-capable client is reconnected; the
      registered MCP tool log line and the static review give high
      confidence in the visual path.

## Breaking changes

None at the MCP level. `set_avatar` continues to accept all six
existing faces; `"off"` is purely additive. Existing clients that
never send `"off"` see no behavior change.

## Related issues

Closes #3.
Unblocks #25 (the WiFi config UI work needs the LCD released).