### PR TITLE
docs(gateway): note that .env changes require an MCP restart

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -83,6 +83,29 @@ will notice the dropped WebSocket and retry while idle. The retry delay starts
 at 5 seconds and backs off up to 60 seconds. After the gateway is listening
 again, check `get_status` from the stdio MCP side to confirm the device is back.
 
+## Configuration changes
+
+The gateway reads `.env` once at process start. Because the gateway runs as a
+**stdio MCP server** (it has no standalone CLI mode beyond `--help` /
+`--version` / `--check`), editing `.env` while it is connected to an MCP
+client does not take effect on the running process — and killing the gateway
+process directly will not auto-restart it; the MCP client owns the lifecycle.
+
+After editing `.env` (for example to update `STACKCHAN_TOKEN`, `VISION_URL`,
+or `VISION_TOKEN`):
+
+1. Reconnect the MCP client. In Claude Code this is `/mcp` to reconnect, or a
+   full Claude Code restart.
+2. Confirm `mcp__stackchan-mcp__get_status` returns `connected: true` with the
+   expected `tools_count`.
+3. If the ESP32 was already connected with a stale auth credential, hard-reset
+   the device (`esptool.py --before default_reset --after hard_reset chip_id`,
+   or DTR/RTS toggle via pyserial) so it reconnects with the fresh
+   configuration.
+
+`STACKCHAN_TOKEN` takes precedence over the legacy `BEARER_TOKEN`; setting
+either is enough, but if you have both, keep them aligned.
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary

- The gateway runs as a stdio MCP server, so editing `gateway/.env` does not affect the running process — Claude Code (or another MCP client) needs to reconnect for new env values to take effect.
- Add a "Configuration changes" section to `gateway/README.md` that documents the recommended `.env` change flow: reconnect the MCP client, verify with `get_status`, hard-reset the device if its auth credential is stale.
- Note that `STACKCHAN_TOKEN` takes precedence over the legacy `BEARER_TOKEN` (consistent with `.env.example` and `esp32_client.py`).

This is a docs-only change. No code or behavior is affected.

## Test plan

- [ ] Read `gateway/README.md` and confirm the new section reads cleanly between "Run" and "Tests".
- [ ] Verify the new guidance matches what `esp32_client.py` actually does (`STACKCHAN_TOKEN or BEARER_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)