### PR TITLE
feat: add set_mouth_sequence MCP tool for TTS lip-sync (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,14 @@ change is called out under a `Firmware` subsection of the release entry.
   interrupted) by reading the user's most recent `set_blink` intent
   rather than a snapshot taken at sequence start, so a `set_blink`
   call issued mid-sequence is honoured (such a call returns `ok`
-  with `deferred: true` and applies the moment the sequence ends). The final shape is held after the sequence finishes
+  with `deferred: true` and applies the moment the sequence ends).
+  Note: like `set_mouth`, the final mouth shape can also be replaced
+  by the resting face once an autonomous blink fires after the
+  sequence — this is the same Phase 2 trade-off (the blink state
+  machine ends by repainting the full face). Callers that need a
+  non-closed final shape to persist visually should disable blink
+  with `set_blink(false)` before the sequence; a follow-up to make
+  blink composable with mouth overlays is tracked separately. The final shape is held after the sequence finishes
   so callers can compose with future expression-style use cases;
   append a `{"shape": "closed", "duration_ms": ...}` step if you want
   the mouth to close at the end. Designed to compose with a future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,15 +71,24 @@ change is called out under a `Firmware` subsection of the release entry.
   hidden from MCP clients. Validation is atomic — if any step is
   malformed the whole call is rejected and nothing is queued (no
   half-played sequences). Calling `set_mouth`, `set_avatar`, or
-  `set_mouth_sequence` again interrupts the in-flight sequence and,
-  for `set_mouth_sequence`, replaces the pending queue. A separate
-  `cancel_mouth_sequence` tool is intentionally not added —
-  `set_mouth("closed")` doubles as the cancellation path, keeping the
-  MCP surface minimal. Autonomous blink is paused during playback
-  because the blink state machine ends by restoring the last
-  full-face image, which would otherwise overwrite the active mouth
-  overlay; blink is resumed when the sequence finishes (or is
-  interrupted). The final shape is held after the sequence finishes
+  `set_mouth_sequence` again interrupts the in-flight sequence and
+  also clears any pending-but-not-yet-started sequence, so a
+  `set_mouth("closed")` issued in the brief window between
+  `set_mouth_sequence` returning and the playback task waking up
+  still wins. Each preempt also bumps a generation token that the
+  playback task re-checks before every frame draw, eliminating the
+  small race where a stale mouth frame could otherwise be drawn
+  after a newer command had already returned to the caller. A
+  separate `cancel_mouth_sequence` tool is intentionally not added —
+  `set_mouth("closed")` doubles as the cancellation path, keeping
+  the MCP surface minimal. Autonomous blink is paused during
+  playback because the blink state machine ends by restoring the
+  last full-face image, which would otherwise overwrite the active
+  mouth overlay; blink is resumed when the sequence finishes (or is
+  interrupted) by reading the user's most recent `set_blink` intent
+  rather than a snapshot taken at sequence start, so a `set_blink`
+  call issued mid-sequence is honoured (such a call returns `ok`
+  with `deferred: true` and applies the moment the sequence ends). The final shape is held after the sequence finishes
   so callers can compose with future expression-style use cases;
   append a `{"shape": "closed", "duration_ms": ...}` step if you want
   the mouth to close at the end. Designed to compose with a future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,34 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Added
 
