### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-09
+
 ### Firmware
 
 - Fixed: WebSocket auto-reconnect now triggers on any post-handshake
@@ -223,7 +225,8 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.4.0
 [0.3.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.3.0
 [0.2.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.2.0
 [0.1.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.1.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1313,7 +1313,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Cuts the **v0.4.0** PyPI release of `stackchan-mcp`, promoting the contents of `[Unreleased]` accumulated since v0.3.0.

This release headlines the new `set_mouth_sequence` MCP tool — TTS lip-sync now ships one MCP call per utterance instead of N back-to-back `set_mouth` calls — plus the on-device WiFi config UI gaining a fallback gateway URL + token field, and a firmware fix for post-handshake WebSocket reconnect.

## Highlights (full text in `CHANGELOG.md` `[0.4.0]`)

### Added (gateway)

- **`set_mouth_sequence` MCP tool** (#5): queue a list of `{shape, duration_ms}` mouth-shape steps and play it on the device locally so a TTS-driven caller can ship one MCP call per utterance instead of N back-to-back `set_mouth` calls (which suffer per-step WebSocket RTT jitter). Internally uses an atomic `mouth_seq_generation_` token + lock-protected pending queue + per-step preempt re-check, and splits user blink intent (`blink_desired_`) from the timer state so calls during a sequence are honoured at sequence end.
- **Fallback gateway URL + bearer token fields** in the on-device WiFi config UI (#43): end users on a pre-built firmware can now set the full primary + fallback + bearer-token gateway profile from `http://192.168.4.1` without rebuilding from source. Token is rendered as a password field, never returned by the GET endpoint, and redacted from save logs.

### Firmware

- **WebSocket auto-reconnect now triggers on any post-handshake server- or network-initiated disconnect** (#61). The fix replaces the global `auto_reconnect_enabled_` atomic with a per-socket `shared_ptr<std::atomic<bool>>` (`notify_disconnect`) tied to the websocket's lifetime, so an unrelated user-initiated `CloseAudioChannel` (e.g. an FT6336 tap reaching `HandleToggleChatEvent`) cannot disarm a reconnect intended for an unrelated server-side close.

## Per-release checklist

- [x] `gateway/pyproject.toml` `version` bumped to `0.4.0`.
- [x] `gateway/uv.lock` resolved to the new version.
- [x] `CHANGELOG.md` `[Unreleased]` section renamed to `[0.4.0] - 2026-05-09`; a fresh empty `[Unreleased]` added above it.
- [x] CHANGELOG comparison links at the bottom updated (`[Unreleased]` now compares `v0.4.0...HEAD`; new `[0.4.0]` link points at `releases/tag/v0.4.0`).
- [x] `cd gateway && uv run pytest` → 86/86 pass.
- [x] `cd gateway && uv run ruff check .` → clean.

## Test plan

- [ ] CI green (`Gateway test` + `Firmware build`).
- [ ] After merge, maintainer creates and pushes the `v0.4.0` tag — the `publish.yml` workflow should validate ancestor-of-main + version-match + ruff + pytest, then publish to PyPI via Trusted Publishing.
- [ ] Verify the new version on https://pypi.org/p/stackchan-mcp and `pipx install --force stackchan-mcp` resolves to `0.4.0`.
- [ ] Create the matching GitHub Release page with the `[0.4.0]` CHANGELOG section as notes (per `rules/stackchan-dev.md` "Per-release steps").

Refs #5
Refs #43
Refs #61