### PR TITLE
feat(wifi-config): add fallback gateway URL and bearer token fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Added
+
+- The on-device WiFi configuration UI now also exposes a **Fallback
+  Gateway URL** field and a **Gateway Token** field on the **Advanced**
+  tab, alongside the existing WebSocket Gateway URL field. The values
+  are persisted to the `websocket` NVS namespace as
+  `websocket.fallback_url` and `websocket.token` — the same keys the
+  firmware connection logic reads on the next boot. End users running a
+  pre-built firmware can now configure the full primary + fallback +
+  bearer-token gateway profile from `http://192.168.4.1` without
+  rebuilding from source. Token handling is hardened against the
+  unauthenticated WiFi config AP: the token value is never returned by
+  the configuration GET endpoint (only an "is set" boolean), is
+  rendered as a password input, and is redacted from the per-submit
+  save log. Submitting the form with the token field left blank keeps
+  the existing token; typing a new value updates it; ❌ writes an empty
+  string to NVS so the firmware falls back to the build-time
+  `CONFIG_DEFAULT_WEBSOCKET_TOKEN` on the next boot — which disables
+  auth on stock builds where no Kconfig default is set, but reverts to
+  the bundled default on builds that ship one. ([#43])
+
+[#43]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/43
+
 ## [0.3.0] - 2026-05-08
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -96,9 +96,14 @@ WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う 
 
    デフォルトでは、対応する NVS キーが空のときだけこの値が使われます。新規デバイスへの初回フラッシュではちょうど期待通りに動作します。primary と fallback の両方を設定した場合、ファームウェアは決まった順番で候補を試し、WebSocket の server hello まで完了した最初の候補を使います。
 
-2. **デバイス上の WiFi 設定 UI を使う（新規ユーザー向け推奨）**: デバイスが WiFi 設定モードになっているとき、`http://192.168.4.1` のキャプティブポータルを開き、**Advanced** タブに切り替えて **WebSocket Gateway URL** フィールド（例: `ws://<gateway-host>:8765/`）を入力して送信します。値は `websocket` NVS namespace（`websocket.url`）に永続化され、次回起動時に使われます。pre-built ファームウェアを使うエンドユーザー向けの想定経路です。URL をクリアして `CONFIG_DEFAULT_WEBSOCKET_URL` に戻したい場合は、フィールド横の ❌ ボタンを押してから再度送信してください。
+2. **デバイス上の WiFi 設定 UI を使う（新規ユーザー向け推奨）**: デバイスが WiFi 設定モードになっているとき、`http://192.168.4.1` のキャプティブポータルを開き、**Advanced** タブに切り替えて以下を入力します:
+   - **WebSocket Gateway URL**（例: `ws://<gateway-host>:8765/`） — primary な gateway 候補。
+   - **Fallback Gateway URL**（例: `wss://<node>.<tailnet>.ts.net/`） — 任意の 2 番目の候補。primary が server hello 完了に失敗したときだけ試行されます。
+   - **Gateway Token** — 任意の bearer トークン。設定時は両候補に対して `Authorization: Bearer <token>` ヘッダで送信されます。WiFi 設定 UI の AP は未認証で開かれるため、GET エンドポイントはトークンの有無だけを返し、現在の値は表示されません。空のまま送信すると既存トークンが保持され、新しい値を入力すると更新、❌ ボタンで build-time の `CONFIG_DEFAULT_WEBSOCKET_TOKEN` に戻ります。Kconfig 既定値が未設定のビルドでは ❌ が認証なしを意味しますが、既定値が組み込まれているビルドでは ❌ で実際に認証が解除されるわけではなく、その既定値に戻る点に注意してください。組み込み既定値があるビルドで認証なしの gateway に向けたい場合は、Kconfig 既定値を空にして再ビルドするか、gateway 側の token を build-time 既定値に揃えてください。
 
-3. **NVS に直接 `websocket.url` / `websocket.token` を書き込む（上級者向け）**: 例えば独自の NVS 書き込みツールをシリアル経由で使うケース。WiFi 設定 UI と同じ永続化セマンティクス。バッチ provisioning などで主に使います。
+   送信すると値が `websocket` NVS namespace（`websocket.url` / `websocket.fallback_url` / `websocket.token`）に永続化され、次回起動時に読み込まれます。pre-built ファームウェアを使うエンドユーザー向けの想定経路です。URL フィールド横の ❌ ボタンでクリアしてから再度送信すると、対応する `CONFIG_DEFAULT_WEBSOCKET_*` Kconfig 値（Kconfig 既定値が未設定なら「fallback なし」）に戻ります。
+
+3. **NVS に直接 `websocket.url` / `websocket.fallback_url` / `websocket.token` を書き込む（上級者向け）**: 例えば独自の NVS 書き込みツールをシリアル経由で使うケース。WiFi 設定 UI と同じ永続化セマンティクス。バッチ provisioning などで主に使います。
 
 4. **一時的なソース hardcode (非推奨)**: `websocket_protocol.cc` を編集すればローカル実験はアンブロックできますが、commit には残さないようにしてください。
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,38 @@ There are three practical ways to provide them:
 
 2. **Use the on-device WiFi config UI (recommended for fresh users)**: while
    the device is in WiFi configuration mode, open the captive portal at
-   `http://192.168.4.1`, switch to the **Advanced** tab, fill in the
-   **WebSocket Gateway URL** field (e.g. `ws://<gateway-host>:8765/`), and
-   submit. The value is persisted to the `websocket` NVS namespace
-   (`websocket.url`) and used on the next boot. This is the intended path
-   for end users running a pre-built firmware. To clear the URL and fall
-   back to `CONFIG_DEFAULT_WEBSOCKET_URL`, hit the ❌ button next to the
-   field and submit again.
+   `http://192.168.4.1`, switch to the **Advanced** tab, and fill in:
+   - **WebSocket Gateway URL** (e.g. `ws://<gateway-host>:8765/`) — the
+     primary gateway candidate.
+   - **Fallback Gateway URL** (e.g. `wss://<node>.<tailnet>.ts.net/`) —
+     optional second candidate, tried only after the primary candidate
+     fails the server-hello flow.
+   - **Gateway Token** — optional bearer token, sent as
+     `Authorization: Bearer <token>` to both candidates when set. The
+     current value is never displayed (the WiFi config AP is
+     unauthenticated, so the GET endpoint reports only whether a token
+     is configured). Leave the field blank to keep the existing token,
+     type a new value to update it, or hit ❌ to fall back to the
+     build-time `CONFIG_DEFAULT_WEBSOCKET_TOKEN`. On stock builds where
+     no Kconfig default is set this disables auth; on builds that ship
+     a default token, ❌ reverts to that default rather than truly
+     clearing authentication. To switch the device to an unauthenticated
+     gateway on a build that ships a default token, rebuild the
+     firmware with the Kconfig default empty (or set a non-empty token
+     on the gateway side that matches the build default).
 
-3. **Write `websocket.url` / `websocket.token` directly to NVS** (advanced):
-   for example with a custom NVS-write tool over serial. Same persistence
-   semantics as the WiFi config UI; primarily useful for batch
-   provisioning.
+   Submit to persist the values to the `websocket` NVS namespace
+   (`websocket.url` / `websocket.fallback_url` / `websocket.token`); they
+   are read on the next boot. This is the intended path for end users
+   running a pre-built firmware. Clearing a URL field with the ❌ button
+   and submitting again falls back to the matching
+   `CONFIG_DEFAULT_WEBSOCKET_*` Kconfig value (or to "no fallback" when
+   no Kconfig default is set).
+
+3. **Write `websocket.url` / `websocket.fallback_url` / `websocket.token`
+   directly to NVS** (advanced): for example with a custom NVS-write tool
+   over serial. Same persistence semantics as the WiFi config UI;
+   primarily useful for batch provisioning.
 
 4. **Temporary source hardcode (not recommended)**: editing
    `websocket_protocol.cc` can unblock local experiments, but keep it out of

--- a/firmware/components/78__esp-wifi-connect/assets/wifi_configuration.html
+++ b/firmware/components/78__esp-wifi-connect/assets/wifi_configuration.html
@@ -287,6 +287,26 @@
                     </div>
                 </p>
 
+                <!-- WebSocket Fallback Gateway URL (stackchan-mcp specific) -->
+                <p>
+                    <label for="websocket_fallback_url" data-lang="websocket_fallback_url">Fallback Gateway URL:</label>
+                    <div style="display: flex; align-items: center; gap: 10px;">
+                        <input type="text" id="websocket_fallback_url" name="websocket_fallback_url" placeholder="wss://example.ts.net/stackchan/" style="flex: 1;">
+                        <button type="button" onclick="clearWebsocketFallbackUrl()" style="padding: 5px 10px; border: 1px solid #ccc; border-radius: 3px; background-color: #f0f0f0; cursor: pointer;">❌</button>
+                    </div>
+                    <small data-lang="websocket_fallback_hint" style="color: #666;">Optional. Tried after the primary URL fails.</small>
+                </p>
+
+                <!-- WebSocket Gateway Bearer Token (stackchan-mcp specific) -->
+                <p>
+                    <label for="websocket_token" data-lang="websocket_token">Gateway Token:</label>
+                    <div style="display: flex; align-items: center; gap: 10px;">
+                        <input type="password" id="websocket_token" name="websocket_token" autocomplete="off" placeholder="your-secret-token" style="flex: 1;">
+                        <button type="button" onclick="clearWebsocketToken()" style="padding: 5px 10px; border: 1px solid #ccc; border-radius: 3px; background-color: #f0f0f0; cursor: pointer;">❌</button>
+                    </div>
+                    <small data-lang="websocket_token_hint" style="color: #666;">Optional. Sent as Authorization: Bearer header when set. The current value is never displayed. Leave blank to keep the existing token, type a new value to update it, or hit ❌ to fall back to the build-time CONFIG_DEFAULT_WEBSOCKET_TOKEN (this disables auth on stock builds where no Kconfig default is set, but reverts to that default on builds that ship one).</small>
+                </p>
+
                 <!-- Max TX Power -->
                 <p style="display: flex; align-items: center; gap: 10px;">
                     <label for="max_tx_power" data-lang="max_tx_power" style="white-space: nowrap;">Wi-Fi Max TX Power:</label>
@@ -477,6 +497,11 @@
                 advanced_tab: 'Advanced',
                 ota_url: 'Custom OTA URL:',
                 websocket_url: 'WebSocket Gateway URL:',
+                websocket_fallback_url: 'Fallback Gateway URL:',
+                websocket_fallback_hint: 'Optional. Tried after the primary URL fails.',
+                websocket_token: 'Gateway Token:',
+                websocket_token_hint: 'Optional. Sent as Authorization: Bearer header when set. The current value is never displayed. Leave blank to keep the existing token, type a new value to update it, or hit ❌ to fall back to the build-time CONFIG_DEFAULT_WEBSOCKET_TOKEN (this disables auth on stock builds where no Kconfig default is set, but reverts to that default on builds that ship one).',
+                websocket_token_placeholder_set: '••••• (token set; leave blank to keep, ❌ to fall back to build default)',
                 max_tx_power: 'Wi-Fi Max TX Power:',
                 remember_bssid: 'Remember BSSID when connecting to Wi-Fi',
                 sleep_mode: 'Enable Sleep Mode',
@@ -694,6 +719,11 @@
                 advanced_tab: '詳細設定',
                 ota_url: 'カスタムOTA URL:',
                 websocket_url: 'WebSocketゲートウェイURL:',
+                websocket_fallback_url: 'フォールバックゲートウェイURL:',
+                websocket_fallback_hint: '任意。主URLへの接続が失敗した後に試行されます。',
+                websocket_token: 'ゲートウェイトークン:',
+                websocket_token_hint: '任意。設定時はAuthorization: Bearerヘッダで送信されます。現在の値は表示されません。空のまま送信すると既存トークンが保持され、新しい値を入力すると更新、❌ ボタンで build-time の CONFIG_DEFAULT_WEBSOCKET_TOKEN に戻ります（Kconfig 既定値が未設定のビルドでは認証なしになり、既定値が設定されているビルドではその既定値に戻ります）。',
+                websocket_token_placeholder_set: '••••• (トークン設定済み: 空のまま送信で保持、❌ で組み込み既定値に戻す)',
                 max_tx_power: 'Wi-Fi最大送信電力:',
                 remember_bssid: 'Wi-Fi接続時にBSSIDを記憶する',
                 sleep_mode: 'スリープモードを有効にする',
@@ -1358,10 +1388,35 @@
             const config = {
                 ota_url: document.getElementById('ota_url').value,
                 websocket_url: document.getElementById('websocket_url').value,
+                websocket_fallback_url: document.getElementById('websocket_fallback_url').value,
                 max_tx_power: parseInt(document.getElementById('max_tx_power').value),
                 remember_bssid: document.getElementById('remember_bssid').checked,
                 sleep_mode: document.getElementById('sleep_mode').checked
             };
+
+            // The websocket_token field is treated specially because the
+            // server intentionally never returns the current token value
+            // (the WiFi config AP is unauthenticated). To avoid wiping a
+            // previously stored token whenever the user submits the form
+            // without retyping it, the payload semantics are:
+            //   * Field has a typed value (any length) -> send that
+            //     value, regardless of whether ❌ was pressed first.
+            //     Treats "❌ to wipe + retype to update" as an update.
+            //   * Field is empty AND ❌ was pressed -> send "" to
+            //     explicitly clear the stored token.
+            //   * Otherwise (field empty, ❌ not pressed) -> omit the
+            //     key from the payload; the server-side handler keeps
+            //     the existing NVS value untouched.
+            const tokenInput = document.getElementById('websocket_token');
+            const tokenWasCleared = tokenInput.dataset.cleared === 'true';
+            let tokenSubmittedNonEmpty = false;
+            if (tokenInput.value !== '') {
+                config.websocket_token = tokenInput.value;
+                tokenSubmittedNonEmpty = true;
+            } else if (tokenWasCleared) {
+                config.websocket_token = '';
+            }
+            // else: field empty, ❌ not pressed -> omit the key.
 
             try {
                 const response = await fetch('/advanced/submit', {
@@ -1375,6 +1430,45 @@
                 const data = await response.json();
                 if (!data.success) {
                     throw new Error(data.error || 'Save failed');
+                }
+
+                // Reset the token UI state so a subsequent save does not
+                // resurrect a stale "cleared" / "wasSet" flag from this
+                // session. After a successful submit:
+                //   * the typed value (if any) is now stored on the device;
+                //   * the password field is cleared so the next view does
+                //     not display the just-typed plaintext;
+                //   * `dataset.cleared` goes back to "false" so a later
+                //     manual-blank submit defaults to "keep existing"
+                //     instead of an unintended delete;
+                //   * `dataset.wasSet` reflects whether a token is
+                //     currently stored, so the placeholder re-renders
+                //     correctly on the next loadAdvancedConfig().
+                tokenInput.value = '';
+                tokenInput.dataset.cleared = 'false';
+                if (tokenSubmittedNonEmpty) {
+                    tokenInput.dataset.wasSet = 'true';
+                } else if (config.websocket_token === '') {
+                    // Explicit clear was sent.
+                    tokenInput.dataset.wasSet = 'false';
+                }
+                // Refresh the placeholder text so it matches the new state.
+                const lang = document.getElementById('language').value;
+                if (tokenInput.dataset.wasSet === 'true') {
+                    const placeholder = (translations[lang]
+                        && translations[lang].websocket_token_placeholder_set)
+                        ?? translations['en-US'].websocket_token_placeholder_set;
+                    tokenInput.placeholder = placeholder;
+                } else {
+                    // Mirror loadAdvancedConfig() so the placeholder
+                    // reflects the "no token currently stored" state the
+                    // server-side just persisted.
+                    const tokenLang = document.getElementById('language').value;
+                    const fallback = (translations[tokenLang]
+                        && translations[tokenLang].websocket_token_placeholder_unset)
+                        ?? translations['en-US'].websocket_token_placeholder_unset
+                        ?? 'your-secret-token';
+                    tokenInput.placeholder = fallback;
                 }
 
                 advancedButton.disabled = false;
@@ -1434,6 +1528,27 @@
                 if (data.websocket_url) {
                     document.getElementById('websocket_url').value = data.websocket_url;
                 }
+                if (data.websocket_fallback_url) {
+                    document.getElementById('websocket_fallback_url').value = data.websocket_fallback_url;
+                }
+                // Token state: the server reports only whether a token is
+                // currently stored (websocket_token_set), never the value
+                // itself, so we cannot prefill the input. Mark it as "set"
+                // and swap the placeholder so the user can tell that
+                // leaving the field blank will keep the existing token.
+                const tokenInput = document.getElementById('websocket_token');
+                tokenInput.value = '';
+                tokenInput.dataset.cleared = 'false';
+                if (data.websocket_token_set) {
+                    tokenInput.dataset.wasSet = 'true';
+                    const lang = document.getElementById('language').value;
+                    const placeholder = (translations[lang]
+                        && translations[lang].websocket_token_placeholder_set)
+                        ?? translations['en-US'].websocket_token_placeholder_set;
+                    tokenInput.placeholder = placeholder;
+                } else {
+                    tokenInput.dataset.wasSet = 'false';
+                }
                 if (data.max_tx_power) {
                     document.getElementById('max_tx_power').value = data.max_tx_power;
                 }
@@ -1462,6 +1577,38 @@
          */
         function clearWebsocketUrl() {
             document.getElementById('websocket_url').value = '';
+        }
+
+        /**
+         * Clear WebSocket fallback gateway URL input field. Saving an
+         * empty value persists "" to NVS so the firmware falls back to
+         * CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL (or stops after the
+         * primary candidate when no fallback is configured).
+         */
+        function clearWebsocketFallbackUrl() {
+            document.getElementById('websocket_fallback_url').value = '';
+        }
+
+        /**
+         * Clear WebSocket gateway token input field. Marks the input as
+         * explicitly cleared so submitAdvancedForm() includes
+         * `websocket_token: ""` in the payload (overwriting any token
+         * currently stored in NVS). Without this flag, blank submissions
+         * are treated as "keep existing" by design — see
+         * submitAdvancedForm() for the full logic.
+         *
+         * Note: writing "" to NVS does not necessarily disable auth on
+         * the next boot; firmware/main/protocols/websocket_protocol.cc
+         * treats an empty NVS token the same as a missing one and falls
+         * back to the build-time CONFIG_DEFAULT_WEBSOCKET_TOKEN. So ❌
+         * effectively disables auth only on stock builds where the
+         * Kconfig default is empty; on builds that ship a default token
+         * the device reverts to that default.
+         */
+        function clearWebsocketToken() {
+            const tokenInput = document.getElementById('websocket_token');
+            tokenInput.value = '';
+            tokenInput.dataset.cleared = 'true';
         }
 
         // ========== Initialization ==========

--- a/firmware/components/78__esp-wifi-connect/include/wifi_configuration_ap.h
+++ b/firmware/components/78__esp-wifi-connect/include/wifi_configuration_ap.h
@@ -74,6 +74,19 @@ private:
     // running a pre-built firmware point the device at their stackchan-mcp
     // gateway from the on-device WiFi config UI without rebuilding.
     std::string websocket_url_;
+    // Optional fallback WebSocket gateway URL persisted to the same
+    // "websocket" NVS namespace (key "fallback_url"). The firmware
+    // connection logic in websocket_protocol.cc tries the primary URL
+    // first and the fallback after the primary candidate fails the
+    // server-hello flow, so users can configure a "local primary +
+    // remote fallback" gateway profile from the WiFi config UI.
+    std::string websocket_fallback_url_;
+    // Optional bearer token persisted to the same "websocket" NVS
+    // namespace (key "token"). websocket_protocol.cc sends it in the
+    // HTTP Authorization header when non-empty. Stored as a separate
+    // field so it can be input via a password-style UI control without
+    // exposing the value in the URL fields.
+    std::string websocket_token_;
     int8_t max_tx_power_;
     bool remember_bssid_;
     bool sleep_mode_;

--- a/firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc
+++ b/firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc
@@ -27,6 +27,38 @@
 extern const char index_html_start[] asm("_binary_wifi_configuration_html_start");
 extern const char done_html_start[] asm("_binary_wifi_configuration_done_html_start");
 
+namespace {
+
+// Reads an NVS string into a std::string without a fixed stack buffer.
+// `nvs_get_str` returns the required length when called with a null
+// destination, so we size the std::string once and read into its
+// storage. Mirrors Settings::GetString in firmware/main/settings.cc so
+// that bearer tokens longer than the previous 256-byte stack limit
+// (e.g. JWTs) are read in full instead of silently coming back empty
+// with ESP_ERR_NVS_INVALID_LENGTH and being treated as "not set" by
+// the WiFi config UI. Returns an empty string on any failure or when
+// the key is absent; callers cannot distinguish "missing key" from
+// "empty stored value", which matches Settings::GetString.
+std::string ReadNvsStringDynamic(nvs_handle_t handle, const char* key) {
+    size_t length = 0;
+    esp_err_t err = nvs_get_str(handle, key, nullptr, &length);
+    if (err != ESP_OK || length == 0) {
+        return std::string();
+    }
+    std::string value;
+    value.resize(length);
+    err = nvs_get_str(handle, key, value.data(), &length);
+    if (err != ESP_OK) {
+        return std::string();
+    }
+    while (!value.empty() && value.back() == '\0') {
+        value.pop_back();
+    }
+    return value;
+}
+
+} // namespace
+
 WifiConfigurationAp::WifiConfigurationAp()
 {
     event_group_ = xEventGroupCreate();
@@ -215,21 +247,40 @@ void WifiConfigurationAp::StartAccessPoint()
         nvs_close(nvs);
     }
 
-    // Load WebSocket gateway URL from the "websocket" NVS namespace.
-    // Kept in a separate namespace because main/protocols/websocket_protocol.cc
-    // reads from Settings("websocket").GetString("url"), and the firmware build
-    // also exposes CONFIG_DEFAULT_WEBSOCKET_URL / FORCE override flags that
-    // operate against the same namespace.
+    // Load WebSocket gateway URL, fallback URL, and bearer token from the
+    // "websocket" NVS namespace. Kept in a separate namespace because
+    // main/protocols/websocket_protocol.cc reads from
+    // Settings("websocket").GetString("url" | "fallback_url" | "token"), and
+    // the firmware build also exposes CONFIG_DEFAULT_WEBSOCKET_URL /
+    // CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL / CONFIG_DEFAULT_WEBSOCKET_TOKEN
+    // and the FORCE override flag that operate against the same namespace.
     nvs_handle_t ws_nvs;
     err = nvs_open("websocket", NVS_READONLY, &ws_nvs);
     if (err == ESP_OK) {
-        char websocket_url[512] = {0};
-        size_t websocket_url_size = sizeof(websocket_url);
-        err = nvs_get_str(ws_nvs, "url", websocket_url, &websocket_url_size);
-        if (err == ESP_OK) {
-            websocket_url_ = websocket_url;
+        // Use ReadNvsStringDynamic instead of fixed-size stack buffers so
+        // long values (long URLs, JWT-style bearer tokens) are read in
+        // full. Returning an empty string for "missing key" / "empty
+        // stored value" / "read failed" is fine here — the UI never
+        // distinguishes those cases anyway.
+        std::string url = ReadNvsStringDynamic(ws_nvs, "url");
+        if (!url.empty()) {
+            websocket_url_ = std::move(url);
             ESP_LOGI(TAG, "WebSocket URL loaded from NVS (websocket.url)");
         }
+
+        std::string fallback_url = ReadNvsStringDynamic(ws_nvs, "fallback_url");
+        if (!fallback_url.empty()) {
+            websocket_fallback_url_ = std::move(fallback_url);
+            ESP_LOGI(TAG, "WebSocket fallback URL loaded from NVS (websocket.fallback_url)");
+        }
+
+        std::string token = ReadNvsStringDynamic(ws_nvs, "token");
+        if (!token.empty()) {
+            websocket_token_ = std::move(token);
+            // Do not log the token value itself.
+            ESP_LOGI(TAG, "WebSocket token loaded from NVS (websocket.token)");
+        }
+
         nvs_close(ws_nvs);
     }
 }
@@ -373,6 +424,9 @@ void WifiConfigurationAp::StartWebServer()
         .handler = [](httpd_req_t *req) -> esp_err_t {
             char *buf;
             size_t buf_len = req->content_len;
+            // /submit only carries WiFi SSID + password (max 32 + 64
+            // bytes plus JSON overhead), so the legacy 1 KiB cap is
+            // sufficient for this endpoint.
             if (buf_len > 1024) { // 限制最大请求体大小
                 httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Payload too large");
                 return ESP_FAIL;
@@ -544,6 +598,18 @@ void WifiConfigurationAp::StartWebServer()
             if (!this_->websocket_url_.empty()) {
                 cJSON_AddStringToObject(json, "websocket_url", this_->websocket_url_.c_str());
             }
+            if (!this_->websocket_fallback_url_.empty()) {
+                cJSON_AddStringToObject(json, "websocket_fallback_url",
+                                        this_->websocket_fallback_url_.c_str());
+            }
+            // Do not return the token value itself: the WiFi config AP
+            // runs unauthenticated (WIFI_AUTH_OPEN), so any nearby device
+            // that can reach /advanced/config could otherwise harvest the
+            // bearer token. Report only whether one is currently
+            // configured so the UI can show a non-leaking placeholder; the
+            // user must re-enter a new value to overwrite it.
+            cJSON_AddBoolToObject(json, "websocket_token_set",
+                                  !this_->websocket_token_.empty());
             cJSON_AddNumberToObject(json, "max_tx_power", this_->max_tx_power_);
             cJSON_AddBoolToObject(json, "remember_bssid", this_->remember_bssid_);
             cJSON_AddBoolToObject(json, "sleep_mode", this_->sleep_mode_);
@@ -573,7 +639,13 @@ void WifiConfigurationAp::StartWebServer()
         .handler = [](httpd_req_t *req) -> esp_err_t {
             char *buf;
             size_t buf_len = req->content_len;
-            if (buf_len > 1024) {
+            // /advanced/submit can carry an OTA URL, two WebSocket
+            // gateway URLs, and a WebSocket bearer token. JWT-style
+            // tokens routinely run 1-2 KiB, so the legacy 1 KiB cap
+            // would reject otherwise valid submissions. 4 KiB still
+            // bounds the per-request allocation conservatively while
+            // accommodating long bearer tokens.
+            if (buf_len > 4096) {
                 httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Payload too large");
                 return ESP_FAIL;
             }
@@ -584,17 +656,28 @@ void WifiConfigurationAp::StartWebServer()
                 return ESP_FAIL;
             }
 
-            int ret = httpd_req_recv(req, buf, buf_len);
-            if (ret <= 0) {
-                free(buf);
-                if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
-                    httpd_resp_send_408(req);
-                } else {
-                    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to receive request");
+            // Loop until the full Content-Length has been received.
+            // httpd_req_recv may legally return fewer bytes than asked
+            // for in a single call once the body grows past a single
+            // socket read (now likely with 1-2 KiB JWT tokens), so the
+            // earlier "single recv -> done" pattern would intermittently
+            // leave the buffer truncated and break cJSON_Parse for valid
+            // long-token submissions.
+            size_t received = 0;
+            while (received < buf_len) {
+                int chunk = httpd_req_recv(req, buf + received, buf_len - received);
+                if (chunk <= 0) {
+                    free(buf);
+                    if (chunk == HTTPD_SOCK_ERR_TIMEOUT) {
+                        httpd_resp_send_408(req);
+                    } else {
+                        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to receive request");
+                    }
+                    return ESP_FAIL;
                 }
-                return ESP_FAIL;
+                received += static_cast<size_t>(chunk);
             }
-            buf[ret] = '\0';
+            buf[received] = '\0';
 
             // 解析JSON数据
             cJSON *json = cJSON_Parse(buf);
@@ -626,39 +709,74 @@ void WifiConfigurationAp::StartWebServer()
                 }
             }
 
-            // 保存WebSocket gateway URL (separate "websocket" NVS namespace).
-            // Empty string is also persisted so that a user clearing the
-            // field can fall back to CONFIG_DEFAULT_WEBSOCKET_URL or to a
-            // value supplied by another channel.
+            // 保存WebSocket gateway URL / fallback URL / token (separate
+            // "websocket" NVS namespace). Empty strings are also persisted so
+            // that a user clearing a field can fall back to the matching
+            // CONFIG_DEFAULT_WEBSOCKET_* Kconfig value (or to a value supplied
+            // by another channel) on the next boot.
             //
             // We track failures in `ws_save_failed` instead of returning
             // immediately so the function still has a single cleanup +
             // response path at the bottom; the final `success` flag below
             // ANDs this in so that a websocket save failure is reported
-            // to the client instead of being silently masked.
+            // to the client instead of being silently masked. The handle is
+            // opened once per request and the three keys share a single
+            // commit, mirroring how `nvs_open("wifi", ...)` batches the
+            // `wifi`-namespace fields below.
             bool ws_save_failed = false;
-            cJSON *websocket_url = cJSON_GetObjectItem(json, "websocket_url");
-            if (cJSON_IsString(websocket_url) && websocket_url->valuestring) {
-                this_->websocket_url_ = websocket_url->valuestring;
-                nvs_handle_t ws_nvs;
-                esp_err_t ws_err = nvs_open("websocket", NVS_READWRITE, &ws_nvs);
-                if (ws_err == ESP_OK) {
-                    ws_err = nvs_set_str(ws_nvs, "url", this_->websocket_url_.c_str());
-                    if (ws_err != ESP_OK) {
-                        ESP_LOGE(TAG, "Failed to save WebSocket URL: %d", ws_err);
-                        ws_save_failed = true;
-                    } else {
-                        ws_err = nvs_commit(ws_nvs);
-                        if (ws_err != ESP_OK) {
-                            ESP_LOGE(TAG, "Failed to commit WebSocket NVS: %d", ws_err);
-                            ws_save_failed = true;
-                        }
-                    }
-                    nvs_close(ws_nvs);
-                } else {
-                    ESP_LOGE(TAG, "Failed to open websocket NVS namespace: %d", ws_err);
+            bool ws_nvs_opened = false;
+            bool ws_dirty = false;
+            nvs_handle_t ws_nvs = 0;
+            auto ensure_ws_nvs_open = [&]() -> bool {
+                if (ws_save_failed) {
+                    return false;
+                }
+                if (ws_nvs_opened) {
+                    return true;
+                }
+                esp_err_t open_err = nvs_open("websocket", NVS_READWRITE, &ws_nvs);
+                if (open_err != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to open websocket NVS namespace: %d", open_err);
+                    ws_save_failed = true;
+                    return false;
+                }
+                ws_nvs_opened = true;
+                return true;
+            };
+
+            auto save_ws_string = [&](const char* key, const char* json_field,
+                                      std::string& dest) {
+                cJSON *item = cJSON_GetObjectItem(json, json_field);
+                if (!cJSON_IsString(item) || !item->valuestring) {
+                    return;
+                }
+                if (!ensure_ws_nvs_open()) {
+                    return;
+                }
+                dest = item->valuestring;
+                esp_err_t set_err = nvs_set_str(ws_nvs, key, dest.c_str());
+                if (set_err != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to save websocket.%s: %d", key, set_err);
+                    ws_save_failed = true;
+                    return;
+                }
+                ws_dirty = true;
+            };
+
+            save_ws_string("url", "websocket_url", this_->websocket_url_);
+            save_ws_string("fallback_url", "websocket_fallback_url",
+                           this_->websocket_fallback_url_);
+            save_ws_string("token", "websocket_token", this_->websocket_token_);
+
+            if (ws_nvs_opened && ws_dirty && !ws_save_failed) {
+                esp_err_t commit_err = nvs_commit(ws_nvs);
+                if (commit_err != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to commit WebSocket NVS: %d", commit_err);
                     ws_save_failed = true;
                 }
+            }
+            if (ws_nvs_opened) {
+                nvs_close(ws_nvs);
             }
 
             // 保存WiFi功率
@@ -717,8 +835,15 @@ void WifiConfigurationAp::StartWebServer()
             httpd_resp_set_hdr(req, "Connection", "close");
             httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
 
-            ESP_LOGI(TAG, "Saved settings: ota_url=%s, websocket_url=%s, max_tx_power=%d, remember_bssid=%d, sleep_mode=%d",
-                this_->ota_url_.c_str(), this_->websocket_url_.c_str(), this_->max_tx_power_, this_->remember_bssid_, this_->sleep_mode_);
+            // The token value is intentionally redacted from this log line
+            // (only its presence is reported) so a serial monitor capture
+            // does not leak the bearer secret.
+            ESP_LOGI(TAG,
+                "Saved settings: ota_url=%s, websocket_url=%s, websocket_fallback_url=%s, websocket_token=%s, max_tx_power=%d, remember_bssid=%d, sleep_mode=%d",
+                this_->ota_url_.c_str(), this_->websocket_url_.c_str(),
+                this_->websocket_fallback_url_.c_str(),
+                this_->websocket_token_.empty() ? "(empty)" : "(set)",
+                this_->max_tx_power_, this_->remember_bssid_, this_->sleep_mode_);
             return ESP_OK;
         },
         .user_ctx = this


### PR DESCRIPTION
## Summary

Closes #43.

Lets users configure all three fields of the WebSocket gateway profile
(`websocket.url` + `websocket.fallback_url` + `websocket.token`) from
the on-device WiFi configuration UI's **Advanced** tab, alongside the
existing WebSocket Gateway URL field added in #50. End users running a
pre-built firmware can now point a fresh device at a "local primary +
remote fallback" gateway profile without rebuilding from source.

The fallback URL field is the natural completion of #50: the runtime
selection path is already in place from #42, only the UI persistence
path was missing. The Gateway Token field is added with extra
hardening because the WiFi config AP runs unauthenticated.

## Token security hardening

The WiFi config AP runs with `WIFI_AUTH_OPEN`, so any nearby device
that can associate to it could otherwise harvest a stored bearer
token from `/advanced/config`. The token field therefore has stricter
handling than the URL fields:

- `/advanced/config` reports only `websocket_token_set: true|false`,
  never the value itself.
- The HTML input is `type="password"` with `autocomplete="off"`.
- The per-submit save log redacts the value (`websocket_token=(set)`
  / `(empty)`).
- NVS read uses a dynamic-length helper instead of a fixed stack
  buffer, so JWT-style tokens longer than 256 bytes load correctly.
- `/advanced/submit` request body cap raised from 1 KiB to 4 KiB and
  `httpd_req_recv` is looped until the full Content-Length has been
  received, so long bearer tokens are not truncated mid-parse.
- Submit-time UI semantics: if the field is blank, the key is omitted
  from the JSON payload (server keeps the existing NVS value); typing
  a new value sends an update; ❌ explicitly sends `""`, which writes
  `""` to NVS — the firmware then falls back to
  `CONFIG_DEFAULT_WEBSOCKET_TOKEN` on the next boot, matching the
  Kconfig fallback semantics already used by the URL fields. So ❌
  disables auth on stock builds where the Kconfig default is empty,
  and reverts to the bundled default on builds that ship one. This
  is documented in the in-page hint, in `README.md` /
  `README.ja.md`, and in the CHANGELOG entry.
- Token UI state (`dataset.cleared` / `dataset.wasSet`) is reset
  after a successful submit so a stale flag from earlier in the same
  session cannot accidentally wipe a freshly stored token.

## Persistence path consolidation

The `/advanced/submit` POST handler now opens the `websocket` NVS
namespace once per request, batches the three string sets behind a
single `ensure_ws_nvs_open` + `save_ws_string` lambda pair, and
commits once at the end. `ws_save_failed` is ANDed into the success
response so a websocket save failure is reported to the client
instead of being silently masked.

## Files changed

- `firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc`:
  NVS load (3 keys via `ReadNvsStringDynamic`), `/advanced/config`
  GET response, `/advanced/submit` POST handler (single nvs_open +
  shared commit, full-body recv loop, 4 KiB cap, redacted log).
- `firmware/components/78__esp-wifi-connect/include/wifi_configuration_ap.h`:
  add `websocket_fallback_url_` and `websocket_token_` members.
- `firmware/components/78__esp-wifi-connect/assets/wifi_configuration.html`:
  two new `<input>` elements (`type="text"` and `type="password"`),
  ❌ buttons, en-US/ja-JP translations, prefill via
  `loadAdvancedConfig()`, smart submit logic for the token field,
  and post-submit UI-state reset.
- `README.md` / `README.ja.md`: document the three-field config flow
  in both languages, including the ❌-on-token semantics.
- `CHANGELOG.md`: `[Unreleased]` entry under #43.

## Test plan

### Code-level

- [x] firmware: `python ./scripts/release.py stackchan` (in
  `espressif/idf:v5.5.2` Docker; produces `build/xiaozhi.bin`
  ~2.93 MiB and `releases/v2.2.6_stackchan.zip`, partition 29% free).
- [x] gateway: not applicable / not run — gateway is untouched.

A pre-PR `codex review --base main` was run iteratively. Findings
addressed in this branch:

- Token leak via the unauthenticated `/advanced/config` GET response
  (P1) → return only an "is set" boolean.
- 256-byte stack buffer truncating JWT-style tokens at NVS load time
  (P2) → introduce `ReadNvsStringDynamic` and use it for the three
  websocket keys.
- Submit-time priority order between "typed value" and "❌ pressed"
  (P2) → typed value always wins; explicit clear only takes effect
  when the field is empty.
- 1 KiB `/advanced/submit` cap rejecting long-token submissions (P2)
  → raise to 4 KiB and loop `httpd_req_recv` until the full body has
  been received.
- Residual `dataset.cleared` after a successful update (P2) → reset
  the token UI state and refresh the placeholder after a successful
  submit.
- Documentation gap around ❌ falling back to
  `CONFIG_DEFAULT_WEBSOCKET_TOKEN` instead of truly clearing auth on
  builds that ship a default token (P2) → call this out explicitly
  in README / README.ja / CHANGELOG / hint text, in line with the
  existing URL-field ❌ behavior.

The final review pass found no remaining blocking issues.

### Hardware

- [x] Device boots without crash (M5Stack CoreS3 + StackChan kit) on
  the rebuilt firmware. The expected `WS:` boot lines confirmed that
  the existing candidate iteration loop reads `websocket.url` /
  `websocket.fallback_url` / `websocket.token` from NVS and tries
  candidate 1/2 followed by candidate 2/2 with the new persistence
  path in place.
- [ ] Visual verification of the three-field form on the captive
  portal at `http://192.168.4.1`: **pending follow-up**, because
  reaching the AP-mode UI requires clearing the saved Wi-Fi
  credentials, which is a destructive operation the author did not
  want to perform on the live development device. Same disposition
  as #50; the static review and the build/flash pass give high
  confidence in the data path, the new code is additive, and the
  touched error paths are local to the `/advanced/submit` handler.

## Breaking changes

None. The new fields are additive in both the HTML form and the JSON
payloads. Clients that do not send the new keys continue to behave
exactly as before. The GET response gains a `websocket_token_set`
boolean alongside the existing keys but no longer includes
`websocket_token` (it never carried a useful value for the Advanced
tab and was not relied on elsewhere in the same UI).

## Related issues

Closes #43.
Builds on #28 (Force mode), #42 (fallback URL runtime support),
#50 (WiFi config UI WebSocket URL field).