### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-08
+
 ### Added
 
 - `set_avatar` now accepts `"off"` as a face value. When called with
@@ -78,7 +80,8 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.2.0
 [0.1.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.1.0
 
 [#11]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/11

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cut **v0.2.0**: bumps `gateway/pyproject.toml` from 0.1.0 to 0.2.0 and
promotes the existing `[Unreleased]` CHANGELOG entries to a dated
`[0.2.0] - 2026-05-08` section.

## What's in this release

- **Added**: `set_avatar("off")` to hide the avatar layer and disable
  blink without erasing NVS, restoring the previous blink state on the
  next non-`"off"` face. (#3)
- **Added**: WebSocket Gateway URL field on the on-device WiFi config
  UI's Advanced tab. End users running a pre-built firmware can now
  point a fresh device at their gateway from `http://192.168.4.1`
  without rebuilding from source. (#25)

Both shipped as merged PRs (#49 / #50) and have been verified on real
CoreS3 hardware.

## Why MINOR

Two new user-facing features added without breaking existing API or
NVS schema → SemVer MINOR per `CONTRIBUTING.md` "Per-release steps".

## Test plan

- [x] `git diff` confirms only `CHANGELOG.md` + `gateway/pyproject.toml` change
- [ ] CI (`build.yml` + `publish.yml` workflow_dispatch dry-run) green
- [ ] After merge: tag `v0.2.0` on `main` → `publish.yml` releases to PyPI
- [ ] `pipx install stackchan-mcp==0.2.0` works in clean env