### PR TITLE
fix(firmware): trigger reconnect after post-handshake server disconnect (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Firmware
+
+- Fixed: WebSocket auto-reconnect now triggers on any post-handshake
+  server- or network-initiated disconnect — gateway crashes, TLS-layer
+  resets, and gateway configurations that tear the WebSocket session
+  down after the handshake. Previously the firmware logged the
+  disconnect, returned to `idle`, and stayed there until a hard reset
+  or user interaction; the reconnect path introduced in PR #35 was
+  effectively suppressed for these cases. Real-device tracing (CoreS3,
+  TLS-terminated gateway) showed that the original global atomic
+  `auto_reconnect_enabled_` flag was being cleared by an *unrelated*
+  user-initiated path (`HandleToggleChatEvent → CloseAudioChannel`,
+  reachable via a brief tap on the FT6336 LCD touch panel while the
+  device was in `listening`) running on the main task between handshake
+  completion and the `OnDisconnected` lambda firing on the WS task —
+  silently disarming the reconnect even when the underlying close was
+  not user-initiated. The fix replaces the global atomic flag with a
+  per-socket `shared_ptr<std::atomic<bool>>` (`notify_disconnect`)
+  whose lifetime is tied to the websocket itself: each candidate in
+  `OpenAudioChannelInternal()` creates its own token, `ParseServerHello`
+  flips it to `true` the moment the server hello arrives (before
+  setting the wait bit, so a near-simultaneous close still observes an
+  armed flag), and any path that intentionally tears down *that
+  specific* socket (`CloseAudioChannel`, the destructive prologue of
+  `OpenAudioChannelInternal`, or the destructor) flips it back to
+  `false` synchronously before invoking `websocket_.reset()`. The
+  lambda's early-return guard short-circuits if and only if the
+  firmware itself wanted the close, while every server- or
+  network-initiated disconnect falls through to `ScheduleReconnect()`.
+  A separate `intentional_close_` atomic re-checks intent on the main
+  task right before the deferred reconnect job runs, so a reconnect
+  enqueued via `Application::Schedule()` before `CloseAudioChannel()`
+  ran cannot reopen the channel against the user's intent (the
+  `esp_timer_stop()` call alone cannot cancel work the timer has
+  already re-posted). The `esp_timer_create` and `esp_timer_start_once`
+  return values are now inspected and logged on failure, and
+  `esp_timer_stop()` warnings other than `ESP_ERR_INVALID_STATE` are
+  surfaced. ([#61])
+
+[#61]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/61
+
 ### Added
 
 - The on-device WiFi configuration UI now also exposes a **Fallback

--- a/README.ja.md
+++ b/README.ja.md
@@ -192,6 +192,10 @@ uv run python -m stackchan_mcp
 ESP32 接続中にゲートウェイを再起動した場合、ファームウェアは idle 中に
 WebSocket 接続を自動再試行します。再試行間隔は 5 秒から始まり、最大 60 秒
 まで伸びます。デバイスが戻ったかどうかは `get_status` で確認できます。
+ハンドシェイク後にゲートウェイ側からセッションが切られた場合 (gateway クラッシュ、
+TLS レイヤの切断、ハンドシェイク後にセッションを閉じる構成のゲートウェイなど) でも
+同じ再試行経路が動くので、次の接続試行をゲートウェイが受け入れた時点で
+自動復帰します。
 
 別ネットワークから使う場合は、Tailscale Funnel と `VISION_URL` による capture
 callback 設定を [`docs/remote-access.md`](docs/remote-access.md) にまとめています。

--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ uv run python -m stackchan_mcp
 If the gateway is restarted while the ESP32 is already connected, the firmware
 automatically retries the WebSocket connection while idle. The retry delay starts
 at 5 seconds and backs off up to 60 seconds; use `get_status` to confirm that
-the device has reappeared.
+the device has reappeared. The same retry path also fires for any
+post-handshake server-initiated close — gateway crashes, TLS-layer resets, and
+gateway configurations that tear the WebSocket session down after the handshake
+— so the device recovers automatically once the gateway accepts the next
+connection attempt.
 
 For non-LAN setups, see [`docs/remote-access.md`](docs/remote-access.md) for the
 Tailscale Funnel flow and the `VISION_URL` capture callback setting.

--- a/firmware/docs/websocket.md
+++ b/firmware/docs/websocket.md
@@ -73,15 +73,20 @@ This document describes the WebSocket communication protocol between the device 
 
    - When the server or network drops, `OnDisconnected()` fires:
      - The device invokes `on_audio_channel_closed_()` and eventually returns to the idle state.
-     - If the socket was not closed intentionally, the firmware schedules a
-       background reconnect while the device is idle. Retries start after 5
-       seconds and back off up to 60 seconds.
+     - If the socket was not closed intentionally by the firmware itself,
+       the firmware schedules a background reconnect while the device is
+       idle. Retries start after 5 seconds and back off up to 60 seconds.
+       This applies to any post-handshake disconnect, including gateway
+       crashes, gateway restarts, TLS-layer resets, and gateway
+       configurations that tear the WebSocket session down after the
+       handshake.
 
 6. **Closing the WebSocket connection**
    - When the device wants to end the session, it calls `CloseAudioChannel()` to tear down the socket and returns to idle.
-   - Intentional closes do not schedule a reconnect. Server-initiated closes
-     and gateway restarts do schedule one, so MCP tools become available again
-     after the gateway comes back.
+   - Intentional device-side closes do not schedule a reconnect. Any
+     server- or network-initiated close after the handshake does schedule
+     one, so MCP tools become available again on the next successful
+     connection attempt without operator intervention on the device.
 
 ---
 

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -509,7 +509,11 @@ std::string WebsocketProtocol::GetHelloMessage() {
 void WebsocketProtocol::ParseServerHello(const cJSON* root,
                                          const std::shared_ptr<std::atomic<bool>>& notify_disconnect) {
     auto transport = cJSON_GetObjectItem(root, "transport");
-    if (transport == nullptr || strcmp(transport->valuestring, "websocket") != 0) {
+    if (transport == nullptr || !cJSON_IsString(transport)) {
+        ESP_LOGE(TAG, "Server hello missing or non-string transport field");
+        return;
+    }
+    if (strcmp(transport->valuestring, "websocket") != 0) {
         ESP_LOGE(TAG, "Unsupported transport: %s", transport->valuestring);
         return;
     }
@@ -533,10 +537,20 @@ void WebsocketProtocol::ParseServerHello(const cJSON* root,
     }
 
     // Arm the per-socket reconnect intent BEFORE setting the wait bit so
-    // a near-simultaneous server-side close (e.g. token mismatch closing
-    // immediately after server hello) observed by the OnDisconnected
-    // lambda still falls into the reconnect path. The release here
-    // synchronises with the load() in the OnDisconnected lambda.
+    // a near-simultaneous server-side close observed by the
+    // OnDisconnected lambda still falls into the reconnect path. The
+    // release here synchronises with the load() in the OnDisconnected
+    // lambda.
     notify_disconnect->store(true, std::memory_order_release);
+    // Clear intentional_close_ on the WS task here too, not only after
+    // the wait returns on the main task. Without this, if the server
+    // closed immediately after sending hello, the OnDisconnected lambda
+    // would observe an armed notify_disconnect and call
+    // ScheduleReconnect(), but ScheduleReconnect()'s intentional_close_
+    // gate (still set by OpenAudioChannelInternal()'s prologue, since
+    // the main task has not yet returned from xEventGroupWaitBits) would
+    // wrongly suppress the reconnect. Clearing here closes that race;
+    // the main task path also clears it for explicitness.
+    intentional_close_.store(false);
     xEventGroupSetBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
 }

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -551,6 +551,17 @@ void WebsocketProtocol::ParseServerHello(const cJSON* root,
     // the main task has not yet returned from xEventGroupWaitBits) would
     // wrongly suppress the reconnect. Clearing here closes that race;
     // the main task path also clears it for explicitness.
+    //
+    // The symmetric race — a user-initiated CloseAudioChannel() running
+    // between this WS-task clear and the main task mirroring the new
+    // notify_disconnect into current_notify_disconnect_ — cannot occur
+    // in practice because every CloseAudioChannel() call site in
+    // application.cc dispatches on the main task (Application::Run()'s
+    // event loop or Schedule() lambdas), and the main task is blocked
+    // inside xEventGroupWaitBits for the duration of this window.
+    // Reusing this protocol from a context that drives CloseAudioChannel
+    // from a separate task would invalidate that assumption and would
+    // also need a different mirror strategy (e.g. atomic_shared_ptr).
     intentional_close_.store(false);
     xEventGroupSetBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
 }

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -38,32 +38,52 @@ WebsocketProtocol::WebsocketProtocol() {
             auto protocol = static_cast<WebsocketProtocol*>(arg);
             auto alive = protocol->alive_;
             Application::GetInstance().Schedule([protocol, alive]() {
-                if (!*alive || !protocol->auto_reconnect_enabled_.load()) {
+                if (!alive->load()) {
+                    return;
+                }
+                // Re-check intent on the main task. esp_timer_stop() does
+                // not cancel work that the timer has already re-posted via
+                // Application::Schedule, so a CloseAudioChannel() or
+                // destructor that ran *between* timer fire and this lambda
+                // executing would otherwise be undone here.
+                if (protocol->intentional_close_.load()) {
+                    ESP_LOGI(TAG, "Reconnect cancelled (close was intentional)");
                     return;
                 }
 
                 auto& app = Application::GetInstance();
-                if (app.GetDeviceState() != kDeviceStateIdle) {
+                auto state = app.GetDeviceState();
+                if (state != kDeviceStateIdle) {
+                    ESP_LOGI(TAG, "Reconnect deferred (device state %d != idle); rescheduling", state);
                     protocol->ScheduleReconnect();
                     return;
                 }
 
                 ESP_LOGI(TAG, "Reconnecting to websocket server");
                 if (!protocol->OpenAudioChannelInternal(false)) {
+                    ESP_LOGW(TAG, "Reconnect attempt failed; rescheduling");
                     protocol->ScheduleReconnect();
                 }
             });
         },
         .arg = this,
     };
-    esp_timer_create(&reconnect_timer_args, &reconnect_timer_);
+    if (esp_timer_create(&reconnect_timer_args, &reconnect_timer_) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create reconnect timer; auto reconnect will not be available");
+        reconnect_timer_ = nullptr;
+    }
 }
 
 WebsocketProtocol::~WebsocketProtocol() {
-    *alive_ = false;
+    alive_->store(false);
+    intentional_close_.store(true);
+    if (current_notify_disconnect_) {
+        current_notify_disconnect_->store(false);
+    }
     StopReconnectTimer();
     if (reconnect_timer_ != nullptr) {
         esp_timer_delete(reconnect_timer_);
+        reconnect_timer_ = nullptr;
     }
     websocket_.reset();
     if (event_group_handle_ != nullptr) {
@@ -128,7 +148,15 @@ bool WebsocketProtocol::IsAudioChannelOpened() const {
 
 void WebsocketProtocol::CloseAudioChannel(bool send_goodbye) {
     (void)send_goodbye;  // Websocket doesn't need to send goodbye message
-    auto_reconnect_enabled_.store(false);
+    // Mark the close as intentional so any reconnect job already
+    // re-posted from the timer callback aborts when it runs on the main
+    // task, then disarm the current socket's per-socket flag so the
+    // OnDisconnected lambda hits the early-return guard the moment the
+    // underlying close fires (the lambda runs on the WS task).
+    intentional_close_.store(true);
+    if (current_notify_disconnect_) {
+        current_notify_disconnect_->store(false);
+    }
     StopReconnectTimer();
     websocket_.reset();
 }
@@ -138,11 +166,18 @@ bool WebsocketProtocol::OpenAudioChannel() {
 }
 
 bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
-    bool reconnect_was_enabled = auto_reconnect_enabled_.load();
-    auto_reconnect_enabled_.store(false);
+    // Resetting the previous websocket may invoke its OnDisconnected
+    // callback synchronously. Disarm the previous socket's flag and
+    // mark the teardown as intentional so neither the per-socket lambda
+    // nor any deferred reconnect job triggers a spurious reconnect; the
+    // new socket below installs a fresh token of its own and clears
+    // intentional_close_ once the server hello has been acked.
+    intentional_close_.store(true);
+    if (current_notify_disconnect_) {
+        current_notify_disconnect_->store(false);
+    }
     StopReconnectTimer();
     websocket_.reset();
-    auto_reconnect_enabled_.store(reconnect_was_enabled);
     session_id_ = "";
     xEventGroupClearBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
 
@@ -258,7 +293,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
             ESP_LOGE(TAG, "Failed to create websocket");
             continue;
         }
-        auto notify_disconnect = std::make_shared<bool>(false);
+        auto notify_disconnect = std::make_shared<std::atomic<bool>>(false);
 
         if (!token.empty()) {
             websocket_->SetHeader("Authorization", token.c_str());
@@ -267,7 +302,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
         websocket_->SetHeader("Device-Id", SystemInfo::GetMacAddress().c_str());
         websocket_->SetHeader("Client-Id", Board::GetInstance().GetUuid().c_str());
 
-        websocket_->OnData([this](const char* data, size_t len, bool binary) {
+        websocket_->OnData([this, notify_disconnect](const char* data, size_t len, bool binary) {
             if (binary) {
                 if (on_incoming_audio_ != nullptr) {
                     if (version_ == 2) {
@@ -309,7 +344,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
                 auto type = cJSON_GetObjectItem(root, "type");
                 if (cJSON_IsString(type)) {
                     if (strcmp(type->valuestring, "hello") == 0) {
-                        ParseServerHello(root);
+                        ParseServerHello(root, notify_disconnect);
                     } else {
                         if (on_incoming_json_ != nullptr) {
                             on_incoming_json_(root);
@@ -324,8 +359,17 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
         });
 
         websocket_->OnDisconnected([this, notify_disconnect]() {
-            if (!*notify_disconnect) {
-                ESP_LOGI(TAG, "Websocket candidate disconnected before server hello");
+            // notify_disconnect carries this socket's reconnect intent.
+            // ParseServerHello() flips it to true the moment the server
+            // hello arrives; an intentional teardown (CloseAudioChannel,
+            // OpenAudioChannelInternal prologue, or destructor) flips it
+            // back to false synchronously before invoking
+            // websocket_.reset(). A `false` reading here therefore means
+            // either the candidate failed before server hello or the
+            // firmware is tearing the socket down on purpose — neither
+            // case should schedule a reconnect.
+            if (!notify_disconnect->load()) {
+                ESP_LOGI(TAG, "Websocket disconnected (no reconnect: candidate failed or intentional close)");
                 return;
             }
             if (on_disconnected_ != nullptr) {
@@ -335,9 +379,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
             if (on_audio_channel_closed_ != nullptr) {
                 on_audio_channel_closed_();
             }
-            if (auto_reconnect_enabled_.load()) {
-                ScheduleReconnect();
-            }
+            ScheduleReconnect();
         });
 
         ESP_LOGI(TAG, "Connecting to websocket server candidate %d/%d: %s with version: %d",
@@ -368,8 +410,14 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
             continue;
         }
 
-        *notify_disconnect = true;
-        auto_reconnect_enabled_.store(true);
+        // ParseServerHello() already armed notify_disconnect on the WS
+        // task (before setting the wait bit) so a near-simultaneous close
+        // is handled by the lambda's reconnect path. Mirror it into the
+        // class member here on the main task so CloseAudioChannel /
+        // OpenAudioChannelInternal / the destructor can disarm it
+        // synchronously when intentionally tearing this socket down.
+        current_notify_disconnect_ = notify_disconnect;
+        intentional_close_.store(false);
         reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
         StopReconnectTimer();
 
@@ -397,19 +445,39 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
 }
 
 void WebsocketProtocol::ScheduleReconnect() {
-    if (reconnect_timer_ == nullptr || !auto_reconnect_enabled_.load()) {
+    if (!alive_->load()) {
+        return;
+    }
+    if (reconnect_timer_ == nullptr) {
+        ESP_LOGW(TAG, "Reconnect timer not initialised; cannot schedule reconnect");
+        return;
+    }
+    if (intentional_close_.load()) {
+        ESP_LOGI(TAG, "Reconnect not scheduled (intentional close in progress)");
         return;
     }
 
     StopReconnectTimer();
+    esp_err_t err = esp_timer_start_once(reconnect_timer_, reconnect_interval_ms_ * 1000);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to start reconnect timer (err=%d); reconnect not scheduled", err);
+        return;
+    }
     ESP_LOGI(TAG, "Schedule websocket reconnect in %d seconds", reconnect_interval_ms_ / 1000);
-    esp_timer_start_once(reconnect_timer_, reconnect_interval_ms_ * 1000);
     reconnect_interval_ms_ = std::min(reconnect_interval_ms_ * 2, WEBSOCKET_RECONNECT_MAX_INTERVAL_MS);
 }
 
 void WebsocketProtocol::StopReconnectTimer() {
-    if (reconnect_timer_ != nullptr) {
-        esp_timer_stop(reconnect_timer_);
+    if (reconnect_timer_ == nullptr) {
+        return;
+    }
+    esp_err_t err = esp_timer_stop(reconnect_timer_);
+    // ESP_ERR_INVALID_STATE just means the timer was not running, which
+    // is the common case when StopReconnectTimer() runs from a path
+    // where no reconnect is currently armed. Log anything else so a
+    // genuinely failed teardown is visible on serial.
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGW(TAG, "Failed to stop reconnect timer (err=%d)", err);
     }
 }
 
@@ -438,7 +506,8 @@ std::string WebsocketProtocol::GetHelloMessage() {
     return message;
 }
 
-void WebsocketProtocol::ParseServerHello(const cJSON* root) {
+void WebsocketProtocol::ParseServerHello(const cJSON* root,
+                                         const std::shared_ptr<std::atomic<bool>>& notify_disconnect) {
     auto transport = cJSON_GetObjectItem(root, "transport");
     if (transport == nullptr || strcmp(transport->valuestring, "websocket") != 0) {
         ESP_LOGE(TAG, "Unsupported transport: %s", transport->valuestring);
@@ -463,5 +532,11 @@ void WebsocketProtocol::ParseServerHello(const cJSON* root) {
         }
     }
 
+    // Arm the per-socket reconnect intent BEFORE setting the wait bit so
+    // a near-simultaneous server-side close (e.g. token mismatch closing
+    // immediately after server hello) observed by the OnDisconnected
+    // lambda still falls into the reconnect path. The release here
+    // synchronises with the load() in the OnDisconnected lambda.
+    notify_disconnect->store(true, std::memory_order_release);
     xEventGroupSetBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
 }

--- a/firmware/main/protocols/websocket_protocol.h
+++ b/firmware/main/protocols/websocket_protocol.h
@@ -32,11 +32,36 @@ private:
     EventGroupHandle_t event_group_handle_;
     std::unique_ptr<WebSocket> websocket_;
     esp_timer_handle_t reconnect_timer_ = nullptr;
-    std::atomic<bool> auto_reconnect_enabled_ = false;
+    // Per-socket "this disconnect should fire the reconnect path" flag.
+    // The candidate loop in OpenAudioChannelInternal() creates a fresh
+    // shared_ptr<atomic<bool>>(false) for each socket and captures it
+    // into that socket's OnDisconnected lambda. ParseServerHello() flips
+    // it to true the moment the server hello arrives (before the wait
+    // bit is set, so a near-simultaneous close still observes an armed
+    // flag). The same shared_ptr is mirrored here so any path that
+    // intentionally tears down the socket (CloseAudioChannel, the
+    // destructive prologue of OpenAudioChannelInternal, the destructor)
+    // can flip it back to false right before calling websocket_.reset().
+    // The lambda then observes the flag synchronously when the underlying
+    // close fires and short-circuits without scheduling a reconnect.
+    // Using std::atomic<bool> inside the shared_ptr makes the cross-task
+    // read/write well-defined (the lambda runs on the WS task; the disarm
+    // path runs on the main task).
+    std::shared_ptr<std::atomic<bool>> current_notify_disconnect_;
+    // Latch flipped by every code path that intentionally tears the
+    // current socket down. Cleared the moment a fresh server hello is
+    // acked. Checked by the deferred reconnect job that the timer
+    // callback re-posts onto the main task — without this, a reconnect
+    // job already enqueued before CloseAudioChannel() ran would fire
+    // and re-open the channel against the user's intent (the timer's
+    // own esp_timer_stop() does not cancel work the timer has already
+    // re-posted via Application::Schedule).
+    std::atomic<bool> intentional_close_ = false;
     int reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
     int version_ = 1;
 
-    void ParseServerHello(const cJSON* root);
+    void ParseServerHello(const cJSON* root,
+                          const std::shared_ptr<std::atomic<bool>>& notify_disconnect);
     bool SendText(const std::string& text) override;
     std::string GetHelloMessage();
     bool OpenAudioChannelInternal(bool report_error);


### PR DESCRIPTION
## Summary

Fixes Issue #61. PR #35 added WebSocket auto-reconnect after gateway restart, but the path was effectively suppressed for any post-handshake server- or network-initiated close. Real-device tracing on a CoreS3 stackchan board (TLS-terminated gateway) showed the original global atomic ` auto_reconnect_enabled_ ` flag being cleared by an unrelated user-initiated path: ` HandleToggleChatEvent ` (reachable via a brief tap on the FT6336 LCD touch panel while the device was in ` listening `) called ` protocol_->CloseAudioChannel() `, and ` CloseAudioChannel() ` cleared the global flag. This ran on the main task between handshake completion and the ` OnDisconnected ` lambda firing on the WS task, silently disarming the reconnect even when the underlying close was not user-initiated.

The fix moves reconnect intent from a global atomic flag to a **per-socket ` shared_ptr<std::atomic<bool>> `** (` notify_disconnect `) tied to the socket itself.

## Why

- ` auto_reconnect_enabled_ ` was global state across two task boundaries and easy to clear in the wrong context.
- Per-socket ` shared_ptr<std::atomic<bool>> ` makes intent travel with the socket lifetime and removes the cross-socket coupling.
- ` ParseServerHello ` arms the new socket *before* the wait bit is set (` std::memory_order_release `), so a near-simultaneous server-side close still observes an armed flag in the ` OnDisconnected ` lambda.
- A separate ` intentional_close_ ` atomic re-checks intent on the main task right before the deferred reconnect job runs, since ` esp_timer_stop() ` cannot cancel work the timer has already re-posted via ` Application::Schedule() `.
- ` esp_timer_create() ` / ` esp_timer_start_once() ` return values are inspected and logged on failure; the destructor clears state in a defined order so any in-flight timer callback observes a consistent shutdown.

## Validation

- Built via ` python ./scripts/release.py stackchan ` against ` espressif/idf:v5.5.2 `; ` xiaozhi.bin ` flashed to ` 0x20000 ` on a CoreS3 stackchan board (TLS-terminated gateway via Tailscale Funnel).
- 90s idle observation with the StackChan **untouched**: no spurious ` CloseAudioChannel ` is invoked between handshake and disconnect, and the previously-observed flag-disarm symptom does not reproduce.
- Reproduction trace before the fix (LCD-touch path): listening transition is followed within ~30 ms by ` CloseAudioChannel called; current_notify_disconnect_ val=1 ` → ` disarmed ` → ` mbedtls_ssl_fetch_input error=76 ` → ` Websocket disconnected (no reconnect: candidate failed or intentional close) `. With the fix and no touch, that disarm path no longer fires for server- or network-initiated closes; with the fix and an intentional touch, the disarm is correctly local to that socket and the lambda short-circuits as designed.
- Local pre-PR ` /codex:review --effort medium ` round addressed: per-socket bool wrapped in ` std::atomic<bool> ` with ordered store/load; deferred reconnect job re-checks ` intentional_close_ `; ` ParseServerHello ` arms before SetBits to close the post-handshake immediate-close race; ` ScheduleReconnect ` bails on ` !alive_ ` / ` intentional_close_ `; ` esp_timer_stop() ` failures other than ` ESP_ERR_INVALID_STATE ` are surfaced.
- License-sensitive headers under ` firmware/main/boards/stackchan/ ` are not touched in this PR.

## Test plan

- [ ] CI green on this branch (build, ruff, pytest).
- [ ] Maintainer real-device sanity: deploy this firmware to a board, leave it untouched, confirm ` listening ` is reached without ` CloseAudioChannel ` being invoked between handshake and any subsequent disconnect.
- [ ] Maintainer reproduction (optional): bring up a gateway configured to close the WebSocket after server hello (e.g. mismatched bearer, deliberate gateway-side restart while the device is in ` listening `) and confirm ` Schedule websocket reconnect in 5 seconds ` appears on serial and the device reconnects within the next backoff window.

Closes #61.