### PR TITLE
chore(gateway): sync uv.lock to v0.2.0

### DIFF
--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1313,7 +1313,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Update the `stackchan-mcp` self-entry in `gateway/uv.lock` from `0.1.0` to `0.2.0` so the lockfile matches the published `gateway/pyproject.toml` version.

## Why

PR #51 (release v0.2.0) bumped `gateway/pyproject.toml` to `0.2.0` but did not regenerate `gateway/uv.lock`. The lockfile still contains:

```toml
[[package]]
name = "stackchan-mcp"
version = "0.1.0"
```

Running `uv sync` in `gateway/` produces exactly this single-line update, so the lockfile is silently drifting from `pyproject.toml` for anyone who runs `uv sync` after pulling main. This PR captures that update so the committed lockfile is deterministic with the released version.

## Validation

- `cd gateway && uv sync` produces no further changes after this commit.
- `git diff main..HEAD --stat` shows only `gateway/uv.lock | 2 +-`.
- No firmware / runtime behavior change.