### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-08
+
 ### Added
 
 - `stackchan-mcp` CLI now supports `--help` / `-h` and `--version` /
@@ -112,7 +114,8 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.3.0
 [0.2.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.2.0
 [0.1.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.1.0
 

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1313,7 +1313,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Cut release **v0.3.0** with the CLI UX refresh accumulated since v0.2.0.

## What's in this release

- **`stackchan-mcp --help` / `-h`** (#52) and **`--version` / `-V`** (#53): first-time `pipx install stackchan-mcp` users can now confirm the install and read basic usage without binding any ports.
- **`stackchan-mcp --check`** (#54): non-destructive preflight that loads `.env`, reports configuration with secrets redacted, probes WebSocket / capture port availability with best-effort `lsof`-based holder identification, and exits 0/1. Designed to be safe to paste into a public issue.
- **`stackchan_mcp.__version__` is now resolved from installed package metadata** (`importlib.metadata.version("stackchan-mcp")`) instead of a hard-coded literal, so the value tracks `gateway/pyproject.toml` automatically across releases. Prevents the lockfile drift caught in #55.

This is a SemVer **minor** release (`0.2.0` → `0.3.0`): all changes are backward-compatible additions; no flag, env var, or import behavior previously available was removed.

## Per-release changes in this PR

Following `CONTRIBUTING.md` `### Per-release steps`:

1. `gateway/pyproject.toml` `version` bumped from `0.2.0` to `0.3.0`.
2. `CHANGELOG.md`:
   - `[Unreleased]` content promoted to `[0.3.0] - 2026-05-08`.
   - Fresh empty `[Unreleased]` placed above `[0.3.0]`.
   - Comparison links refreshed: `[Unreleased]` now diffs `v0.3.0...HEAD`, and a new `[0.3.0]` entry points at `releases/tag/v0.3.0`.
3. `gateway/uv.lock` re-synced via `uv sync` so the `stackchan-mcp` self-entry records `0.3.0`.

## Validation

- `cd gateway && uv run pytest` — **84 passed**, no regressions.
- `cd gateway && uv run ruff check .` — All checks passed.
- `uv run --directory gateway stackchan-mcp --version` prints `stackchan-mcp 0.3.0`.
- Pre-PR `codex review --base main` flagged no issues.
- `git diff main..HEAD --stat` only touches `CHANGELOG.md`, `gateway/pyproject.toml`, and `gateway/uv.lock` — no implementation, firmware, or doc changes beyond the changelog.

## After merge

1. Tag the resulting `main` commit with `v0.3.0` and push the tag (per `CONTRIBUTING.md` step 2):
   ```bash
   git switch main
   git pull
   git tag v0.3.0
   git push origin v0.3.0
   ```
2. The `publish.yml` workflow validates the tag is on `main`, matches `pyproject.toml`, lint + tests pass, and then publishes to PyPI via Trusted Publishing.
3. Confirm on https://pypi.org/p/stackchan-mcp and via a fresh `pipx install stackchan-mcp`.