### PR TITLE
feat(cli): add --help / --version flags and dynamic version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Added
+
+- `stackchan-mcp` CLI now supports `--help` / `-h` and `--version` /
+  `-V` flags. `--help` prints usage and the supported environment
+  variables (`STACKCHAN_TOKEN`, `VISION_URL`, `VISION_HOST`,
+  `VISION_TOKEN`, `HOST`, `WS_PORT`, `CAPTURE_PORT`) plus pointers to
+  the in-tree READMEs, and exits without binding any ports.
+  `--version` prints the installed package version. End users running
+  `pipx install stackchan-mcp` can now confirm the install and check
+  basic usage without starting a server. ([#52], [#53])
+
+### Changed
+
+- `stackchan_mcp.__version__` is now resolved from installed package
+  metadata (`importlib.metadata.version("stackchan-mcp")`) instead of
+  a hard-coded literal, so the value tracks `gateway/pyproject.toml`
+  automatically across releases.
+
+[#52]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/52
+[#53]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/53
+
 ## [0.2.0] - 2026-05-08
 
 ### Added

--- a/gateway/stackchan_mcp/__init__.py
+++ b/gateway/stackchan_mcp/__init__.py
@@ -4,4 +4,9 @@ MCP client side: stdio MCP server (mcp Python SDK)
 ESP32 side: WebSocket server (MCP client over JSON-RPC 2.0)
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("stackchan-mcp")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0+unknown"

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -11,10 +11,51 @@ working.
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 
+from . import __version__
+
 logger = logging.getLogger(__name__)
+
+
+_DESCRIPTION = (
+    "stdio MCP gateway for the StackChan / xiaozhi-esp32 firmware. "
+    "Bridges stdio MCP clients (for example Claude Code) to a StackChan "
+    "ESP32 device over WebSocket, and exposes an HTTP capture endpoint "
+    "for photo uploads from the device."
+)
+
+_EPILOG = """\
+Environment variables:
+  STACKCHAN_TOKEN   Bearer token shared with the ESP32 firmware.
+  VISION_URL        Full public capture URL (e.g. Tailscale Funnel).
+  VISION_HOST       LAN IP of this machine, as seen from the ESP32.
+  VISION_TOKEN      Optional separate token for VISION_URL uploads.
+  HOST              Bind address for the ESP32 WebSocket server (default 0.0.0.0).
+  WS_PORT           Port for the ESP32 WebSocket server (default 8765).
+  CAPTURE_PORT      Port for the HTTP capture server (default 8766).
+
+See gateway/README.md and the top-level README.md for full setup,
+including pairing the ESP32 firmware and configuring the WiFi gateway URL.
+"""
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stackchan-mcp",
+        description=_DESCRIPTION,
+        epilog=_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    return parser
 
 
 async def _run() -> None:
@@ -34,13 +75,19 @@ async def _run() -> None:
         await gateway.stop()
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Console-script entry point.
 
-    Loads ``.env``, configures logging, and starts the gateway. Side
+    Parses ``--help`` / ``--version`` early (without side effects), then
+    loads ``.env``, configures logging, and starts the gateway. Side
     effects are intentionally scoped to this function so that
     ``import stackchan_mcp`` stays clean.
     """
+    parser = _build_arg_parser()
+    # argparse exits with status 0 on --help / --version before reaching
+    # any of the gateway start-up below, which is the intended behaviour.
+    parser.parse_args(argv)
+
     from dotenv import load_dotenv
 
     load_dotenv()

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -1,0 +1,90 @@
+"""Tests for the stackchan-mcp CLI entry point.
+
+These tests focus on the no-side-effect command-line flags
+(``--help``, ``--version``); full gateway start-up is covered by
+``test_stdio_server.py`` and ``test_gateway.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stackchan_mcp import __version__
+from stackchan_mcp.cli import _build_arg_parser, main
+
+
+def test_arg_parser_help_long_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = _build_arg_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--help"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    out = captured.out
+    # Help text should mention prog name, the headline env vars, and a
+    # pointer to the in-tree READMEs so end users know where to look next.
+    assert "stackchan-mcp" in out
+    assert "STACKCHAN_TOKEN" in out
+    assert "VISION_URL" in out
+    assert "WS_PORT" in out
+    assert "README" in out
+
+
+def test_arg_parser_help_short_flag() -> None:
+    parser = _build_arg_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["-h"])
+    assert exc.value.code == 0
+
+
+def test_arg_parser_version_long_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    parser = _build_arg_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--version"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    # argparse writes --version output to stdout on Python 3.4+.
+    combined = captured.out + captured.err
+    assert f"stackchan-mcp {__version__}" in combined
+
+
+def test_arg_parser_version_short_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    parser = _build_arg_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["-V"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert f"stackchan-mcp {__version__}" in combined
+
+
+def test_main_help_exits_before_side_effects(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``main(['--help'])`` must exit 0 *before* load_dotenv / asyncio.run.
+
+    The whole point of the new flag is that first-time users can run
+    ``stackchan-mcp --help`` without binding port 8765 or waiting on
+    stdin, so this regression test guards that contract.
+    """
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "stackchan-mcp" in captured.out
+
+
+def test_version_resolves_from_installed_metadata() -> None:
+    """``__version__`` should be sourced from package metadata, not a literal.
+
+    This guards against the previous failure mode where the literal in
+    ``stackchan_mcp/__init__.py`` drifted away from
+    ``gateway/pyproject.toml`` across releases.
+    """
+    assert __version__ != "0.0.0+unknown"
+    # Expect a SemVer-ish leading digit; the editable install resolves
+    # to whatever ``pyproject.toml`` declares.
+    assert __version__[:1].isdigit()

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1313,7 +1313,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Add `--help` / `-h` and `--version` / `-V` flags to the `stackchan-mcp` console script, and resolve `__version__` dynamically from package metadata so it stays in sync with `gateway/pyproject.toml` across releases.

Closes #52
Closes #53

## Why

On `0.2.0`, `stackchan-mcp --help` and `stackchan-mcp --version` fell through to `asyncio.run(_run())`, binding the WebSocket server to `:8765` and waiting on stdin instead of printing usage / version. End users running `pipx install stackchan-mcp` had no quick way to verify the install or read basic usage.

`stackchan_mcp.__version__` was also a hard-coded `"0.1.0"` literal that had silently drifted from the released `0.2.0` since #51, with nothing reading it. Moving to `importlib.metadata.version(...)` fixes the drift and makes `--version` print the actually-installed wheel's version automatically on future releases.

## Changes

- `gateway/stackchan_mcp/cli.py`
  - `_build_arg_parser()` factored out so tests and `main()` share the same argparse setup
  - `RawDescriptionHelpFormatter` epilog lists every supported environment variable (`STACKCHAN_TOKEN`, `VISION_URL`, `VISION_HOST`, `VISION_TOKEN`, `HOST`, `WS_PORT`, `CAPTURE_PORT`) and points at `gateway/README.md` and the top-level `README.md`
  - `--version` / `-V` uses argparse's `action="version"` with `f"%(prog)s {__version__}"`
  - `main(argv=None)` now parses arguments **before** `load_dotenv()` and `logging.basicConfig()`, so `--help` / `--version` exit `0` with no side effects (no port binding, no `.env` load, no log noise)
- `gateway/stackchan_mcp/__init__.py`: `__version__` is now resolved via `importlib.metadata.version("stackchan-mcp")`, falling back to `"0.0.0+unknown"` for source checkouts that aren't installed
- `gateway/tests/test_cli.py` (new): exercises both flag forms via `_build_arg_parser` and through `main(argv)`, plus a guard test that `__version__` is sourced from package metadata
- `CHANGELOG.md`: `[Unreleased]` entry under `### Added` and `### Changed`

## Validation

- `cd gateway && uv run pytest` — 41 passed (35 existing + 6 new)
- `cd gateway && uv run ruff check .` — All checks passed
- Manual:
  - `uv run stackchan-mcp --help` prints the new usage block (no port binding, no `.env` load)
  - `uv run stackchan-mcp --version` prints `stackchan-mcp 0.2.0`
- `git diff main..HEAD --stat` only touches `CHANGELOG.md`, `gateway/stackchan_mcp/{cli,__init__}.py`, `gateway/tests/test_cli.py`, and the same one-line `gateway/uv.lock` sync as #55
- Pre-PR `codex review --base main` flagged no issues
- No firmware changes

## Notes

- `gateway/uv.lock` includes the same single-line `stackchan-mcp 0.1.0 → 0.2.0` sync as #55. Rebasing on top of whichever lands first is a no-op for that line.