### PR TITLE
feat(cli): add --check preflight diagnostics flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ change is called out under a `Firmware` subsection of the release entry.
   `--version` prints the installed package version. End users running
   `pipx install stackchan-mcp` can now confirm the install and check
   basic usage without starting a server. ([#52], [#53])
+- `stackchan-mcp --check` runs a non-destructive preflight and exits
+  without entering the stdio MCP loop. It loads `.env`, reports
+  configuration with secrets redacted (`STACKCHAN_TOKEN`, `VISION_URL`
+  derived from `VISION_HOST` when not set explicitly, `VISION_TOKEN`),
+  probes the WebSocket and capture ports (`HOST:WS_PORT`,
+  `HOST:CAPTURE_PORT`) via a non-blocking `bind()`, and best-effort
+  reports the holding process via `lsof` when a port is in use. Exit
+  status is `0` if ready, non-zero with an issue count when at least
+  one blocking problem is detected. Live device connectivity probing
+  is intentionally out of scope. ([#54])
 
 ### Changed
 
@@ -35,6 +45,7 @@ change is called out under a `Firmware` subsection of the release entry.
 
 [#52]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/52
 [#53]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/53
+[#54]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/54
 
 ## [0.2.0] - 2026-05-08
 

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import logging
 import os
 import shutil
@@ -82,15 +83,25 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 # subcommand (Issue #54 "Out of scope" note).
 
 
+_BIND_ERROR_PREFIX = "bind error: "
+
+
 def _check_port(host: str, port: int) -> tuple[bool, str | None]:
     """Probe ``(host, port)`` by trying to ``bind()`` to it.
 
-    Returns ``(available, holder_info)``:
+    Returns ``(available, info)``:
 
-    - ``available=True``: the bind succeeded, port is free.
-    - ``available=False``: the bind failed (port is in use). ``holder_info``
-      is a best-effort ``"pid <N>, <cmd>"`` string from ``lsof``, or
-      ``None`` if ``lsof`` is unavailable / the lookup fails.
+    - ``(True, None)``: bind succeeded, port is free.
+    - ``(False, "pid <N>, <cmd>")``: bind failed with ``EADDRINUSE`` and
+      ``lsof`` identified the holder.
+    - ``(False, None)``: bind failed with ``EADDRINUSE`` but ``lsof`` is
+      unavailable / the lookup failed.
+    - ``(False, "bind error: <reason>")``: bind failed for a non-
+      ``EADDRINUSE`` reason (for example, ``EADDRNOTAVAIL`` when ``HOST``
+      is not actually assigned to this machine, or ``EACCES`` on a
+      privileged port without permission). Distinguishing this from
+      "in use" prevents users from looking for a phantom process when
+      the real problem is the bind address.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Deliberately skip SO_REUSEADDR: we want bind to fail when the
@@ -98,8 +109,13 @@ def _check_port(host: str, port: int) -> tuple[bool, str | None]:
     try:
         try:
             sock.bind((host, port))
-        except OSError:
-            return (False, _try_get_port_holder(port))
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE:
+                return (False, _try_get_port_holder(port))
+            reason = exc.strerror or (
+                os.strerror(exc.errno) if exc.errno is not None else str(exc)
+            )
+            return (False, f"{_BIND_ERROR_PREFIX}{reason}")
     finally:
         sock.close()
     return (True, None)
@@ -144,9 +160,15 @@ def _try_get_port_holder(port: int) -> str | None:
 def _format_port_status(available: bool, holder: str | None) -> str:
     if available:
         return "AVAILABLE"
-    if holder:
-        return f"IN USE ({holder})"
-    return "IN USE"
+    if holder is None:
+        return "IN USE"
+    if holder.startswith(_BIND_ERROR_PREFIX):
+        # Don't say "IN USE" for non-EADDRINUSE bind failures
+        # (EADDRNOTAVAIL, EACCES, etc.). Surface the actual reason
+        # instead so the user does not chase a phantom process.
+        reason = holder.removeprefix(_BIND_ERROR_PREFIX)
+        return f"BIND ERROR ({reason})"
+    return f"IN USE ({holder})"
 
 
 _TCP_PORT_RANGE = range(0, 65536)

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -125,8 +125,22 @@ def _check_port(host: str, port: int) -> tuple[bool, str | None]:
     bound_at_least_once = False
     for family, socktype, proto, _canonname, sockaddr in infos:
         sock = socket.socket(family, socktype, proto)
-        # Deliberately skip SO_REUSEADDR: we want bind to fail when the
-        # port is genuinely held by another process, not silently succeed.
+        # Mirror ``asyncio.create_server``'s default behaviour on POSIX:
+        # the gateway sets SO_REUSEADDR=1, so a port in TIME_WAIT after
+        # a recent gateway restart would NOT actually block a fresh
+        # bind. Without this option the preflight would misreport such
+        # a port as IN USE and exit non-zero, even though the gateway
+        # itself would start cleanly. SO_REUSEADDR does not let the
+        # bind succeed when another process is currently LISTENing on
+        # the port (POSIX semantics), so the EADDRINUSE branch below
+        # still fires for genuine collisions.
+        if hasattr(socket, "SO_REUSEADDR"):
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            except OSError:
+                # Some platforms reject SO_REUSEADDR for certain socket
+                # types; fall through and try the bind anyway.
+                pass
         try:
             try:
                 sock.bind(sockaddr)
@@ -256,11 +270,8 @@ def _resolve_capture_port() -> tuple[int | None, str]:
     return _validate_port_value(raw, "CAPTURE_PORT")
 
 
-# Query parameter names that, when present, are treated as secrets and
-# replaced with ``***redacted***`` in the preflight output. These cover
-# the common patterns for Basic-auth-in-URL, OAuth-style bearer tokens,
-# and signed URLs (Tailscale Funnel, S3 presigned URLs, etc.). The set
-# is intentionally case-insensitive — comparisons use ``.lower()``.
+# Exact query parameter names that are always redacted in preflight
+# output. Compared lowercased.
 _SECRET_QUERY_KEYS = frozenset(
     {
         "access_token",
@@ -276,6 +287,27 @@ _SECRET_QUERY_KEYS = frozenset(
         "token",
     }
 )
+
+# Suffix-based heuristic for redacting provider-specific signed-URL
+# parameters without enumerating every variant. Matches things like
+# ``X-Amz-Signature``, ``X-Amz-Security-Token``, ``X-Goog-Signature``,
+# Azure SAS ``sig`` (already covered by the exact set), generic
+# ``*_token`` / ``*-secret`` patterns, etc. Compared lowercased.
+_SECRET_QUERY_KEY_SUFFIXES = (
+    "signature",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "credentials",
+)
+
+
+def _is_secret_query_key(key: str) -> bool:
+    lower = key.lower()
+    if lower in _SECRET_QUERY_KEYS:
+        return True
+    return any(lower.endswith(suffix) for suffix in _SECRET_QUERY_KEY_SUFFIXES)
 
 
 def _redact_url_secrets(url: str) -> str:
@@ -318,9 +350,7 @@ def _redact_url_secrets(url: str) -> str:
             params = None
         if params is not None:
             redacted = [
-                (k, "***redacted***")
-                if k.lower() in _SECRET_QUERY_KEYS
-                else (k, v)
+                (k, "***redacted***") if _is_secret_query_key(k) else (k, v)
                 for k, v in params
             ]
             query = urlencode(redacted)

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -149,6 +149,45 @@ def _format_port_status(available: bool, holder: str | None) -> str:
     return "IN USE"
 
 
+def _resolve_ws_port() -> tuple[int | None, str]:
+    """Resolve the WebSocket port using the same precedence as ``gateway.py``.
+
+    Mirrors ``int(os.getenv("WS_PORT", os.getenv("PORT", "8765")))`` from
+    ``gateway.py`` so the preflight checks the port the gateway will
+    actually bind, not a hard-coded default. Returns ``(port, source)``
+    where ``source`` describes the env var (or ``"default"``). On a
+    non-integer value, returns ``(None, "WS_PORT=<value> (not an
+    integer)")`` etc., which the caller turns into a blocking issue
+    rather than silently falling through to the default — silent
+    fallback would be a misleading "ready" report for an environment
+    the gateway itself would refuse to start with.
+    """
+    for var in ("WS_PORT", "PORT"):
+        raw = os.getenv(var)
+        if raw is None:
+            continue
+        try:
+            return (int(raw), var)
+        except ValueError:
+            return (None, f"{var}={raw!r} (not an integer)")
+    return (8765, "default")
+
+
+def _resolve_capture_port() -> tuple[int | None, str]:
+    """Resolve the HTTP capture port using ``gateway.py``'s precedence.
+
+    Mirrors ``int(os.getenv("CAPTURE_PORT", "8766"))``. See
+    ``_resolve_ws_port`` for the rationale around invalid values.
+    """
+    raw = os.getenv("CAPTURE_PORT")
+    if raw is None:
+        return (8766, "default")
+    try:
+        return (int(raw), "CAPTURE_PORT")
+    except ValueError:
+        return (None, f"CAPTURE_PORT={raw!r} (not an integer)")
+
+
 def _load_dotenv() -> None:
     """Lazy ``.env`` loader exposed as a single attachable seam.
 
@@ -217,29 +256,45 @@ def _run_preflight() -> int:
     print()
     print("Ports:")
     host = os.getenv("HOST", "0.0.0.0")
-    try:
-        ws_port = int(os.getenv("WS_PORT", "8765"))
-    except ValueError:
-        ws_port = 8765
-    try:
-        capture_port = int(capture_port_raw)
-    except ValueError:
-        capture_port = 8766
+    ws_port, ws_source = _resolve_ws_port()
+    cap_port, cap_source = _resolve_capture_port()
 
-    ws_available, ws_holder = _check_port(host, ws_port)
-    print(
-        f"  ws://{host}:{ws_port}   {_format_port_status(ws_available, ws_holder)}"
-    )
-    if not ws_available:
+    if ws_port is None:
+        print(f"  ws://{host}:???     INVALID ({ws_source})")
+        issues += 1
+    if cap_port is None:
+        print(f"  http://{host}:???   INVALID ({cap_source})")
         issues += 1
 
-    cap_available, cap_holder = _check_port(host, capture_port)
-    print(
-        f"  http://{host}:{capture_port} "
-        f"{_format_port_status(cap_available, cap_holder)}"
-    )
-    if not cap_available:
+    if ws_port is not None and cap_port is not None and ws_port == cap_port:
+        # The gateway runs WebSocket and HTTP capture as separate
+        # listeners; binding the WebSocket server first will then make
+        # the HTTP bind fail. Independent _check_port probes can't see
+        # this on their own (each one binds-and-releases), so we surface
+        # the conflict explicitly.
+        print(
+            f"  WS_PORT ({ws_source}) and CAPTURE_PORT ({cap_source}) "
+            f"both resolve to {ws_port}; the gateway needs distinct ports."
+        )
         issues += 1
+
+    if ws_port is not None:
+        ws_available, ws_holder = _check_port(host, ws_port)
+        print(
+            f"  ws://{host}:{ws_port}   "
+            f"{_format_port_status(ws_available, ws_holder)}"
+        )
+        if not ws_available:
+            issues += 1
+
+    if cap_port is not None:
+        cap_available, cap_holder = _check_port(host, cap_port)
+        print(
+            f"  http://{host}:{cap_port} "
+            f"{_format_port_status(cap_available, cap_holder)}"
+        )
+        if not cap_available:
+            issues += 1
 
     # --- Result -------------------------------------------------------------
     print()

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -14,6 +14,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
+import shutil
+import socket
+import subprocess
+import sys
 
 from . import __version__
 
@@ -55,7 +60,195 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"%(prog)s {__version__}",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Run a non-destructive preflight (configuration, port "
+            "availability, derived URLs) and exit. Exit 0 if ready to run, "
+            "non-zero if at least one blocking issue is found."
+        ),
+    )
     return parser
+
+
+# --- Preflight diagnostics (--check) ----------------------------------------
+#
+# The preflight is intentionally side-effect-free: it loads ``.env``, reads
+# environment variables, attempts non-blocking ``bind()`` calls to the two
+# server ports, and prints a concise human-readable report. It does NOT
+# reach out to any ESP32, does not start either server, and does not modify
+# any files. Live device connectivity belongs in a future ``status``
+# subcommand (Issue #54 "Out of scope" note).
+
+
+def _check_port(host: str, port: int) -> tuple[bool, str | None]:
+    """Probe ``(host, port)`` by trying to ``bind()`` to it.
+
+    Returns ``(available, holder_info)``:
+
+    - ``available=True``: the bind succeeded, port is free.
+    - ``available=False``: the bind failed (port is in use). ``holder_info``
+      is a best-effort ``"pid <N>, <cmd>"`` string from ``lsof``, or
+      ``None`` if ``lsof`` is unavailable / the lookup fails.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Deliberately skip SO_REUSEADDR: we want bind to fail when the
+    # port is genuinely held by another process, not silently succeed.
+    try:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return (False, _try_get_port_holder(port))
+    finally:
+        sock.close()
+    return (True, None)
+
+
+def _try_get_port_holder(port: int) -> str | None:
+    """Best-effort lookup of the process holding ``port`` via ``lsof``.
+
+    Returns ``"pid <N>, <cmd>"`` on success, or ``None`` if ``lsof`` is
+    not installed, the call fails, or the port is not in fact held (for
+    example, the bind failure was due to a permission error rather than
+    EADDRINUSE).
+    """
+    if shutil.which("lsof") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["lsof", f"-iTCP:{port}", "-sTCP:LISTEN", "-Fpcn"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    pid: str | None = None
+    cmd: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("p"):
+            pid = line[1:]
+        elif line.startswith("c"):
+            cmd = line[1:]
+    if pid and cmd:
+        return f"pid {pid}, {cmd}"
+    if pid:
+        return f"pid {pid}"
+    return None
+
+
+def _format_port_status(available: bool, holder: str | None) -> str:
+    if available:
+        return "AVAILABLE"
+    if holder:
+        return f"IN USE ({holder})"
+    return "IN USE"
+
+
+def _load_dotenv() -> None:
+    """Lazy ``.env`` loader exposed as a single attachable seam.
+
+    Wrapping ``python-dotenv`` here keeps two properties:
+
+    1. ``import stackchan_mcp.cli`` stays side-effect free (the
+       ``dotenv`` import only happens when the gateway / preflight is
+       actually invoked).
+    2. Tests can ``monkeypatch.setattr(cli, "_load_dotenv", ...)`` to
+       prevent the real ``find_dotenv()`` walking up to the developer's
+       ``gateway/.env`` and contaminating environment-isolation tests.
+    """
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+
+def _run_preflight() -> int:
+    """Run preflight diagnostics. Returns the desired process exit code.
+
+    Output is intentionally fixed-width and grep-friendly. Exit 0 means
+    "ready to run"; non-zero means at least one blocking issue (currently
+    only port unavailability). Missing optional configuration is reported
+    but does not fail the check, mirroring how the gateway itself only
+    warns about a missing ``STACKCHAN_TOKEN``.
+    """
+    _load_dotenv()
+
+    issues = 0
+    print(f"stackchan-mcp {__version__} preflight")
+    print()
+
+    # --- Configuration ------------------------------------------------------
+    print("Configuration:")
+    token = os.getenv("STACKCHAN_TOKEN") or os.getenv("BEARER_TOKEN")
+    if token:
+        print("  STACKCHAN_TOKEN     set (***redacted***)")
+    else:
+        print("  STACKCHAN_TOKEN     not set (gateway will accept any client)")
+
+    vision_host = os.getenv("VISION_HOST", "")
+    capture_port_raw = os.getenv("CAPTURE_PORT", "8766")
+    if vision_host:
+        print(f"  VISION_HOST         {vision_host}")
+    else:
+        print("  VISION_HOST         not set")
+
+    vision_url_explicit = os.getenv("VISION_URL", "")
+    if vision_url_explicit:
+        print(f"  VISION_URL          {vision_url_explicit}")
+    elif vision_host:
+        derived = f"http://{vision_host}:{capture_port_raw}/capture"
+        print(f"  VISION_URL          (derived) {derived}")
+    else:
+        print(
+            "  VISION_URL          not set "
+            "(set VISION_HOST or VISION_URL for take_photo)"
+        )
+
+    if os.getenv("VISION_TOKEN"):
+        print("  VISION_TOKEN        set (***redacted***)")
+    else:
+        print("  VISION_TOKEN        not set (will reuse STACKCHAN_TOKEN)")
+
+    # --- Ports --------------------------------------------------------------
+    print()
+    print("Ports:")
+    host = os.getenv("HOST", "0.0.0.0")
+    try:
+        ws_port = int(os.getenv("WS_PORT", "8765"))
+    except ValueError:
+        ws_port = 8765
+    try:
+        capture_port = int(capture_port_raw)
+    except ValueError:
+        capture_port = 8766
+
+    ws_available, ws_holder = _check_port(host, ws_port)
+    print(
+        f"  ws://{host}:{ws_port}   {_format_port_status(ws_available, ws_holder)}"
+    )
+    if not ws_available:
+        issues += 1
+
+    cap_available, cap_holder = _check_port(host, capture_port)
+    print(
+        f"  http://{host}:{capture_port} "
+        f"{_format_port_status(cap_available, cap_holder)}"
+    )
+    if not cap_available:
+        issues += 1
+
+    # --- Result -------------------------------------------------------------
+    print()
+    if issues == 0:
+        print("Result: ready. Exit 0.")
+        return 0
+    plural = "s" if issues > 1 else ""
+    print(f"Result: {issues} issue{plural}. Exit 1.")
+    return 1
 
 
 async def _run() -> None:
@@ -78,19 +271,22 @@ async def _run() -> None:
 def main(argv: list[str] | None = None) -> None:
     """Console-script entry point.
 
-    Parses ``--help`` / ``--version`` early (without side effects), then
-    loads ``.env``, configures logging, and starts the gateway. Side
-    effects are intentionally scoped to this function so that
-    ``import stackchan_mcp`` stays clean.
+    Parses ``--help`` / ``--version`` / ``--check`` early (without
+    starting the server), then loads ``.env``, configures logging, and
+    starts the gateway. Side effects are intentionally scoped to this
+    function so that ``import stackchan_mcp`` stays clean.
     """
     parser = _build_arg_parser()
     # argparse exits with status 0 on --help / --version before reaching
     # any of the gateway start-up below, which is the intended behaviour.
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
 
-    from dotenv import load_dotenv
+    if args.check:
+        # ``_run_preflight`` loads ``.env`` itself; do not double-load
+        # via the path below.
+        sys.exit(_run_preflight())
 
-    load_dotenv()
+    _load_dotenv()
 
     logging.basicConfig(
         level=logging.INFO,

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -20,6 +20,7 @@ import shutil
 import socket
 import subprocess
 import sys
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from . import __version__
 
@@ -255,6 +256,80 @@ def _resolve_capture_port() -> tuple[int | None, str]:
     return _validate_port_value(raw, "CAPTURE_PORT")
 
 
+# Query parameter names that, when present, are treated as secrets and
+# replaced with ``***redacted***`` in the preflight output. These cover
+# the common patterns for Basic-auth-in-URL, OAuth-style bearer tokens,
+# and signed URLs (Tailscale Funnel, S3 presigned URLs, etc.). The set
+# is intentionally case-insensitive — comparisons use ``.lower()``.
+_SECRET_QUERY_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth",
+        "auth_token",
+        "key",
+        "password",
+        "secret",
+        "sig",
+        "signature",
+        "token",
+    }
+)
+
+
+def _redact_url_secrets(url: str) -> str:
+    """Mask userinfo and secret-looking query params in ``url``.
+
+    The preflight output is meant to be safe to paste into a public
+    issue or log, so any in-URL credential is replaced before
+    printing:
+
+    - ``https://user:pass@host/path`` → ``https://***:***@host/path``
+    - ``?token=abc&page=1`` → ``?token=%2A%2A%2Aredacted%2A%2A%2A&page=1``
+      (only keys in ``_SECRET_QUERY_KEYS`` are touched; non-secret
+      params keep their value)
+
+    Non-credential structure (scheme, host, port, path, fragment,
+    non-secret query keys) is preserved so users can still see what
+    the gateway is actually configured to call. Inputs that fail to
+    parse are returned unchanged so the preflight never crashes on a
+    malformed value.
+    """
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return url
+
+    netloc = parsed.netloc
+    if "@" in netloc:
+        # Strip userinfo and replace with a fixed placeholder. Don't
+        # try to preserve the username — the username alone can leak
+        # information and the structural info we care about (host,
+        # port) lives after the @.
+        _userinfo, _, host_part = netloc.rpartition("@")
+        netloc = f"***:***@{host_part}"
+
+    query = parsed.query
+    if query:
+        try:
+            params = parse_qsl(query, keep_blank_values=True)
+        except ValueError:
+            params = None
+        if params is not None:
+            redacted = [
+                (k, "***redacted***")
+                if k.lower() in _SECRET_QUERY_KEYS
+                else (k, v)
+                for k, v in params
+            ]
+            query = urlencode(redacted)
+
+    return urlunparse(
+        (parsed.scheme, netloc, parsed.path, parsed.params, query, parsed.fragment)
+    )
+
+
 def _load_dotenv() -> None:
     """Lazy ``.env`` loader exposed as a single attachable seam.
 
@@ -304,8 +379,11 @@ def _run_preflight() -> int:
 
     vision_url_explicit = os.getenv("VISION_URL", "")
     if vision_url_explicit:
-        print(f"  VISION_URL          {vision_url_explicit}")
+        print(f"  VISION_URL          {_redact_url_secrets(vision_url_explicit)}")
     elif vision_host:
+        # Derived URL has no userinfo or query params, so no redaction
+        # needed; the host part is shown as-is by design (it is the IP
+        # the user has configured for capture).
         derived = f"http://{vision_host}:{capture_port_raw}/capture"
         print(f"  VISION_URL          (derived) {derived}")
     else:

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -149,27 +149,46 @@ def _format_port_status(available: bool, holder: str | None) -> str:
     return "IN USE"
 
 
+_TCP_PORT_RANGE = range(0, 65536)
+
+
+def _validate_port_value(raw: str, var: str) -> tuple[int | None, str]:
+    """Parse ``raw`` as a TCP port, returning ``(port, source_or_error)``.
+
+    Returns ``(int_value, var)`` for a valid in-range integer (0..65535
+    inclusive — ``0`` lets the OS pick, which the gateway may not
+    actually want but is at least bind-able). Returns ``(None, "<var>=
+    <raw> (...)")`` otherwise; the caller treats that as a blocking
+    issue rather than silently falling through to a default.
+
+    Both branches matter for the preflight: ``socket.bind()`` raises
+    ``OverflowError`` for values outside the TCP port range, so without
+    this validation ``--check`` would crash with a stack trace instead
+    of producing the diagnostic report it exists to produce.
+    """
+    try:
+        value = int(raw)
+    except ValueError:
+        return (None, f"{var}={raw!r} (not an integer)")
+    if value not in _TCP_PORT_RANGE:
+        return (None, f"{var}={raw!r} (out of TCP port range 0-65535)")
+    return (value, var)
+
+
 def _resolve_ws_port() -> tuple[int | None, str]:
     """Resolve the WebSocket port using the same precedence as ``gateway.py``.
 
     Mirrors ``int(os.getenv("WS_PORT", os.getenv("PORT", "8765")))`` from
     ``gateway.py`` so the preflight checks the port the gateway will
-    actually bind, not a hard-coded default. Returns ``(port, source)``
-    where ``source`` describes the env var (or ``"default"``). On a
-    non-integer value, returns ``(None, "WS_PORT=<value> (not an
-    integer)")`` etc., which the caller turns into a blocking issue
-    rather than silently falling through to the default — silent
-    fallback would be a misleading "ready" report for an environment
-    the gateway itself would refuse to start with.
+    actually bind, not a hard-coded default. See ``_validate_port_value``
+    for the validation rules; on success returns ``(port, "WS_PORT")``
+    or ``(port, "PORT")``, otherwise ``(None, "<var>=<raw> (...)")``.
     """
     for var in ("WS_PORT", "PORT"):
         raw = os.getenv(var)
         if raw is None:
             continue
-        try:
-            return (int(raw), var)
-        except ValueError:
-            return (None, f"{var}={raw!r} (not an integer)")
+        return _validate_port_value(raw, var)
     return (8765, "default")
 
 
@@ -177,15 +196,12 @@ def _resolve_capture_port() -> tuple[int | None, str]:
     """Resolve the HTTP capture port using ``gateway.py``'s precedence.
 
     Mirrors ``int(os.getenv("CAPTURE_PORT", "8766"))``. See
-    ``_resolve_ws_port`` for the rationale around invalid values.
+    ``_validate_port_value`` for the validation rules.
     """
     raw = os.getenv("CAPTURE_PORT")
     if raw is None:
         return (8766, "default")
-    try:
-        return (int(raw), "CAPTURE_PORT")
-    except ValueError:
-        return (None, f"CAPTURE_PORT={raw!r} (not an integer)")
+    return _validate_port_value(raw, "CAPTURE_PORT")
 
 
 def _load_dotenv() -> None:

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -87,38 +87,67 @@ _BIND_ERROR_PREFIX = "bind error: "
 
 
 def _check_port(host: str, port: int) -> tuple[bool, str | None]:
-    """Probe ``(host, port)`` by trying to ``bind()`` to it.
+    """Probe ``(host, port)`` by trying to ``bind()`` it across every family.
+
+    Resolves ``host`` via ``getaddrinfo`` with ``AF_UNSPEC`` and walks
+    each (family, sockaddr) candidate so the preflight matches the
+    same dual-stack behaviour as ``websockets.serve`` / ``aiohttp``.
+    A literal ``::1`` or an IPv6-resolving ``localhost`` is therefore
+    probed against the right address family rather than being
+    misreported by an ``AF_INET``-only socket.
 
     Returns ``(available, info)``:
 
-    - ``(True, None)``: bind succeeded, port is free.
-    - ``(False, "pid <N>, <cmd>")``: bind failed with ``EADDRINUSE`` and
-      ``lsof`` identified the holder.
-    - ``(False, None)``: bind failed with ``EADDRINUSE`` but ``lsof`` is
-      unavailable / the lookup failed.
-    - ``(False, "bind error: <reason>")``: bind failed for a non-
-      ``EADDRINUSE`` reason (for example, ``EADDRNOTAVAIL`` when ``HOST``
-      is not actually assigned to this machine, or ``EACCES`` on a
-      privileged port without permission). Distinguishing this from
-      "in use" prevents users from looking for a phantom process when
-      the real problem is the bind address.
+    - ``(True, None)``: at least one address family bound successfully.
+      (Some IPv6 stacks fail with ``EADDRNOTAVAIL`` on hosts without a
+      configured v6 interface; the gateway also tolerates that, so we
+      report "ready" if any candidate succeeded.)
+    - ``(False, "pid <N>, <cmd>")``: at least one candidate reported
+      ``EADDRINUSE``. We short-circuit on the first one because the
+      gateway will collide with the holder regardless of any other
+      family that may have been free.
+    - ``(False, None)``: same as above, but ``lsof`` could not identify
+      the holder (or is unavailable on this platform).
+    - ``(False, "bind error: <reason>")``: every candidate failed for
+      a non-``EADDRINUSE`` reason (typically ``EADDRNOTAVAIL`` for an
+      IP that is not assigned to any local interface, or ``EACCES`` on
+      a privileged port without permission). Distinguishing this from
+      "in use" prevents users from chasing a phantom process when the
+      real issue is the bind address.
     """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    # Deliberately skip SO_REUSEADDR: we want bind to fail when the
-    # port is genuinely held by another process, not silently succeed.
     try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        return (False, f"{_BIND_ERROR_PREFIX}getaddrinfo failed: {exc}")
+
+    last_error: str | None = None
+    bound_at_least_once = False
+    for family, socktype, proto, _canonname, sockaddr in infos:
+        sock = socket.socket(family, socktype, proto)
+        # Deliberately skip SO_REUSEADDR: we want bind to fail when the
+        # port is genuinely held by another process, not silently succeed.
         try:
-            sock.bind((host, port))
-        except OSError as exc:
-            if exc.errno == errno.EADDRINUSE:
-                return (False, _try_get_port_holder(port))
-            reason = exc.strerror or (
-                os.strerror(exc.errno) if exc.errno is not None else str(exc)
-            )
-            return (False, f"{_BIND_ERROR_PREFIX}{reason}")
-    finally:
-        sock.close()
-    return (True, None)
+            try:
+                sock.bind(sockaddr)
+            except OSError as exc:
+                if exc.errno == errno.EADDRINUSE:
+                    # Mirror gateway behaviour: an EADDRINUSE on any
+                    # candidate family means the gateway will collide.
+                    return (False, _try_get_port_holder(port))
+                reason = exc.strerror or (
+                    os.strerror(exc.errno)
+                    if exc.errno is not None
+                    else str(exc)
+                )
+                last_error = f"{_BIND_ERROR_PREFIX}{reason}"
+            else:
+                bound_at_least_once = True
+        finally:
+            sock.close()
+
+    if bound_at_least_once:
+        return (True, None)
+    return (False, last_error)
 
 
 def _try_get_port_holder(port: int) -> str | None:

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -304,12 +304,22 @@ def _run_preflight() -> int:
         print(f"  http://{host}:???   INVALID ({cap_source})")
         issues += 1
 
-    if ws_port is not None and cap_port is not None and ws_port == cap_port:
+    if (
+        ws_port is not None
+        and cap_port is not None
+        and ws_port == cap_port
+        and ws_port != 0
+    ):
         # The gateway runs WebSocket and HTTP capture as separate
         # listeners; binding the WebSocket server first will then make
         # the HTTP bind fail. Independent _check_port probes can't see
         # this on their own (each one binds-and-releases), so we surface
         # the conflict explicitly.
+        #
+        # Port 0 is excluded: each ``bind((host, 0))`` asks the OS for a
+        # fresh ephemeral port, so two listeners both configured with 0
+        # do NOT collide (this is exactly the configuration the existing
+        # gateway tests use).
         print(
             f"  WS_PORT ({ws_source}) and CAPTURE_PORT ({cap_source}) "
             f"both resolve to {ws_port}; the gateway needs distinct ports."

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -359,6 +359,37 @@ def test_resolve_ws_port_invalid_value_returns_none(
     assert "not an integer" in source
 
 
+@pytest.mark.parametrize("bad_value", ["-1", "65536", "100000"])
+def test_resolve_ws_port_out_of_range_returns_none(
+    monkeypatch: pytest.MonkeyPatch, bad_value: str
+) -> None:
+    """Values outside 0-65535 must be rejected before they reach bind().
+
+    ``socket.bind()`` raises ``OverflowError`` for integers outside the
+    TCP port range, which would crash ``--check`` with a stack trace
+    instead of producing the diagnostic report it is meant to produce.
+    """
+    monkeypatch.setenv("WS_PORT", bad_value)
+    port, source = cli._resolve_ws_port()
+    assert port is None
+    assert "out of TCP port range" in source
+
+
+def test_resolve_ws_port_zero_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``0`` lets the OS pick an ephemeral port — bind-able, so accept it.
+
+    The gateway may not actually want this in production, but it is a
+    valid TCP port value and ``bind((host, 0))`` succeeds. Preflight
+    only filters out values that would crash ``bind()``.
+    """
+    monkeypatch.setenv("WS_PORT", "0")
+    port, source = cli._resolve_ws_port()
+    assert port == 0
+    assert source == "WS_PORT"
+
+
 def test_resolve_capture_port_defaults_to_8766(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -376,6 +407,39 @@ def test_resolve_capture_port_invalid_value_returns_none(
     assert port is None
     assert "CAPTURE_PORT" in source
     assert "not an integer" in source
+
+
+@pytest.mark.parametrize("bad_value", ["-1", "65536", "99999"])
+def test_resolve_capture_port_out_of_range_returns_none(
+    monkeypatch: pytest.MonkeyPatch, bad_value: str
+) -> None:
+    monkeypatch.setenv("CAPTURE_PORT", bad_value)
+    port, source = cli._resolve_capture_port()
+    assert port is None
+    assert "out of TCP port range" in source
+
+
+def test_run_preflight_out_of_range_ws_port_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Out-of-range WS port must be reported, not crashed on.
+
+    Before this guard, ``WS_PORT=65536`` would parse as int and reach
+    ``socket.bind()``, which raises ``OverflowError`` and aborts the
+    preflight without printing the result line — exactly the failure
+    mode ``--check`` is meant to catch in advance.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("WS_PORT", "65536")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "INVALID" in out
+    assert "out of TCP port range" in out
 
 
 def test_run_preflight_invalid_ws_port_is_blocking(

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -17,6 +17,7 @@ from stackchan_mcp.cli import (
     _build_arg_parser,
     _check_port,
     _format_port_status,
+    _redact_url_secrets,
     _run_preflight,
     main,
 )
@@ -340,6 +341,69 @@ def test_run_preflight_explicit_vision_url_overrides_derivation(
     assert "VISION_URL          https://stackchan.example.ts.net/capture" in out
     # The derived line must not appear when an explicit URL is set.
     assert "(derived)" not in out
+
+
+def test_redact_url_secrets_strips_basic_auth_userinfo() -> None:
+    """``user:pass@`` must be replaced before the URL is printed."""
+    out = _redact_url_secrets("https://user:pass@example.com:8443/capture")
+    assert "user" not in out
+    assert "pass" not in out
+    assert "***:***@example.com:8443/capture" in out
+    assert out.startswith("https://")
+
+
+def test_redact_url_secrets_masks_secret_query_params() -> None:
+    """Common token / signature keys must be redacted; other keys stay."""
+    out = _redact_url_secrets(
+        "https://example.com/capture?token=abc123&page=1&signature=xyz"
+    )
+    assert "abc123" not in out
+    assert "xyz" not in out
+    assert "page=1" in out  # non-secret params are preserved
+    assert "redacted" in out
+
+
+def test_redact_url_secrets_leaves_safe_url_unchanged() -> None:
+    """A URL with no userinfo or secret params must not be altered."""
+    safe = "https://stackchan.example.ts.net:8443/capture?page=2"
+    assert _redact_url_secrets(safe) == safe
+
+
+def test_redact_url_secrets_handles_unparseable_input_gracefully() -> None:
+    """Malformed input must not crash the preflight."""
+    # urlparse is very permissive, so this is more about the contract
+    # than triggering the except: anything weird simply round-trips.
+    assert _redact_url_secrets("") == ""
+    weird = "not a url at all"
+    # Either the input is returned as-is or urlparse rebuilds it
+    # losslessly; we only care that no exception escapes.
+    assert isinstance(_redact_url_secrets(weird), str)
+
+
+def test_run_preflight_redacts_explicit_vision_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Tokens in ``VISION_URL`` must not appear in preflight output.
+
+    The preflight is meant to be safe to paste into an issue or log,
+    so signed-URL secrets and Basic-auth userinfo have to be masked at
+    print time.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv(
+        "VISION_URL",
+        "https://signer:topsecret@example.com/capture?token=tk_abc123",
+    )
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    _run_preflight()
+    out = capsys.readouterr().out
+    assert "topsecret" not in out
+    assert "tk_abc123" not in out
+    assert "signer" not in out
+    assert "example.com/capture" in out
 
 
 def test_run_preflight_in_use_ports_return_nonzero(

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -1,16 +1,55 @@
 """Tests for the stackchan-mcp CLI entry point.
 
 These tests focus on the no-side-effect command-line flags
-(``--help``, ``--version``); full gateway start-up is covered by
-``test_stdio_server.py`` and ``test_gateway.py``.
+(``--help``, ``--version``, ``--check``); full gateway start-up is
+covered by ``test_stdio_server.py`` and ``test_gateway.py``.
 """
 
 from __future__ import annotations
 
+import socket
+from pathlib import Path
+
 import pytest
 
-from stackchan_mcp import __version__
-from stackchan_mcp.cli import _build_arg_parser, main
+from stackchan_mcp import __version__, cli
+from stackchan_mcp.cli import (
+    _build_arg_parser,
+    _check_port,
+    _format_port_status,
+    _run_preflight,
+    main,
+)
+
+
+_PREFLIGHT_ENV_VARS = (
+    "STACKCHAN_TOKEN",
+    "BEARER_TOKEN",
+    "VISION_HOST",
+    "VISION_URL",
+    "VISION_TOKEN",
+    "HOST",
+    "WS_PORT",
+    "CAPTURE_PORT",
+)
+
+
+def _isolate_preflight_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Make preflight tests independent of any host ``.env`` / inherited env.
+
+    ``python-dotenv`` resolves ``.env`` via ``find_dotenv()``, which
+    walks up the **calling stack frame's** file path — not the cwd —
+    so simply ``chdir(tmp_path)`` is not enough to escape a developer's
+    real ``gateway/.env``. We instead replace ``cli._load_dotenv`` with
+    a no-op for the duration of the test, then strip the relevant env
+    vars to give the preflight a deterministic baseline.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
+    for var in _PREFLIGHT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
 
 
 def test_arg_parser_help_long_flag(capsys: pytest.CaptureFixture[str]) -> None:
@@ -88,3 +127,189 @@ def test_version_resolves_from_installed_metadata() -> None:
     # Expect a SemVer-ish leading digit; the editable install resolves
     # to whatever ``pyproject.toml`` declares.
     assert __version__[:1].isdigit()
+
+
+# --- --check flag tests -----------------------------------------------------
+
+
+def test_arg_parser_check_flag_is_registered() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(["--check"])
+    assert args.check is True
+
+
+def test_arg_parser_check_defaults_to_false() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args([])
+    assert args.check is False
+
+
+def test_format_port_status_available() -> None:
+    assert _format_port_status(True, None) == "AVAILABLE"
+
+
+def test_format_port_status_in_use_no_holder() -> None:
+    assert _format_port_status(False, None) == "IN USE"
+
+
+def test_format_port_status_in_use_with_holder() -> None:
+    assert (
+        _format_port_status(False, "pid 12345, python")
+        == "IN USE (pid 12345, python)"
+    )
+
+
+def test_check_port_against_unbound_port_reports_available() -> None:
+    """Ask the OS for an ephemeral port, release it, then probe.
+
+    Not perfectly race-free (something else could grab the port between
+    ``close()`` and ``_check_port``'s bind), but the window is tiny and
+    this gives confidence that ``_check_port`` plays nicely with the
+    real socket layer rather than only the mocked variant.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    available, holder = _check_port("127.0.0.1", port)
+    assert available is True
+    assert holder is None
+
+
+def test_check_port_against_held_port_reports_in_use() -> None:
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.bind(("127.0.0.1", 0))
+    held.listen(1)
+    try:
+        port = held.getsockname()[1]
+        available, _holder = _check_port("127.0.0.1", port)
+        assert available is False
+    finally:
+        held.close()
+
+
+def test_run_preflight_with_no_config_reports_defaults_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    # Don't actually open sockets in the test process.
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "STACKCHAN_TOKEN     not set" in out
+    assert "VISION_HOST         not set" in out
+    assert "VISION_URL          not set" in out
+    assert "VISION_TOKEN        not set" in out
+    assert "ws://0.0.0.0:8765" in out
+    assert "http://0.0.0.0:8766" in out
+    assert "AVAILABLE" in out
+    assert "Result: ready. Exit 0." in out
+
+
+def test_run_preflight_masks_secrets_and_derives_vision_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Tokens must never be echoed; VISION_URL is derived from VISION_HOST."""
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("STACKCHAN_TOKEN", "super-secret-token-value")
+    monkeypatch.setenv("VISION_HOST", "192.168.1.42")
+    monkeypatch.setenv("VISION_TOKEN", "another-secret-value")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "super-secret-token-value" not in out
+    assert "another-secret-value" not in out
+    # Both tokens should be reported as redacted, not as their raw value.
+    assert out.count("***redacted***") == 2
+    # VISION_HOST is configuration, not a secret, so it is shown as-is.
+    assert "VISION_HOST         192.168.1.42" in out
+    assert "(derived) http://192.168.1.42:8766/capture" in out
+
+
+def test_run_preflight_explicit_vision_url_overrides_derivation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VISION_HOST", "192.168.1.42")
+    monkeypatch.setenv("VISION_URL", "https://stackchan.example.ts.net/capture")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    _run_preflight()
+    out = capsys.readouterr().out
+    assert "VISION_URL          https://stackchan.example.ts.net/capture" in out
+    # The derived line must not appear when an explicit URL is set.
+    assert "(derived)" not in out
+
+
+def test_run_preflight_in_use_ports_return_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_check_port",
+        lambda host, port: (False, f"pid 12345, mock-{port}"),
+    )
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "IN USE (pid 12345, mock-8765)" in out
+    assert "IN USE (pid 12345, mock-8766)" in out
+    assert "Result: 2 issues. Exit 1." in out
+
+
+def test_run_preflight_one_in_use_port_singular_phrasing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+
+    def fake_check(host: str, port: int) -> tuple[bool, str | None]:
+        if port == 8765:
+            return (False, "pid 999, fake")
+        return (True, None)
+
+    monkeypatch.setattr(cli, "_check_port", fake_check)
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    # Singular ``issue`` (not ``issues``) when exactly one port is held.
+    assert "Result: 1 issue. Exit 1." in out
+
+
+def test_main_check_flag_runs_preflight_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``main(['--check'])`` exits with the preflight return code.
+
+    Guards the contract that ``--check`` never reaches the asyncio
+    gateway start-up below the early exit, by relying on ``main`` to
+    propagate ``_run_preflight``'s return as ``SystemExit``.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--check"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "preflight" in out
+    assert "Result: ready" in out

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -193,6 +193,62 @@ def test_check_port_bind_error_when_host_not_local() -> None:
     assert info.startswith("bind error:")
 
 
+def test_check_port_unresolvable_host_returns_bind_error() -> None:
+    """``getaddrinfo`` failure is reported as a bind error, not a crash."""
+    # ``.invalid`` is reserved by RFC 6761 and never resolves.
+    available, info = _check_port("nonexistent.invalid", 0)
+    assert available is False
+    assert info is not None
+    assert info.startswith("bind error:")
+    assert "getaddrinfo failed" in info
+
+
+def test_check_port_resolves_via_getaddrinfo_for_localhost() -> None:
+    """``localhost`` should be probed across every resolved address family.
+
+    This is the regression guard for the IPv6 fix: the previous probe
+    pinned ``AF_INET``, which would misreport an IPv6-only or
+    dual-stack ``localhost`` setup. We just need the call not to raise
+    and to produce a sensible boolean — the actual availability is
+    racy for any specific port, so we only assert the contract.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    available, info = _check_port("localhost", port)
+    # Either outcome is fine in principle (the port may have been
+    # grabbed between close() and probe); the regression we're catching
+    # is "the call raises an exception because of an AF mismatch".
+    assert isinstance(available, bool)
+    if not available:
+        assert info is None or info.startswith("bind error:") or "pid" in info
+
+
+@pytest.mark.skipif(
+    not socket.has_ipv6, reason="IPv6 stack not available on this host"
+)
+def test_check_port_against_unbound_ipv6_loopback_reports_available() -> None:
+    """``::1`` (IPv6 loopback) must be reachable through the new probe.
+
+    Pre-fix this would have raised because the socket was hard-coded
+    to ``AF_INET``; the new ``getaddrinfo`` resolver picks ``AF_INET6``
+    for the literal address.
+    """
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        sock.bind(("::1", 0))
+    except OSError:
+        pytest.skip("IPv6 loopback not configured on this host")
+    port = sock.getsockname()[1]
+    sock.close()
+
+    available, holder = _check_port("::1", port)
+    assert available is True
+    assert holder is None
+
+
 def test_check_port_against_unbound_port_reports_available() -> None:
     """Ask the OS for an ephemeral port, release it, then probe.
 

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -369,6 +369,32 @@ def test_redact_url_secrets_leaves_safe_url_unchanged() -> None:
     assert _redact_url_secrets(safe) == safe
 
 
+def test_redact_url_secrets_masks_provider_specific_signed_params() -> None:
+    """AWS / GCP / Azure signed-URL params must be redacted via heuristic.
+
+    The exact-match set covers generic names like ``token`` and
+    ``signature``, but provider-specific parameters such as
+    ``X-Amz-Signature``, ``X-Amz-Security-Token``,
+    ``X-Goog-Signature``, ``X-Amz-Credential`` are not in the explicit
+    list; the suffix heuristic ensures they are still masked so a
+    pre-signed S3 / GCS URL pasted into ``VISION_URL`` does not leak
+    its credential payload through ``--check``.
+    """
+    out = _redact_url_secrets(
+        "https://bucket.s3.amazonaws.com/capture"
+        "?X-Amz-Signature=AAAA&X-Amz-Security-Token=BBBB"
+        "&X-Amz-Credential=CCCC&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        "&page=1"
+    )
+    assert "AAAA" not in out
+    assert "BBBB" not in out
+    assert "CCCC" not in out
+    # Algorithm name is not a secret; it should remain visible so the
+    # user can still tell what scheme the URL is signed with.
+    assert "AWS4-HMAC-SHA256" in out
+    assert "page=1" in out
+
+
 def test_redact_url_secrets_handles_unparseable_input_gracefully() -> None:
     """Malformed input must not crash the preflight."""
     # urlparse is very permissive, so this is more about the contract

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -313,3 +313,153 @@ def test_main_check_flag_runs_preflight_and_exits(
     out = capsys.readouterr().out
     assert "preflight" in out
     assert "Result: ready" in out
+
+
+# --- Port resolution tests (must mirror gateway.py) -------------------------
+
+
+def test_resolve_ws_port_defaults_to_8765(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WS_PORT", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
+    port, source = cli._resolve_ws_port()
+    assert port == 8765
+    assert source == "default"
+
+
+def test_resolve_ws_port_prefers_ws_port_over_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WS_PORT", "9000")
+    monkeypatch.setenv("PORT", "9001")
+    port, source = cli._resolve_ws_port()
+    assert port == 9000
+    assert source == "WS_PORT"
+
+
+def test_resolve_ws_port_falls_back_to_PORT(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gateway.py: int(os.getenv("WS_PORT", os.getenv("PORT", "8765")))."""
+    monkeypatch.delenv("WS_PORT", raising=False)
+    monkeypatch.setenv("PORT", "9001")
+    port, source = cli._resolve_ws_port()
+    assert port == 9001
+    assert source == "PORT"
+
+
+def test_resolve_ws_port_invalid_value_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WS_PORT", "abc")
+    port, source = cli._resolve_ws_port()
+    assert port is None
+    assert "WS_PORT" in source
+    assert "not an integer" in source
+
+
+def test_resolve_capture_port_defaults_to_8766(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CAPTURE_PORT", raising=False)
+    port, source = cli._resolve_capture_port()
+    assert port == 8766
+    assert source == "default"
+
+
+def test_resolve_capture_port_invalid_value_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CAPTURE_PORT", "not-a-number")
+    port, source = cli._resolve_capture_port()
+    assert port is None
+    assert "CAPTURE_PORT" in source
+    assert "not an integer" in source
+
+
+def test_run_preflight_invalid_ws_port_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``WS_PORT=<garbage>`` must NOT silently fall back to the default.
+
+    The gateway itself wraps the lookup in ``int(...)`` without a
+    try/except — silent fallback in preflight would mean reporting
+    "ready" for an environment the gateway would actually refuse to
+    start. That is the exact failure mode --check is meant to catch.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("WS_PORT", "not-a-number")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "INVALID" in out
+    assert "WS_PORT" in out
+    assert "Result: 1 issue. Exit 1." in out
+
+
+def test_run_preflight_invalid_capture_port_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("CAPTURE_PORT", "garbage")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "INVALID" in out
+    assert "CAPTURE_PORT" in out
+
+
+def test_run_preflight_uses_PORT_fallback_for_ws_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``PORT=<value>`` must be honored when ``WS_PORT`` is unset.
+
+    ``gateway.py`` resolves ``WS_PORT`` → ``PORT`` → ``8765``, so the
+    preflight must check the same port that ``Gateway.start()`` will
+    actually bind to.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("PORT", "9999")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    _run_preflight()
+    out = capsys.readouterr().out
+    assert "ws://0.0.0.0:9999" in out
+    # Capture port still falls through to its own default.
+    assert "http://0.0.0.0:8766" in out
+
+
+def test_run_preflight_ws_and_capture_same_port_is_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``WS_PORT == CAPTURE_PORT`` must be flagged even when the port is free.
+
+    ``_check_port`` binds-and-releases each port independently, so two
+    successive probes for the same free port both report AVAILABLE.
+    The gateway, however, holds the WebSocket port for the entire
+    process lifetime, so a subsequent capture bind would fail. The
+    conflict has to be caught at the configuration layer.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("WS_PORT", "8765")
+    monkeypatch.setenv("CAPTURE_PORT", "8765")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "8765" in out
+    assert "distinct ports" in out

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -30,6 +30,11 @@ _PREFLIGHT_ENV_VARS = (
     "VISION_TOKEN",
     "HOST",
     "WS_PORT",
+    # ``_resolve_ws_port`` falls back to ``PORT`` when ``WS_PORT`` is
+    # unset, so ``PORT`` must also be cleared for the default-port
+    # tests to be deterministic across CI / dev environments that
+    # already export ``PORT``.
+    "PORT",
     "CAPTURE_PORT",
 )
 
@@ -157,6 +162,35 @@ def test_format_port_status_in_use_with_holder() -> None:
         _format_port_status(False, "pid 12345, python")
         == "IN USE (pid 12345, python)"
     )
+
+
+def test_format_port_status_bind_error_is_not_in_use() -> None:
+    """Non-EADDRINUSE bind failures must not be reported as ``IN USE``.
+
+    Showing ``IN USE`` for, say, ``EADDRNOTAVAIL`` (HOST not assigned
+    to this machine) sends the user looking for a competing process
+    that does not exist.
+    """
+    holder = "bind error: Cannot assign requested address"
+    assert (
+        _format_port_status(False, holder)
+        == "BIND ERROR (Cannot assign requested address)"
+    )
+
+
+def test_check_port_bind_error_when_host_not_local() -> None:
+    """A LAN-but-not-local IP triggers EADDRNOTAVAIL, not EADDRINUSE.
+
+    Binding to an IP that is not assigned to any local interface fails
+    with ``EADDRNOTAVAIL`` on macOS / Linux. The probe must report this
+    distinct from "port in use" so the diagnostic does not mislead.
+    192.0.2.0/24 (TEST-NET-1, RFC 5737) is reserved for documentation
+    and is virtually guaranteed not to be on a developer's machine.
+    """
+    available, info = _check_port("192.0.2.1", 0)
+    assert available is False
+    assert info is not None
+    assert info.startswith("bind error:")
 
 
 def test_check_port_against_unbound_port_reports_available() -> None:

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -561,3 +561,29 @@ def test_run_preflight_ws_and_capture_same_port_is_conflict(
     out = capsys.readouterr().out
     assert "8765" in out
     assert "distinct ports" in out
+
+
+def test_run_preflight_both_ports_zero_is_not_a_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``WS_PORT=0`` AND ``CAPTURE_PORT=0`` is a valid ephemeral setup.
+
+    Each ``bind((host, 0))`` asks the OS for a fresh ephemeral port, so
+    two listeners both configured with 0 do not actually collide —
+    this is the exact configuration the existing gateway tests use.
+    The conflict check must therefore exclude port 0; otherwise
+    ``--check`` would falsely fail a supported gateway start-up
+    scenario.
+    """
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("WS_PORT", "0")
+    monkeypatch.setenv("CAPTURE_PORT", "0")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "distinct ports" not in out
+    assert "Result: ready. Exit 0." in out


### PR DESCRIPTION
## Summary

Add a `--check` flag to the `stackchan-mcp` console script that performs a non-destructive preflight (configuration + port availability + derived URLs) and exits without entering the stdio MCP loop.

Closes #54

> **Note (stacked PR)**: Built on top of `#56` (the argparse boilerplate from `--help` / `--version`). Please merge `#56` first; this PR's base will then automatically retarget `main` and the conflict-free portion will collapse to the `--check` diff alone.

## Why

When users start `stackchan-mcp` with a misconfigured `.env` (missing `STACKCHAN_TOKEN`, wrong `VISION_HOST`, port already in use, etc.) the gateway either silently warns and keeps running, or crashes mid-init with a Python traceback. There has been no quick *"is my environment OK?"* command for new users to run before wiring up an MCP client.

`--check` fills that gap. It is read-only, side-effect-free, and produces a fixed-width grep-friendly report with a 0/1 exit code so it can also be wired into shell scripts or CI smoke checks.

## Implementation

### Configuration block
- Loads `.env`, reports each var with status:
  - `STACKCHAN_TOKEN` / `VISION_TOKEN`: masked as `***redacted***` when set
  - `VISION_HOST`: shown as-is (it is configuration, not a credential)
  - `VISION_URL`: shown as-is when not set; **redacted** when set (userinfo and secret-looking query params, including AWS / GCP / Azure provider-specific names like `X-Amz-Signature` / `X-Amz-Security-Token` / `X-Goog-Signature`, masked via an exact key set + suffix heuristic)
  - When `VISION_URL` is unset, derived from `VISION_HOST:CAPTURE_PORT/capture` and shown with a `(derived)` marker

### Port block
- Resolves `WS_PORT` with the same precedence as `gateway.py` (`WS_PORT` → `PORT` → `8765`)
- Resolves `CAPTURE_PORT` with `CAPTURE_PORT` → `8766`
- Validates that resolved values are integers in the TCP port range (`0..65535`); non-integer or out-of-range values become a blocking issue rather than silently falling through to a default (silent fallback would mean reporting "ready" for an environment the gateway itself would refuse to start with `ValueError`)
- Detects `WS_PORT == CAPTURE_PORT` collisions; exempts port `0` (each `bind((host, 0))` gets its own ephemeral port from the OS, which is the configuration the existing gateway tests use)
- Probes each port via `socket.getaddrinfo(host, port, type=SOCK_STREAM)` to handle IPv4 / IPv6 / dual-stack `HOST` values; matches `asyncio.create_server`'s default `SO_REUSEADDR=1` so a port in `TIME_WAIT` after a recent gateway restart is not misreported as `IN USE`
- Distinguishes `EADDRINUSE` (formatted as `IN USE` with best-effort `lsof` pid+cmd) from other bind errors (formatted as `BIND ERROR (<reason>)`, e.g. `EADDRNOTAVAIL` for an IP that is not assigned to any local interface) — collapsing them would send users chasing phantom processes

### Exit
- Exit `0` if no blocking issues were detected
- Exit `1` if at least one blocking issue (invalid port, port collision, port in use, or non-EADDRINUSE bind error) was detected; the result line includes the count and uses correct singular / plural phrasing

### Out of scope
- Live ESP32 connectivity probing (no WS handshake against a remote device) — belongs in a future `status` subcommand per the issue
- Auto-fix actions (killing the offending process, rewriting `.env`, etc.) — `--check` is read-only by design

## Sample output

Against a host where the gateway is already running:

```
stackchan-mcp 0.2.0 preflight

Configuration:
  STACKCHAN_TOKEN     set (***redacted***)
  VISION_HOST         not set
  VISION_URL          https://stackchan.example.ts.net:8443/capture
  VISION_TOKEN        not set (will reuse STACKCHAN_TOKEN)

Ports:
  ws://0.0.0.0:8765   IN USE (pid 78725, python3.14)
  http://0.0.0.0:8766 IN USE (pid 78725, python3.14)

Result: 2 issues. Exit 1.
```

## Validation

- `cd gateway && uv run pytest` — **84 passed** (35 existing + 6 from #52/#53 + 43 new for `--check`)
- `cd gateway && uv run ruff check .` — All checks passed
- Manual: `uv run stackchan-mcp --check` against a host with the gateway already running correctly reports both ports IN USE with `pid + cmd` from `lsof`, exits 1
- Pre-PR `codex review --base issue-52-53-help-version-flags` — 7 review rounds, every flagged issue addressed:
  1. Mirror `gateway.py` port precedence (`WS_PORT` → `PORT` → 8765)
  2. Reject invalid integer port values as blocking
  3. Reject out-of-range port values (-1, 65536) before they reach `bind()`
  4. Detect `WS_PORT == CAPTURE_PORT` collisions
  5. Exempt port 0 (ephemeral) from the collision rule
  6. Distinguish `EADDRINUSE` from other bind errors (`EADDRNOTAVAIL`, `EACCES`)
  7. Strip `PORT` in test isolation so CI environments with `PORT` exported stay deterministic
  8. Resolve hosts via `getaddrinfo` for IPv6 / dual-stack support
  9. Redact userinfo + secret query params (incl. AWS / GCP / Azure signed-URL parameters) from `VISION_URL` output
  10. Mirror `asyncio.create_server`'s `SO_REUSEADDR=1` so `TIME_WAIT` is not misclassified

  One round-8 P2 (IPV6_V6ONLY for `HOST=::` dual-stack coexistence) is intentionally deferred — the StackChan deployment model is IPv4-LAN / Tailscale-IPv4, and the failure mode requires both an IPv6 wildcard `HOST` and a coexisting IPv4 listener on the same port, which the project does not encounter in practice. Can be addressed in a follow-up if a user reports it.

- `git diff main..HEAD --stat` (against this PR's eventual base) only touches `CHANGELOG.md`, `gateway/stackchan_mcp/cli.py`, and `gateway/tests/test_cli.py`. No firmware changes, no personal config files, no `.env`.