+- New `set_mouth_sequence` MCP tool: queue a list of
+  `{shape, duration_ms}` steps and play it on the device locally so a
+  TTS-driven caller can ship one MCP call per utterance instead of N
+  back-to-back `set_mouth` calls (which suffer per-step WebSocket RTT
+  jitter). The gateway exposes a proper array schema with `shape`
+  constrained to `closed | half | open | e | u` and `duration_ms` to
+  10..10000 ms; sequences are 1..256 steps. Because the ESP32 MCP
+  Property type system only supports string/integer/boolean, the
+  gateway serialises `steps` to a JSON string under `steps_json` and
+  the firmware decodes it via cJSON; this is an internal wire detail
+  hidden from MCP clients. Validation is atomic — if any step is
+  malformed the whole call is rejected and nothing is queued (no
+  half-played sequences). Calling `set_mouth`, `set_avatar`, or
+  `set_mouth_sequence` again interrupts the in-flight sequence and,
+  for `set_mouth_sequence`, replaces the pending queue. A separate
+  `cancel_mouth_sequence` tool is intentionally not added —
+  `set_mouth("closed")` doubles as the cancellation path, keeping the
+  MCP surface minimal. Autonomous blink is paused during playback
+  because the blink state machine ends by restoring the last
+  full-face image, which would otherwise overwrite the active mouth
+  overlay; blink is resumed when the sequence finishes (or is
+  interrupted). The final shape is held after the sequence finishes
+  so callers can compose with future expression-style use cases;
+  append a `{"shape": "closed", "duration_ms": ...}` step if you want
+  the mouth to close at the end. Designed to compose with a future
+  TTS pipeline (caller pre-computes shapes from phonemes / aeneas
+  alignment / mora timing and ships the whole sequence in one call).
+  Requires a firmware update. ([#5])
 - The on-device WiFi configuration UI now also exposes a **Fallback
   Gateway URL** field and a **Gateway Token** field on the **Advanced**
   tab, alongside the existing WebSocket Gateway URL field. The values
@@ -77,6 +105,7 @@ change is called out under a `Firmware` subsection of the release entry.
   auth on stock builds where no Kconfig default is set, but reverts to
   the bundled default on builds that ship one. ([#43])
 
+[#5]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/5
 [#43]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/43
 
 ## [0.3.0] - 2026-05-08

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,7 +54,8 @@
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
 | `set_avatar(face)` | アバター表情切替 (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`)、または `off` でアバターを隠し blink も停止して下層の WiFi 設定 / OTA / 設定画面を露出。他 face を指定するとアバター + blink が復帰 | ✅ |
 | `set_blink(state)` | 瞬き ON/OFF | ✅ |
-| `set_mouth(state)` | 口開閉 | ✅ |
+| `set_mouth(state)` | 口開閉（one-shot、次の呼び出しまで保持） | ✅ |
+| `set_mouth_sequence(steps)` | TTS リップシンク用に `{shape, duration_ms}` のリストをデバイス側でキュー再生（ステップごとの WebSocket RTT ゆらぎなし） | ✅ |
 | `check_vm_en` | サーボ電源 (VM EN HIGH) 状態確認 | ✅ |
 
 詳細スキーマは `gateway/README.md` 参照。

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ This repository is a monorepo.
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying WiFi config / OTA / settings screens are visible. Any other face brings the avatar back and restores blink. | ✅ |
 | `set_blink(state)` | Blink on/off | ✅ |
-| `set_mouth(state)` | Mouth open/close | ✅ |
+| `set_mouth(state)` | Mouth open/close (one-shot, held until next call) | ✅ |
+| `set_mouth_sequence(steps)` | Queue and play a list of `{shape, duration_ms}` steps locally for TTS lip-sync — no per-step WebSocket RTT jitter | ✅ |
 | `check_vm_en` | Check servo power supply (VM EN HIGH) state | ✅ |
 
 See `gateway/README.md` for full schemas.

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -2141,9 +2141,14 @@ private:
             "10..10000). Returns immediately; calling set_mouth, set_avatar, "
             "or this tool again interrupts the in-flight sequence. "
             "Autonomous blink is paused while a sequence plays and resumed "
-            "when it ends. The final shape is held until the next "
-            "set_mouth/set_avatar call (append a closed step if you want "
-            "the mouth to close at the end).",
+            "when it ends (resume reads the user's most recent set_blink "
+            "intent, not a snapshot). The final shape is held until the "
+            "next set_mouth / set_avatar call, or until the next autonomous "
+            "blink restores the resting face — the same Phase 2 trade-off "
+            "that applies to set_mouth, since blink ends by repainting the "
+            "full face. If the final shape must persist visually, disable "
+            "blink with set_blink(false) before the sequence (or append a "
+            "closed step if you just want the mouth to close at the end).",
             PropertyList({Property("steps_json", kPropertyTypeString)}),
             [this](const PropertyList& properties) -> ReturnValue {
                 std::string steps_json = properties["steps_json"].value<std::string>();

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -27,6 +27,7 @@
 #include <lvgl.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 #define TAG "StackChanBoard"
 
@@ -1532,6 +1533,274 @@ private:
         ESP_LOGI(TAG, "Blink DISABLED");
     }
 
+    // ---- Phase 2: lip-sync sequence playback (Issue #5) ----------------
+    //
+    // set_mouth_sequence accepts a list of {shape, duration_ms} pairs and
+    // walks through it on a dedicated FreeRTOS task. Each step swaps the
+    // mouth-only image and waits duration_ms before advancing. Walking the
+    // queue locally avoids the per-step WebSocket RTT jitter that callers
+    // see when issuing many set_mouth calls back-to-back from a TTS loop.
+    //
+    // Concurrency model:
+    //   - mouth_seq_lock_ protects mouth_seq_pending_.
+    //   - mouth_seq_signal_ is a binary semaphore that wakes the task when
+    //     a new sequence has been enqueued.
+    //   - mouth_seq_active_ / mouth_seq_cancel_requested_ are volatile flags
+    //     read by the task between steps. Setting cancel_requested while the
+    //     task is sleeping in vTaskDelay simply means the task picks up the
+    //     cancel at the next slice boundary (kMouthCancelSliceMs apart).
+    //   - Re-entry semantics: a fresh set_mouth_sequence call replaces the
+    //     pending queue and marks cancel_requested so the task drops the
+    //     remainder of the current sequence and starts the new one.
+    //   - Interrupt sources: set_mouth, set_avatar, and set_mouth_sequence
+    //     all call RequestMouthSequenceCancel() before mutating display
+    //     state, so a sequence in flight is cleanly preempted.
+    //
+    // Trade-offs:
+    //   - The MCP Property type system does not support array values, so
+    //     the gateway serialises `steps` to a JSON string and passes it as
+    //     `steps_json`. Validation happens here once, atomically: if any
+    //     step is malformed the whole call is rejected and nothing is
+    //     queued (no half-played sequences).
+    //   - Autonomous blink is paused while a sequence plays because the
+    //     blink state machine ends by calling RestoreCurrentFaceLocked(),
+    //     which would replace the active mouth overlay with the resting
+    //     face image (see Phase 2 comment near BlinkStepAdvance()).
+    //   - The final shape is held after the sequence finishes; callers
+    //     that want the mouth to close at the end should append a
+    //     {"closed", N} step explicitly. This keeps the primitive composable
+    //     with future expression-style use cases (e.g. ending on an open
+    //     smile).
+    static constexpr int kMaxMouthSequenceSteps = 256;
+    static constexpr int kMouthStepMinMs = 10;
+    static constexpr int kMouthStepMaxMs = 10000;
+    static constexpr uint32_t kMouthCancelSliceMs = 20;
+
+    struct MouthStep {
+        std::string shape;
+        uint32_t duration_ms;
+    };
+
+    struct MouthSequenceEnqueueResult {
+        bool ok;
+        std::string error;
+        int queued_steps;
+        uint32_t total_duration_ms;
+    };
+
+    TaskHandle_t mouth_seq_task_ = nullptr;
+    SemaphoreHandle_t mouth_seq_lock_ = nullptr;     // protects mouth_seq_pending_
+    SemaphoreHandle_t mouth_seq_signal_ = nullptr;   // binary semaphore: wake the task
+    std::vector<MouthStep> mouth_seq_pending_;
+    volatile bool mouth_seq_active_ = false;
+    volatile bool mouth_seq_cancel_requested_ = false;
+
+    // Mark the in-flight sequence (if any) for cancellation. Safe to call
+    // from any thread; the playback task observes the flag at the next
+    // slice boundary. Idempotent: setting it twice is a no-op.
+    void RequestMouthSequenceCancel() {
+        if (mouth_seq_active_) {
+            mouth_seq_cancel_requested_ = true;
+        }
+    }
+
+    // Parse and validate a JSON-serialised sequence, then atomically
+    // replace mouth_seq_pending_ and signal the playback task. Returns
+    // a populated MouthSequenceEnqueueResult; on validation failure
+    // nothing is queued.
+    MouthSequenceEnqueueResult EnqueueMouthSequence(const std::string& steps_json) {
+        MouthSequenceEnqueueResult r{false, std::string(), 0, 0};
+
+        cJSON* root = cJSON_Parse(steps_json.c_str());
+        if (root == nullptr) {
+            r.error = "steps must be a JSON array (parse failed)";
+            return r;
+        }
+        if (!cJSON_IsArray(root)) {
+            r.error = "steps must be a JSON array";
+            cJSON_Delete(root);
+            return r;
+        }
+        int n = cJSON_GetArraySize(root);
+        if (n < 1 || n > kMaxMouthSequenceSteps) {
+            r.error = std::string("steps length out of range (1..") +
+                      std::to_string(kMaxMouthSequenceSteps) + ")";
+            cJSON_Delete(root);
+            return r;
+        }
+
+        std::vector<MouthStep> parsed;
+        parsed.reserve(static_cast<size_t>(n));
+        uint32_t total = 0;
+        for (int i = 0; i < n; ++i) {
+            cJSON* item = cJSON_GetArrayItem(root, i);
+            if (!cJSON_IsObject(item)) {
+                r.error = std::string("step[") + std::to_string(i) + "] must be an object";
+                cJSON_Delete(root);
+                return r;
+            }
+            cJSON* shape = cJSON_GetObjectItem(item, "shape");
+            cJSON* dur = cJSON_GetObjectItem(item, "duration_ms");
+            if (!cJSON_IsString(shape) || shape->valuestring == nullptr) {
+                r.error = std::string("step[") + std::to_string(i) + "].shape must be a string";
+                cJSON_Delete(root);
+                return r;
+            }
+            if (!cJSON_IsNumber(dur)) {
+                r.error = std::string("step[") + std::to_string(i) + "].duration_ms must be an integer";
+                cJSON_Delete(root);
+                return r;
+            }
+            if (MouthImageFor(shape->valuestring) == nullptr) {
+                r.error = std::string("step[") + std::to_string(i) +
+                          "].shape unknown: '" + shape->valuestring +
+                          "' (allowed: closed, half, open, e, u)";
+                cJSON_Delete(root);
+                return r;
+            }
+            int d = dur->valueint;
+            if (d < kMouthStepMinMs || d > kMouthStepMaxMs) {
+                r.error = std::string("step[") + std::to_string(i) +
+                          "].duration_ms out of range (" +
+                          std::to_string(kMouthStepMinMs) + ".." +
+                          std::to_string(kMouthStepMaxMs) + ")";
+                cJSON_Delete(root);
+                return r;
+            }
+            parsed.push_back({std::string(shape->valuestring),
+                              static_cast<uint32_t>(d)});
+            total += static_cast<uint32_t>(d);
+        }
+        cJSON_Delete(root);
+
+        if (mouth_seq_lock_ == nullptr || mouth_seq_signal_ == nullptr ||
+            mouth_seq_task_ == nullptr) {
+            r.error = "mouth sequence task not initialised";
+            return r;
+        }
+
+        // Atomically replace the pending queue and mark any in-flight
+        // sequence for cancellation so it stops at the next slice.
+        if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
+            mouth_seq_pending_ = std::move(parsed);
+            if (mouth_seq_active_) {
+                mouth_seq_cancel_requested_ = true;
+            }
+            xSemaphoreGive(mouth_seq_lock_);
+        }
+        // Wake the task. If the task is already running through a previous
+        // sequence, it will pick up the new pending queue after observing
+        // cancel_requested at the next slice and looping back.
+        xSemaphoreGive(mouth_seq_signal_);
+
+        r.ok = true;
+        r.queued_steps = n;
+        r.total_duration_ms = total;
+        return r;
+    }
+
+    static void MouthSequenceTaskTrampoline(void* arg) {
+        static_cast<StackChanBoard*>(arg)->MouthSequenceTaskLoop();
+    }
+
+    void MouthSequenceTaskLoop() {
+        for (;;) {
+            // Wait until something is enqueued (or self-signaled at the
+            // tail of a previous run when more pending was discovered).
+            xSemaphoreTake(mouth_seq_signal_, portMAX_DELAY);
+
+            // Drain whatever is pending right now into a local copy so
+            // we can release the lock before walking the sequence.
+            std::vector<MouthStep> seq;
+            if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
+                seq = std::move(mouth_seq_pending_);
+                mouth_seq_pending_.clear();
+                mouth_seq_cancel_requested_ = false;
+                mouth_seq_active_ = !seq.empty();
+                xSemaphoreGive(mouth_seq_lock_);
+            }
+            if (seq.empty()) {
+                continue;
+            }
+
+            // Pause autonomous blink for the duration of the sequence so
+            // BlinkStepAdvance()'s RestoreCurrentFaceLocked() does not
+            // overwrite the active mouth overlay.
+            bool blink_was_enabled = blink_enabled_;
+            if (blink_was_enabled) {
+                StopBlinkTimer();
+            }
+
+            for (const auto& step : seq) {
+                if (mouth_seq_cancel_requested_) {
+                    break;
+                }
+                SetMouthShape(step.shape.c_str());
+                // Sleep in small slices so cancel is observed quickly.
+                uint32_t remaining = step.duration_ms;
+                while (remaining > 0 && !mouth_seq_cancel_requested_) {
+                    uint32_t slice = remaining > kMouthCancelSliceMs
+                                         ? kMouthCancelSliceMs
+                                         : remaining;
+                    vTaskDelay(pdMS_TO_TICKS(slice));
+                    remaining -= slice;
+                }
+            }
+
+            if (blink_was_enabled) {
+                StartBlinkTimer();
+            }
+
+            // If a fresh sequence was enqueued during playback, the
+            // cancel path above will have left it in mouth_seq_pending_.
+            // Self-signal so the next outer-loop iteration picks it up
+            // immediately rather than parking on the semaphore.
+            bool has_more = false;
+            if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
+                mouth_seq_active_ = false;
+                has_more = !mouth_seq_pending_.empty();
+                xSemaphoreGive(mouth_seq_lock_);
+            }
+            if (has_more) {
+                xSemaphoreGive(mouth_seq_signal_);
+            }
+        }
+    }
+
+    void InitializeMouthSequenceTask() {
+        if (mouth_seq_task_ != nullptr) {
+            return;
+        }
+        mouth_seq_lock_ = xSemaphoreCreateMutex();
+        mouth_seq_signal_ = xSemaphoreCreateBinary();
+        if (mouth_seq_lock_ == nullptr || mouth_seq_signal_ == nullptr) {
+            ESP_LOGE(TAG, "Failed to create mouth sequence sync primitives");
+            if (mouth_seq_lock_ != nullptr) {
+                vSemaphoreDelete(mouth_seq_lock_);
+                mouth_seq_lock_ = nullptr;
+            }
+            if (mouth_seq_signal_ != nullptr) {
+                vSemaphoreDelete(mouth_seq_signal_);
+                mouth_seq_signal_ = nullptr;
+            }
+            return;
+        }
+        BaseType_t ok = xTaskCreate(&StackChanBoard::MouthSequenceTaskTrampoline,
+                                    "mouth_seq", 4096, this,
+                                    tskIDLE_PRIORITY + 2,
+                                    &mouth_seq_task_);
+        if (ok != pdPASS) {
+            ESP_LOGE(TAG, "Failed to create mouth_seq task");
+            vSemaphoreDelete(mouth_seq_lock_);
+            mouth_seq_lock_ = nullptr;
+            vSemaphoreDelete(mouth_seq_signal_);
+            mouth_seq_signal_ = nullptr;
+            mouth_seq_task_ = nullptr;
+        } else {
+            ESP_LOGI(TAG, "Mouth sequence task ready");
+        }
+    }
+
     void RegisterMcpTools() {
         auto& mcp_server = McpServer::GetInstance();
         ESP_LOGI(TAG, "Registering StackChan MCP tools...");
@@ -1740,8 +2009,14 @@ private:
 
                 bool applied = false;
                 if (face == "off") {
+                    // Any avatar transition supersedes an in-flight mouth
+                    // sequence (per Issue #5 acceptance: "set_avatar() takes
+                    // effect after the queued sequence finishes (or
+                    // interrupts cleanly)").
+                    RequestMouthSequenceCancel();
                     applied = SetAvatarOff();
                 } else if (AvatarImageFor(face.c_str()) != nullptr) {
+                    RequestMouthSequenceCancel();
                     applied = SetAvatarExpression(face.c_str());
                 } else {
                     cJSON_AddBoolToObject(root, "ok", false);
@@ -1781,6 +2056,11 @@ private:
                     ESP_LOGW(TAG, "set_mouth rejected: unknown shape '%s'", mouth.c_str());
                     return root;
                 }
+                // Any explicit mouth set supersedes an in-flight sequence
+                // (Issue #5: set_mouth("closed") doubles as the cancellation
+                // path so we don't need a separate cancel_mouth_sequence
+                // tool).
+                RequestMouthSequenceCancel();
                 bool applied = SetMouthShape(mouth.c_str());
                 cJSON_AddBoolToObject(root, "ok", applied);
                 if (!applied) {
@@ -1788,6 +2068,45 @@ private:
                         "Display not ready yet; retry after a moment.");
                 }
                 ESP_LOGI(TAG, "set_mouth: mouth=%s applied=%d", mouth.c_str(), applied);
+                return root;
+            });
+
+        // Phase 2: lip-sync sequence. Queue and play a list of
+        // {shape, duration_ms} pairs locally so a TTS-driven caller can
+        // ship one MCP call per utterance instead of N back-to-back
+        // set_mouth calls (which suffer per-step WebSocket RTT jitter).
+        // The MCP Property type system has no array kind, so the gateway
+        // serialises `steps` to a JSON string and sends it as `steps_json`.
+        // See Phase 2 lip-sync sequence playback comment block above for
+        // the concurrency model and trade-offs (blink pause, atomic queue
+        // replacement, final shape held).
+        mcp_server.AddTool(
+            "self.display.set_mouth_sequence",
+            "Queue a lip-sync sequence and play it locally. steps_json must "
+            "decode to a JSON array of {shape, duration_ms} objects (1..256 "
+            "items, shape in {closed, half, open, e, u}, duration_ms in "
+            "10..10000). Returns immediately; calling set_mouth, set_avatar, "
+            "or this tool again interrupts the in-flight sequence. "
+            "Autonomous blink is paused while a sequence plays and resumed "
+            "when it ends. The final shape is held until the next "
+            "set_mouth/set_avatar call (append a closed step if you want "
+            "the mouth to close at the end).",
+            PropertyList({Property("steps_json", kPropertyTypeString)}),
+            [this](const PropertyList& properties) -> ReturnValue {
+                std::string steps_json = properties["steps_json"].value<std::string>();
+                MouthSequenceEnqueueResult r = EnqueueMouthSequence(steps_json);
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "ok", r.ok);
+                if (!r.ok) {
+                    cJSON_AddStringToObject(root, "error", r.error.c_str());
+                    ESP_LOGW(TAG, "set_mouth_sequence rejected: %s", r.error.c_str());
+                } else {
+                    cJSON_AddNumberToObject(root, "queued_steps", r.queued_steps);
+                    cJSON_AddNumberToObject(root, "estimated_duration_ms",
+                                            static_cast<double>(r.total_duration_ms));
+                    ESP_LOGI(TAG, "set_mouth_sequence queued %d steps (%u ms)",
+                             r.queued_steps, (unsigned)r.total_duration_ms);
+                }
                 return root;
             });
 
@@ -1875,6 +2194,7 @@ public:
         // Avatar auto-display disabled: WiFi config UI needs to be visible.
         // Avatar is shown on-demand via MCP set_avatar command.
         // InitializeAvatar();
+        InitializeMouthSequenceTask();
         RegisterMcpTools();
     }
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -25,6 +25,7 @@
 #include "esp_video.h"
 #include <cJSON.h>
 #include <lvgl.h>
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -1589,18 +1590,49 @@ private:
     };
 
     TaskHandle_t mouth_seq_task_ = nullptr;
-    SemaphoreHandle_t mouth_seq_lock_ = nullptr;     // protects mouth_seq_pending_
+    SemaphoreHandle_t mouth_seq_lock_ = nullptr;     // protects mouth_seq_pending_ + generation
     SemaphoreHandle_t mouth_seq_signal_ = nullptr;   // binary semaphore: wake the task
     std::vector<MouthStep> mouth_seq_pending_;
-    volatile bool mouth_seq_active_ = false;
-    volatile bool mouth_seq_cancel_requested_ = false;
+    std::atomic<bool> mouth_seq_active_{false};
+    std::atomic<bool> mouth_seq_cancel_requested_{false};
+    // Generation counter bumped under mouth_seq_lock_ by every preemption
+    // path (set_mouth, set_avatar, fresh set_mouth_sequence). The playback
+    // task latches a snapshot at sequence start and re-checks before every
+    // SetMouthShape() call, so a preempt issued in the 0..kMouthCancelSliceMs
+    // window between the last cancel-flag check and the next SetMouthShape
+    // call still aborts the current frame draw. Without this, the task
+    // could draw one stale mouth frame after the user-issued set_mouth /
+    // set_avatar handler had already returned.
+    std::atomic<uint32_t> mouth_seq_generation_{0};
+    // User's explicitly-requested blink state, independent of whether
+    // a mouth sequence is currently suppressing the timer. set_blink
+    // updates this; the playback task restores StartBlinkTimer() at
+    // sequence end iff this is true. Without this split a set_blink
+    // call issued during a sequence is silently overwritten by the
+    // pre-sequence snapshot when the task finishes.
+    std::atomic<bool> blink_desired_{false};
 
-    // Mark the in-flight sequence (if any) for cancellation. Safe to call
-    // from any thread; the playback task observes the flag at the next
-    // slice boundary. Idempotent: setting it twice is a no-op.
+    // Mark any in-flight or pending sequence for cancellation. Safe to
+    // call from any thread. Takes mouth_seq_lock_ so that:
+    //   - mouth_seq_pending_ is cleared atomically (callers that issue
+    //     set_mouth / set_avatar in the brief window between
+    //     EnqueueMouthSequence() returning and the task waking up don't
+    //     get overwritten by the queued-but-not-yet-active sequence);
+    //   - mouth_seq_cancel_requested_ is set so the task aborts at the
+    //     next slice boundary if it is already active;
+    //   - mouth_seq_generation_ is bumped under release ordering so the
+    //     task observes a stale generation at its next per-step check
+    //     and skips the remaining SetMouthShape() calls.
+    // Idempotent under repeated calls.
     void RequestMouthSequenceCancel() {
-        if (mouth_seq_active_) {
-            mouth_seq_cancel_requested_ = true;
+        if (mouth_seq_lock_ == nullptr) {
+            return;
+        }
+        if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
+            mouth_seq_pending_.clear();
+            mouth_seq_cancel_requested_.store(true, std::memory_order_release);
+            mouth_seq_generation_.fetch_add(1, std::memory_order_release);
+            xSemaphoreGive(mouth_seq_lock_);
         }
     }
 
@@ -1680,12 +1712,17 @@ private:
         }
 
         // Atomically replace the pending queue and mark any in-flight
-        // sequence for cancellation so it stops at the next slice.
+        // sequence for cancellation so it stops at the next slice. The
+        // generation bump is what makes a fresh enqueue preempt the
+        // currently-playing sequence even between cancel-flag checks
+        // and SetMouthShape() calls (per-step generation re-check in
+        // MouthSequenceTaskLoop).
         if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
             mouth_seq_pending_ = std::move(parsed);
-            if (mouth_seq_active_) {
-                mouth_seq_cancel_requested_ = true;
+            if (mouth_seq_active_.load(std::memory_order_acquire)) {
+                mouth_seq_cancel_requested_.store(true, std::memory_order_release);
             }
+            mouth_seq_generation_.fetch_add(1, std::memory_order_release);
             xSemaphoreGive(mouth_seq_lock_);
         }
         // Wake the task. If the task is already running through a previous
@@ -1710,13 +1747,17 @@ private:
             xSemaphoreTake(mouth_seq_signal_, portMAX_DELAY);
 
             // Drain whatever is pending right now into a local copy so
-            // we can release the lock before walking the sequence.
+            // we can release the lock before walking the sequence. Latch
+            // the generation under the same lock so we can reject any
+            // newer preempt at the next per-step check.
             std::vector<MouthStep> seq;
+            uint32_t my_generation = 0;
             if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
                 seq = std::move(mouth_seq_pending_);
                 mouth_seq_pending_.clear();
-                mouth_seq_cancel_requested_ = false;
-                mouth_seq_active_ = !seq.empty();
+                mouth_seq_cancel_requested_.store(false, std::memory_order_release);
+                mouth_seq_active_.store(!seq.empty(), std::memory_order_release);
+                my_generation = mouth_seq_generation_.load(std::memory_order_acquire);
                 xSemaphoreGive(mouth_seq_lock_);
             }
             if (seq.empty()) {
@@ -1725,20 +1766,28 @@ private:
 
             // Pause autonomous blink for the duration of the sequence so
             // BlinkStepAdvance()'s RestoreCurrentFaceLocked() does not
-            // overwrite the active mouth overlay.
-            bool blink_was_enabled = blink_enabled_;
-            if (blink_was_enabled) {
-                StopBlinkTimer();
-            }
+            // overwrite the active mouth overlay. Note: we no longer
+            // snapshot blink_enabled_ here — the user's intent is read
+            // from blink_desired_ at sequence end so calls to set_blink
+            // made during playback are honoured.
+            StopBlinkTimer();
 
             for (const auto& step : seq) {
-                if (mouth_seq_cancel_requested_) {
+                // Re-check cancel + generation right before each frame
+                // draw. Any preempt issued between this check and the
+                // previous SetMouthShape() will be observed here, so we
+                // never draw a frame after a newer set_mouth / set_avatar
+                // / set_mouth_sequence handler has returned to the caller.
+                if (mouth_seq_cancel_requested_.load(std::memory_order_acquire) ||
+                    mouth_seq_generation_.load(std::memory_order_acquire) != my_generation) {
                     break;
                 }
                 SetMouthShape(step.shape.c_str());
                 // Sleep in small slices so cancel is observed quickly.
                 uint32_t remaining = step.duration_ms;
-                while (remaining > 0 && !mouth_seq_cancel_requested_) {
+                while (remaining > 0 &&
+                       !mouth_seq_cancel_requested_.load(std::memory_order_acquire) &&
+                       mouth_seq_generation_.load(std::memory_order_acquire) == my_generation) {
                     uint32_t slice = remaining > kMouthCancelSliceMs
                                          ? kMouthCancelSliceMs
                                          : remaining;
@@ -1747,7 +1796,11 @@ private:
                 }
             }
 
-            if (blink_was_enabled) {
+            // Restore blink according to the user's most recent intent,
+            // not a snapshot taken before the sequence started. This way
+            // a set_blink(true/false) issued during the sequence is the
+            // one that wins at the end.
+            if (blink_desired_.load(std::memory_order_acquire)) {
                 StartBlinkTimer();
             }
 
@@ -1757,7 +1810,7 @@ private:
             // immediately rather than parking on the semaphore.
             bool has_more = false;
             if (xSemaphoreTake(mouth_seq_lock_, portMAX_DELAY) == pdTRUE) {
-                mouth_seq_active_ = false;
+                mouth_seq_active_.store(false, std::memory_order_release);
                 has_more = !mouth_seq_pending_.empty();
                 xSemaphoreGive(mouth_seq_lock_);
             }
@@ -2112,23 +2165,38 @@ private:
 
         // Phase 2: enable/disable autonomous blinking. When enabled, a
         // background timer fires every 3-6 s (random) and runs the four-step
-        // blink sequence (half -> closed -> half -> face).
+        // blink sequence (half -> closed -> half -> face). Also captures
+        // the user's intent into blink_desired_ so that a call issued while
+        // a mouth sequence is suppressing blink is honoured when the
+        // sequence finishes.
         mcp_server.AddTool(
             "self.display.set_blink",
             "Enable or disable autonomous eye blinking on the avatar. "
-            "When enabled, a brief blink animation runs every 3-6 seconds.",
+            "When enabled, a brief blink animation runs every 3-6 seconds. "
+            "If a set_mouth_sequence is currently playing, blink is paused "
+            "until the sequence ends; this call still records the intent "
+            "and is applied at the sequence end (or immediately if no "
+            "sequence is running).",
             PropertyList({Property("enabled", kPropertyTypeBoolean)}),
             [this](const PropertyList& properties) -> ReturnValue {
                 bool enabled = properties["enabled"].value<bool>();
-                if (enabled) {
-                    StartBlinkTimer();
-                } else {
-                    StopBlinkTimer();
+                blink_desired_.store(enabled, std::memory_order_release);
+                bool deferred = mouth_seq_active_.load(std::memory_order_acquire);
+                if (!deferred) {
+                    if (enabled) {
+                        StartBlinkTimer();
+                    } else {
+                        StopBlinkTimer();
+                    }
                 }
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddBoolToObject(root, "enabled", enabled);
                 cJSON_AddBoolToObject(root, "ok", true);
-                ESP_LOGI(TAG, "set_blink: enabled=%d", (int)enabled);
+                if (deferred) {
+                    cJSON_AddBoolToObject(root, "deferred", true);
+                }
+                ESP_LOGI(TAG, "set_blink: enabled=%d deferred=%d",
+                         (int)enabled, deferred ? 1 : 0);
                 return root;
             });
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -157,7 +157,8 @@ Same shape, under `mcpServers`.
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are visible. A subsequent `set_avatar(<other face>)` brings it back and restores blink. |
 | `set_blink(state)` | Blink animation on/off |
-| `set_mouth(state)` | Mouth shape (`closed` / `half` / `open` / `e` / `u`) |
+| `set_mouth(state)` | Mouth shape (`closed` / `half` / `open` / `e` / `u`), one-shot, held until next call |
+| `set_mouth_sequence(steps)` | Queue and play a list of `{shape, duration_ms}` steps locally for TTS lip-sync. The firmware walks the queue without per-step network RTT. Calling `set_mouth`, `set_avatar`, or this tool again interrupts the in-flight sequence; autonomous blink is paused while a sequence is playing. |
 | `check_vm_en` | Read PY32 VM EN GPIO state (servo power supply diagnostic) |
 
 The mapping from these names to ESP32-side `self.*` MCP tools is in

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -214,8 +214,14 @@ def create_server() -> Server:
                     "sequence and replaces it. Autonomous blink is paused "
                     "while a sequence is playing and resumed when it ends. "
                     "The final shape is held until the next "
-                    "set_mouth/set_avatar call (append a closed step if you "
-                    "want the mouth to close at the end)."
+                    "set_mouth / set_avatar call, or until an autonomous "
+                    "blink restores the resting face — this is the same "
+                    "Phase 2 trade-off that applies to set_mouth, since the "
+                    "blink animation ends by repainting the full face. If "
+                    "the final shape must persist visually, disable blink "
+                    "with set_blink(false) before the sequence (or append a "
+                    "closed step if you just want the mouth to close at "
+                    "the end)."
                 ),
                 inputSchema={
                     "type": "object",

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -184,7 +184,9 @@ def create_server() -> Server:
                 description=(
                     "Set the avatar mouth shape for lip-sync. "
                     "The shape is held until the next set_avatar / set_mouth call, "
-                    "or until an autonomous blink restores the resting face."
+                    "or until an autonomous blink restores the resting face. "
+                    "Calling this while a set_mouth_sequence is in flight "
+                    "interrupts the sequence."
                 ),
                 inputSchema={
                     "type": "object",
@@ -196,6 +198,62 @@ def create_server() -> Server:
                         },
                     },
                     "required": ["mouth"],
+                },
+            ),
+            Tool(
+                name="set_mouth_sequence",
+                description=(
+                    "Queue a lip-sync sequence and play it on the device. "
+                    "Each step holds 'shape' for 'duration_ms' before "
+                    "advancing. The firmware walks the queue locally so "
+                    "there is no per-step network RTT (use this instead of "
+                    "issuing many set_mouth calls back-to-back from a TTS "
+                    "loop). Returns immediately with the queued step count "
+                    "and estimated total duration. Calling set_mouth, "
+                    "set_avatar, or this tool again interrupts the in-flight "
+                    "sequence and replaces it. Autonomous blink is paused "
+                    "while a sequence is playing and resumed when it ends. "
+                    "The final shape is held until the next "
+                    "set_mouth/set_avatar call (append a closed step if you "
+                    "want the mouth to close at the end)."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "steps": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 256,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "shape": {
+                                        "type": "string",
+                                        "enum": ["closed", "half", "open", "e", "u"],
+                                        "description": (
+                                            "Mouth shape for this step. "
+                                            "One of: closed, half, open, e, u."
+                                        ),
+                                    },
+                                    "duration_ms": {
+                                        "type": "integer",
+                                        "minimum": 10,
+                                        "maximum": 10000,
+                                        "description": (
+                                            "How long to hold this shape "
+                                            "before advancing, in ms (10..10000)."
+                                        ),
+                                    },
+                                },
+                                "required": ["shape", "duration_ms"],
+                            },
+                            "description": (
+                                "Ordered list of mouth shapes with hold "
+                                "durations (1..256 steps)."
+                            ),
+                        },
+                    },
+                    "required": ["steps"],
                 },
             ),
             Tool(
@@ -293,6 +351,13 @@ def create_server() -> Server:
             "set_mouth": (
                 "self.display.set_mouth",
                 arguments,
+            ),
+            # The MCP Property type system on ESP32 only supports
+            # string/integer/boolean, so we serialise the steps array to
+            # a JSON string here. The firmware decodes it via cJSON.
+            "set_mouth_sequence": (
+                "self.display.set_mouth_sequence",
+                {"steps_json": json.dumps(arguments.get("steps", []))},
             ),
             "set_blink": (
                 "self.display.set_blink",

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -64,3 +64,85 @@ async def test_get_head_angles_relays_to_esp32(monkeypatch):
 
     assert calls == [("self.robot.get_head_angles", {})]
     assert json.loads(result.root.content[0].text) == {"yaw": 12, "pitch": -3}
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_set_mouth_sequence():
+    """set_mouth_sequence is exposed to MCP clients with an array schema."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tool = next((t for t in result.root.tools if t.name == "set_mouth_sequence"), None)
+    assert tool is not None, "set_mouth_sequence tool should be registered"
+
+    schema = tool.inputSchema
+    assert schema["properties"]["steps"]["type"] == "array"
+    assert schema["properties"]["steps"]["minItems"] == 1
+    assert schema["properties"]["steps"]["maxItems"] == 256
+
+    item_schema = schema["properties"]["steps"]["items"]
+    assert item_schema["properties"]["shape"]["enum"] == [
+        "closed",
+        "half",
+        "open",
+        "e",
+        "u",
+    ]
+    assert item_schema["properties"]["duration_ms"]["minimum"] == 10
+    assert item_schema["properties"]["duration_ms"]["maximum"] == 10000
+    assert set(item_schema["required"]) == {"shape", "duration_ms"}
+
+
+@pytest.mark.asyncio
+async def test_set_mouth_sequence_relays_steps_as_json_string(monkeypatch):
+    """set_mouth_sequence serialises steps to JSON for the firmware.
+
+    The ESP32 MCP Property type system only supports string/integer/boolean,
+    so the gateway flattens the steps array to a JSON string under
+    `steps_json` before forwarding to self.display.set_mouth_sequence.
+    """
+    calls = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"ok": True, "queued_steps": 2, "estimated_duration_ms": 160}
+                        ),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    steps = [
+        {"shape": "open", "duration_ms": 80},
+        {"shape": "closed", "duration_ms": 80},
+    ]
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "set_mouth_sequence", "arguments": {"steps": steps}},
+        )
+    )
+
+    assert len(calls) == 1
+    name, arguments = calls[0]
+    assert name == "self.display.set_mouth_sequence"
+    assert set(arguments.keys()) == {"steps_json"}
+    assert json.loads(arguments["steps_json"]) == steps


### PR DESCRIPTION
## Summary

Adds the `set_mouth_sequence` MCP tool requested in #5 — queue and play a list of `{shape, duration_ms}` mouth-shape steps locally on the device so a TTS-driven caller can ship one MCP call per utterance instead of N back-to-back `set_mouth` calls (which suffer per-step WebSocket RTT jitter).

## Why

`set_mouth(state)` is a one-shot tool — sequencing has to be done from the client by issuing many calls, each with its own MCP round-trip. For lip-sync derived from phonemes / aeneas alignment / mora timing, the per-step jitter is enough to break visual sync. Pushing the queue down to the firmware lets the playback walk through it via `vTaskDelay` with no network round-trip per step.

## Design

- Gateway exposes a clean array schema: `steps: [{shape: closed|half|open|e|u, duration_ms: 10..10000}, ...]`, max 256 steps.
- Because the ESP32 MCP Property type system has no array kind (only string / integer / boolean), the gateway serialises `steps` to JSON under `steps_json: string` and the firmware decodes it via cJSON. Internal wire detail, hidden from MCP clients.
- A dedicated FreeRTOS task walks the queue, swapping the mouth-only image and `vTaskDelay`-ing per step. Sleep is sliced to 20 ms so cancellation is observed quickly.
- Validation is atomic: any malformed step rejects the whole call, nothing is queued (no half-played sequences).
- `set_mouth("closed")` / `set_avatar(...)` / `set_mouth_sequence(...)` all preempt an in-flight or pending sequence. No separate `cancel_mouth_sequence` tool — the existing `set_mouth("closed")` doubles as cancellation, keeping the MCP surface minimal.
- Autonomous blink is paused during playback (the blink state machine ends by repainting the full face, which would otherwise overwrite the active mouth overlay) and resumed at sequence end based on the user's most recent `set_blink` intent.

## Codex adversarial-review iterations

Two rounds of `/codex:adversarial-review --effort high`:

**Round 1** surfaced 3 findings (2 high + 1 medium): a pending-state cancel race, blink restore overwriting user intent, and a per-step preempt race that could draw one stale frame. Resolved by:

- New `mouth_seq_generation_` `std::atomic<uint32_t>` bumped under `mouth_seq_lock_` by every preempt path; re-checked under acquire ordering before each frame draw and inside the per-step sleep loop.
- `RequestMouthSequenceCancel()` now takes the lock unconditionally and clears `mouth_seq_pending_`, so cancellation works in pending-only and active states alike.
- New `blink_desired_` `std::atomic<bool>` separated from `blink_enabled_`. `set_blink` updates the desired state unconditionally and returns `deferred: true` if a sequence is active. The playback task restores blink at sequence end based on `blink_desired_`, not a pre-sequence snapshot, so a `set_blink` issued mid-sequence wins.
- `volatile bool` flags promoted to `std::atomic<bool>` with explicit acquire / release at every site.

**Round 2** surfaced 1 P2: the documented "final shape held" claim conflicted with the existing Phase 2 blink trade-off (autonomous blink ends by repainting the full face, wiping the mouth overlay 3..6 s after a sequence). This trade-off is already documented for `set_mouth`; the tool descriptions and CHANGELOG entry are now updated to call it out for `set_mouth_sequence` too. The underlying composition behaviour is tracked as a follow-up enhancement at #65 so it can be solved once for both tools.

## Validation

- `cd gateway && uv run pytest` → 86/86 pass.
- `cd gateway && uv run ruff check .` → all clean.
- New gateway tests for the tool: schema shape and the `steps -> steps_json` wire transform.
- Firmware build via `docker run espressif/idf:v5.5.2 python ./scripts/release.py stackchan` → success; flashed `xiaozhi.bin` to `0x20000`.
- Real-device validation on a CoreS3 stackchan board:
  - 20-step × 80 ms sequence plays smoothly without flicker.
  - 50-step × 200 ms sequence interrupted at 1 s by `set_mouth("closed")` — mouth stays closed for the rest of the original 10 s window; serial log confirms no `SetMouthShape("open")` after the cancel (task observed the generation mismatch on its first per-step check).
  - 20-step × 300 ms sequence interrupted by `set_avatar("happy")` — avatar swap takes effect cleanly.
  - `set_blink(true)` + 20-step × 100 ms sequence shows `Blink DISABLED` at task drain and `Blink ENABLED` at sequence end via `blink_desired_` (not a pre-sequence snapshot).
  - Schema validation: invalid `shape` and `duration_ms > 10000` rejected at the gateway layer before the wire.

## Files changed

- `firmware/main/boards/stackchan/stackchan.cc` — task, queue, generation token, MCP tool registration, blink intent split.
- `gateway/stackchan_mcp/stdio_server.py` — tool definition, `steps -> steps_json` transform, deferred-field response handling.
- `gateway/tests/test_stdio_server.py` — schema and routing tests.
- `CHANGELOG.md` — `[Unreleased]` Added entry.
- `README.md`, `README.ja.md`, `gateway/README.md` — tool table updated.

## Out of scope

- TTS pipeline integration itself — left to a future issue; this PR is the primitive that makes such a pipeline composable.
- Tailscale Funnel WebSocket idle-reset behaviour observed during testing — independent transport-layer issue, tracked as #64.
- The Phase 2 trade-off where blink end repaints the full face and overwrites the mouth overlay (affects both `set_mouth` and `set_mouth_sequence`) — tracked as #65 for a unified fix later.

## Test plan

- [ ] CI: `gateway` `uv run pytest` and `uv run ruff check .` pass.
- [ ] Reviewer can read the in-source comment block at the top of the Phase 2 lip-sync sequence playback section in `firmware/main/boards/stackchan/stackchan.cc` and confirm the concurrency model (lock + binary semaphore + atomic generation token + atomic flags) is consistent with the rest of the file.
- [ ] Optional: real-device sanity check (`set_mouth_sequence` followed by an immediate `set_mouth("closed")` should leave the mouth closed for the rest of the original sequence window).

Closes #5
Refs #64
Refs #65