### PR TITLE
feat(LED): add MCP tools for the 12x WS2812C base RGB strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Added
+
+- New MCP tools to drive the 12× WS2812C RGB LEDs on the StackChan
+  base: `set_led(index, r, g, b)`, `set_all_leds(r, g, b)`,
+  `set_leds(colors)` (batch, single I2C burst for animations), and
+  `clear_leds()`. The strip is wired to the PY32L020 IO expander on
+  expander pin 13 — not an ESP32 GPIO — so the firmware extends the
+  existing `Py32IoExpander` helper with `SetDriveMode`, `SetLedCount`,
+  `SetLedColor` (RGB888 → RGB565 packing), `SetLedData` (burst write),
+  and `RefreshLeds` (RMW preserves the count nibble alongside the
+  bit-6 latch trigger), matching the M5 BSP's
+  `PY32IOExpander_Class.cpp`. `InitializeIOExpander` configures pin 13
+  as push-pull output with pull-up, sets the LED count to 12, waits
+  the M5-prescribed 200 ms before the first refresh, then clears the
+  strip. The on-device tools (`self.led.set_color`, `self.led.set_all`,
+  `self.led.set_many`, `self.led.clear`) all latch implicitly so each
+  call is WYSIWYG; the gateway re-packs the Python `colors` list as a
+  JSON string for `set_many` since the device-side MCP property layer
+  has only scalar types. `set_many` validates every entry (including
+  a `cJSON_IsNumber` guard so non-number elements like `"255"` or
+  `null` no longer silently coerce to 0) before any I2C write, so
+  malformed input cannot leave the strip in a partially-mutated
+  state. All four tools no-op cleanly with an `available=false`
+  reply when the PY32 init failed, so a flaky expander does not
+  cascade into errors.
+
 ## [0.4.0] - 2026-05-09
 
 ### Firmware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,26 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Added
 
+- New MCP tools to drive the 12× WS2812C RGB LEDs on the StackChan
+  base: `set_led(index, r, g, b)`, `set_all_leds(r, g, b)`,
+  `set_leds(colors)` (batch, one I2C burst for animations), and
+  `clear_leds()`. The strip is wired to the PY32L020 IO expander on
+  expander pin 13 — not an ESP32 GPIO — so the firmware extends the
+  existing `Py32IoExpander` helper with `SetDriveMode`, `SetLedCount`,
+  `SetLedColor` (RGB888 → RGB565 packing), `SetLedData` (burst write),
+  and `RefreshLeds` (RMW preserves the count nibble alongside the
+  bit-6 latch trigger), matching the M5 BSP's
+  `PY32IOExpander_Class.cpp`. `InitializeIOExpander` configures pin 13
+  as push-pull output with pull-up, sets the LED count to 12, waits
+  the M5-prescribed 200 ms before the first refresh, then clears the
+  strip. The on-device tools (`self.led.set_color`, `self.led.set_all`,
+  `self.led.set_many`, `self.led.clear`) all latch implicitly so each
+  call is WYSIWYG; the gateway re-packs the Python `colors` list as a
+  JSON string for `set_many` since the device-side MCP property layer
+  has only scalar types. All four tools no-op cleanly with an
+  `available=false` reply when the PY32 init failed, so a flaky
+  expander does not cascade into errors.
+
 - The on-device WiFi configuration UI now also exposes a **Fallback
   Gateway URL** field and a **Gateway Token** field on the **Advanced**
   tab, alongside the existing WebSocket Gateway URL field. The values

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,10 @@ The gateway translates between two tool naming conventions:
 | `set_blink` | `self.avatar.set_blink` |
 | `set_mouth` | `self.avatar.set_mouth` |
 | `check_vm_en` | `self.robot.check_vm_en` |
+| `set_led` | `self.led.set_color` |
+| `set_all_leds` | `self.led.set_all` |
+| `set_leds` | `self.led.set_many` |
+| `clear_leds` | `self.led.clear` |
 
 The mapping lives in `gateway/stackchan_mcp/stdio_server.py`.
 
@@ -91,4 +95,5 @@ schedule this reconnect loop.
 - **Phase 1**: real servo, volume, brightness → done
 - **Phase 2**: HTTP camera capture → done
 - **Phase 3**: avatar, blink, mouth, touch (Si12T), gesture (TAP/STROKE) → done
-- **Phase 4** (planned): Opus audio stream (STT / TTS pipeline)
+- **Phase 4**: 12x WS2812C base RGB LEDs via PY32 IO expander → done
+- **Phase 5** (planned): Opus audio stream (STT / TTS pipeline)

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -2482,8 +2482,17 @@ private:
                 }
                 int n = cJSON_GetArraySize(arr);
                 if (n > RGB_LED_COUNT) n = RGB_LED_COUNT;
+
+                // Validate every entry FIRST and pack into a local buffer.
+                // Only after the whole array is known good do we touch the
+                // PY32 — that way a malformed entry at i=5 cannot leave
+                // LEDs 0..4 mutated (atomic semantics, same as
+                // set_mouth_sequence). cJSON_IsNumber is required because
+                // valueint silently returns 0 for non-number nodes (string,
+                // null, bool), so without the guard a payload like
+                // [["255",0,0]] would write black and report ok=true.
+                uint8_t buf[RGB_LED_COUNT * 2];   // 24 bytes, fits the cap
                 bool parse_ok = true;
-                int written = 0;
                 for (int i = 0; i < n; i++) {
                     cJSON* triple = cJSON_GetArrayItem(arr, i);
                     if (!cJSON_IsArray(triple) || cJSON_GetArraySize(triple) < 3) {
@@ -2493,29 +2502,34 @@ private:
                     cJSON* jr = cJSON_GetArrayItem(triple, 0);
                     cJSON* jg = cJSON_GetArrayItem(triple, 1);
                     cJSON* jb = cJSON_GetArrayItem(triple, 2);
-                    if (jr == nullptr || jg == nullptr || jb == nullptr) {
+                    if (!cJSON_IsNumber(jr) || !cJSON_IsNumber(jg) || !cJSON_IsNumber(jb)) {
                         parse_ok = false;
                         break;
                     }
-                    if (!io_expander_->SetLedColor((uint8_t)i,
-                                                   ClampByte(jr->valueint),
-                                                   ClampByte(jg->valueint),
-                                                   ClampByte(jb->valueint))) {
-                        parse_ok = false;
-                        break;
-                    }
-                    written++;
+                    PackRgb565(ClampByte(jr->valueint),
+                               ClampByte(jg->valueint),
+                               ClampByte(jb->valueint),
+                               &buf[i * 2]);
                 }
                 cJSON_Delete(arr);
-                bool ok_r = parse_ok ? io_expander_->RefreshLeds() : false;
-                cJSON_AddBoolToObject(root, "ok", parse_ok && ok_r);
-                cJSON_AddNumberToObject(root, "written", written);
+
+                // Single I2C burst for the validated prefix, then one latch.
+                // n=0 is treated as success (gateway schema enforces
+                // minItems=1, but a direct device caller could hit this).
+                bool ok_w = false, ok_r = false;
+                if (parse_ok && n > 0) {
+                    ok_w = io_expander_->SetLedData(buf, (size_t)(n * 2));
+                    ok_r = ok_w ? io_expander_->RefreshLeds() : false;
+                }
+                bool ok = parse_ok && (n == 0 || (ok_w && ok_r));
+                cJSON_AddBoolToObject(root, "ok", ok);
+                cJSON_AddNumberToObject(root, "written", ok ? n : 0);
                 if (!parse_ok) {
                     cJSON_AddStringToObject(root, "error",
                         "Each entry must be a [r,g,b] triple of integers");
                 }
                 ESP_LOGI(TAG, "set_many_leds: written=%d/%d ok=%d",
-                         written, n, parse_ok && ok_r);
+                         ok ? n : 0, n, ok);
                 return root;
             });
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -184,20 +184,21 @@ public:
         return true;
     }
 
-    // direction: false=input, true=output
+    // direction: false=input, true=output. Accepts pin 0..15 (PY32 has 14
+    // GPIOs; the WS2812 data line is on pin 13, in the high byte).
     bool SetDirection(uint8_t pin, bool output) {
-        return WriteBitSafe(REG_GPIO_M_L, pin, output);
+        return WriteBitWideSafe(REG_GPIO_M_L, REG_GPIO_M_H, pin, output);
     }
 
-    // mode: false=pull down, true=pull up
+    // mode: false=pull down, true=pull up. Accepts pin 0..15.
     bool SetPullMode(uint8_t pin, bool up) {
         if (up) {
-            bool a = WriteBitSafe(REG_GPIO_PD_L, pin, false);
-            bool b = WriteBitSafe(REG_GPIO_PU_L, pin, true);
+            bool a = WriteBitWideSafe(REG_GPIO_PD_L, REG_GPIO_PD_H, pin, false);
+            bool b = WriteBitWideSafe(REG_GPIO_PU_L, REG_GPIO_PU_H, pin, true);
             return a && b;
         } else {
-            bool a = WriteBitSafe(REG_GPIO_PU_L, pin, false);
-            bool b = WriteBitSafe(REG_GPIO_PD_L, pin, true);
+            bool a = WriteBitWideSafe(REG_GPIO_PU_L, REG_GPIO_PU_H, pin, false);
+            bool b = WriteBitWideSafe(REG_GPIO_PD_L, REG_GPIO_PD_H, pin, true);
             return a && b;
         }
     }
@@ -212,6 +213,55 @@ public:
         return SafeReadReg(REG_GPIO_O_L, out);
     }
 
+    // Drive mode for any pin (0..15). false=push-pull, true=open-drain.
+    // The WS2812 data line on pin 13 must be push-pull.
+    bool SetDriveMode(uint8_t pin, bool open_drain) {
+        return WriteBitWideSafe(REG_GPIO_DRV_L, REG_GPIO_DRV_H, pin, open_drain);
+    }
+
+    // ---- LED (WS2812 driven by the PY32 itself, data line on pin 13) ----
+    // REG_LED_CFG packs both the LED count (bits 0-5, max 32) and the latch
+    // trigger (bit 6). Writing the count clears bit 6, which is fine because
+    // it's a self-clearing strobe. RefreshLeds() does read-modify-write so
+    // the count is preserved when we latch.
+    bool SetLedCount(uint8_t count) {
+        if (count > 32) count = 32;
+        return SafeWriteReg(REG_LED_CFG, count & 0x3F);
+    }
+
+    // Set one LED to RGB888. RGB888 → RGB565 packing matches the M5 BSP:
+    // ((r&0xF8)<<8) | ((g&0xFC)<<3) | (b>>3), little-endian on the wire.
+    // Does NOT latch — call RefreshLeds() once after a batch of updates.
+    bool SetLedColor(uint8_t index, uint8_t r, uint8_t g, uint8_t b) {
+        if (index >= 32) return false;
+        uint16_t v = (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
+        uint8_t buf[3] = { (uint8_t)(REG_LED_RAM_START + index * 2),
+                           (uint8_t)(v & 0xFF),
+                           (uint8_t)((v >> 8) & 0xFF) };
+        return SafeWriteRaw(buf, sizeof(buf));
+    }
+
+    // Burst-write up to N LED RGB565 pairs starting at index 0. data is
+    // packed { lo0, hi0, lo1, hi1, ... } and len is the byte count
+    // (=2*num_leds, max 64). Single I2C transaction — much faster than
+    // calling SetLedColor in a loop. Does NOT latch.
+    bool SetLedData(const uint8_t* data, size_t len) {
+        if (data == nullptr || len == 0) return false;
+        if (len > 64) len = 64;
+        uint8_t buf[1 + 64];
+        buf[0] = REG_LED_RAM_START;
+        for (size_t i = 0; i < len; i++) buf[1 + i] = data[i];
+        return SafeWriteRaw(buf, 1 + len);
+    }
+
+    // Latch the LED RAM out to the WS2812 strip. Read-modify-write so the
+    // current count (bits 0-5) is preserved alongside the latch bit (bit 6).
+    bool RefreshLeds() {
+        uint8_t cfg = 0;
+        if (!SafeReadReg(REG_LED_CFG, &cfg)) return false;
+        return SafeWriteReg(REG_LED_CFG, (uint8_t)(cfg | (1u << 6)));
+    }
+
 private:
     // Owned device handle (NOT inherited from I2cDevice — see class comment).
     // Registered at 100 kHz in the constructor so this transport runs slower
@@ -220,9 +270,17 @@ private:
 
     static constexpr uint8_t REG_VERSION  = 0x02;
     static constexpr uint8_t REG_GPIO_M_L = 0x03;  // Direction (mode) low byte
+    static constexpr uint8_t REG_GPIO_M_H = 0x04;  // Direction (mode) high byte
     static constexpr uint8_t REG_GPIO_O_L = 0x05;  // Output low byte
+    static constexpr uint8_t REG_GPIO_O_H = 0x06;  // Output high byte
     static constexpr uint8_t REG_GPIO_PU_L = 0x09; // Pull-up low byte
+    static constexpr uint8_t REG_GPIO_PU_H = 0x0A; // Pull-up high byte
     static constexpr uint8_t REG_GPIO_PD_L = 0x0B; // Pull-down low byte
+    static constexpr uint8_t REG_GPIO_PD_H = 0x0C; // Pull-down high byte
+    static constexpr uint8_t REG_GPIO_DRV_L = 0x13; // Drive mode low byte
+    static constexpr uint8_t REG_GPIO_DRV_H = 0x14; // Drive mode high byte
+    static constexpr uint8_t REG_LED_CFG       = 0x24;  // count[5:0] + latch[6]
+    static constexpr uint8_t REG_LED_RAM_START = 0x30;  // 2 bytes per LED, RGB565 LE
 
     // I2C op transient-retry parameters. Total budget per failed op is
     // (I2C_INNER_RETRIES - 1) * I2C_RETRY_DELAY_MS, i.e. ~30 ms here.
@@ -281,6 +339,40 @@ private:
             v &= (uint8_t)~(1u << pin);
         }
         return SafeWriteReg(reg, v);
+    }
+
+    // 16-bit RMW: pin 0..7 -> reg_l, pin 8..15 -> reg_h. Used for any pin
+    // beyond pin 7 (LED data line is on pin 13, so all the LED setup goes
+    // through this path).
+    bool WriteBitWideSafe(uint8_t reg_l, uint8_t reg_h, uint8_t pin, bool value) {
+        if (pin >= 16) return false;
+        uint8_t reg = (pin < 8) ? reg_l : reg_h;
+        uint8_t bit = (uint8_t)(pin & 0x07);
+        uint8_t v = 0;
+        if (!SafeReadReg(reg, &v)) return false;
+        if (value) v |= (uint8_t)(1u << bit);
+        else       v &= (uint8_t)~(1u << bit);
+        return SafeWriteReg(reg, v);
+    }
+
+    // Burst write: ship a pre-built {reg, ...payload} buffer in a single
+    // i2c_master_transmit. Used by the LED RAM writes which would otherwise
+    // require dozens of individual register writes. Same retry semantics
+    // as SafeWriteReg.
+    bool SafeWriteRaw(const uint8_t* buf, size_t len) {
+        esp_err_t err = ESP_FAIL;
+        for (int i = 0; i < I2C_INNER_RETRIES; i++) {
+            err = i2c_master_transmit(i2c_device_, buf, len, 100);
+            if (err == ESP_OK) {
+                return true;
+            }
+            if (i + 1 < I2C_INNER_RETRIES) {
+                vTaskDelay(pdMS_TO_TICKS(I2C_RETRY_DELAY_MS));
+            }
+        }
+        ESP_LOGW("Py32IoExpander", "I2C raw write (len=%u) failed after %d tries: 0x%X",
+                 (unsigned)len, I2C_INNER_RETRIES, err);
+        return false;
     }
 };
 
@@ -729,6 +821,9 @@ private:
     }
 
     bool servo_ok_ = false;
+    bool rgb_ok_ = false;
+    static constexpr uint8_t RGB_LED_COUNT = 12;  // StackChan base has 12 WS2812C
+    static constexpr uint8_t RGB_DATA_PIN  = 13;  // PY32 expander pin (not ESP32 GPIO)
 
     void InitializeIOExpander() {
         ESP_LOGI(TAG, "Init PY32 IO expander (I2C addr 0x%02X)", Py32IoExpander::DEFAULT_ADDR);
@@ -799,6 +894,58 @@ private:
             ESP_LOGW(TAG, "Servo power writes OK, but readback verify failed "
                           "(can't confirm VM EN level)");
         }
+
+        // ---- RGB strip init (12x WS2812C on the StackChan base) ----
+        // The data line is on PY32 pin 13 (not an ESP32 GPIO); the PY32
+        // bit-bangs the WS2812 protocol itself. We just write RGB565 into
+        // its LED RAM and toggle the latch bit. Sequence is the same as the
+        // M5 BSP: configure pin 13 as push-pull output with pull-up,
+        // SetLedCount(12), small settle delay, then clear all LEDs.
+        bool ok_d   = io_expander_->SetDirection(RGB_DATA_PIN, true);
+        bool ok_p   = io_expander_->SetPullMode(RGB_DATA_PIN, true);
+        bool ok_dr  = io_expander_->SetDriveMode(RGB_DATA_PIN, false);
+        bool ok_cnt = io_expander_->SetLedCount(RGB_LED_COUNT);
+        if (!ok_d || !ok_p || !ok_dr || !ok_cnt) {
+            const char* failed = "?";
+            if      (!ok_d)   failed = "SetDirection(13)";
+            else if (!ok_p)   failed = "SetPullMode(13)";
+            else if (!ok_dr) failed = "SetDriveMode(13)";
+            else if (!ok_cnt) failed = "SetLedCount";
+            ESP_LOGE(TAG, "RGB strip init FAILED at step=%s; LEDs disabled", failed);
+            return;
+        }
+        // M5 reference firmware waits 200 ms after SetLedCount before the
+        // first refresh — the PY32 internal LED engine needs the settle.
+        vTaskDelay(pdMS_TO_TICKS(200));
+
+        // Clear strip: zero RAM in one burst, then latch.
+        uint8_t clear_buf[RGB_LED_COUNT * 2] = {0};
+        bool ok_clear = io_expander_->SetLedData(clear_buf, sizeof(clear_buf));
+        bool ok_ref   = io_expander_->RefreshLeds();
+        if (!ok_clear || !ok_ref) {
+            ESP_LOGE(TAG, "RGB strip clear FAILED (data=%d refresh=%d); LEDs disabled",
+                     ok_clear, ok_ref);
+            return;
+        }
+        rgb_ok_ = true;
+        ESP_LOGI(TAG, "RGB strip READY (%d WS2812C via PY32 pin %d, all cleared)",
+                 RGB_LED_COUNT, RGB_DATA_PIN);
+    }
+
+    // Helpers for the LED MCP tools below. Centralised so the parsing/
+    // clamping logic isn't duplicated in three handlers.
+    static uint8_t ClampByte(int v) {
+        if (v < 0) return 0;
+        if (v > 255) return 255;
+        return (uint8_t)v;
+    }
+
+    // Pack one RGB888 sample into the {lo, hi} RGB565 pair the PY32
+    // expects in its LED RAM.
+    static void PackRgb565(uint8_t r, uint8_t g, uint8_t b, uint8_t out[2]) {
+        uint16_t v = (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
+        out[0] = (uint8_t)(v & 0xFF);
+        out[1] = (uint8_t)((v >> 8) & 0xFF);
     }
 
     void InitializeServo() {
@@ -1843,6 +1990,159 @@ private:
                     if (age_ms < 0) age_ms = 0;
                 }
                 cJSON_AddNumberToObject(root, "last_event_age_ms", (double)age_ms);
+                return root;
+            });
+
+        // ---- LED tools (12x WS2812C on the StackChan base) ----
+        // The strip is driven by the PY32 IO expander on its pin 13, not by
+        // an ESP32 GPIO. Updates are non-latching writes into the PY32 LED
+        // RAM followed by a single RefreshLeds() to strobe the strip. All
+        // four tools refresh implicitly so the LLM gets WYSIWYG behaviour.
+        mcp_server.AddTool(
+            "self.led.set_color",
+            "Set a single RGB LED on the StackChan base. There are 12 LEDs "
+            "(index 0..11). r/g/b are 0..255. Updates immediately.",
+            PropertyList({
+                Property("index", kPropertyTypeInteger, 0, RGB_LED_COUNT - 1),
+                Property("r", kPropertyTypeInteger, 0, 255),
+                Property("g", kPropertyTypeInteger, 0, 255),
+                Property("b", kPropertyTypeInteger, 0, 255),
+            }),
+            [this](const PropertyList& properties) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", rgb_ok_);
+                if (!rgb_ok_) {
+                    cJSON_AddStringToObject(root, "error", "RGB strip not available (PY32 init failed?)");
+                    return root;
+                }
+                int index = properties["index"].value<int>();
+                uint8_t r = ClampByte(properties["r"].value<int>());
+                uint8_t g = ClampByte(properties["g"].value<int>());
+                uint8_t b = ClampByte(properties["b"].value<int>());
+                bool ok_w = io_expander_->SetLedColor((uint8_t)index, r, g, b);
+                bool ok_r = ok_w ? io_expander_->RefreshLeds() : false;
+                cJSON_AddBoolToObject(root, "ok", ok_w && ok_r);
+                cJSON_AddNumberToObject(root, "index", index);
+                ESP_LOGI(TAG, "set_led: index=%d rgb=(%u,%u,%u) ok=%d", index, r, g, b, ok_w && ok_r);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.led.set_all",
+            "Set all 12 RGB LEDs on the StackChan base to the same color. "
+            "r/g/b are 0..255. Updates immediately.",
+            PropertyList({
+                Property("r", kPropertyTypeInteger, 0, 255),
+                Property("g", kPropertyTypeInteger, 0, 255),
+                Property("b", kPropertyTypeInteger, 0, 255),
+            }),
+            [this](const PropertyList& properties) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", rgb_ok_);
+                if (!rgb_ok_) {
+                    cJSON_AddStringToObject(root, "error", "RGB strip not available (PY32 init failed?)");
+                    return root;
+                }
+                uint8_t r = ClampByte(properties["r"].value<int>());
+                uint8_t g = ClampByte(properties["g"].value<int>());
+                uint8_t b = ClampByte(properties["b"].value<int>());
+                uint8_t buf[RGB_LED_COUNT * 2];
+                uint8_t pair[2];
+                PackRgb565(r, g, b, pair);
+                for (int i = 0; i < RGB_LED_COUNT; i++) {
+                    buf[i * 2 + 0] = pair[0];
+                    buf[i * 2 + 1] = pair[1];
+                }
+                bool ok_w = io_expander_->SetLedData(buf, sizeof(buf));
+                bool ok_r = ok_w ? io_expander_->RefreshLeds() : false;
+                cJSON_AddBoolToObject(root, "ok", ok_w && ok_r);
+                ESP_LOGI(TAG, "set_all_leds: rgb=(%u,%u,%u) ok=%d", r, g, b, ok_w && ok_r);
+                return root;
+            });
+
+        // Batch set: accepts a JSON-encoded array of 12 [r,g,b] triples.
+        // Single I2C burst + one refresh — use this for animations or any
+        // multi-color pattern to avoid 12x round-trips. Missing trailing
+        // entries are left at their previous color (PY32 RAM is sticky).
+        mcp_server.AddTool(
+            "self.led.set_many",
+            "Set multiple RGB LEDs in one shot. 'colors' is a JSON-encoded "
+            "array of [r,g,b] triples starting at index 0, e.g. "
+            "\"[[255,0,0],[0,255,0],[0,0,255]]\". Up to 12 entries; extras "
+            "are ignored, missing entries keep their previous color. "
+            "r/g/b are 0..255. Updates immediately.",
+            PropertyList({Property("colors", kPropertyTypeString)}),
+            [this](const PropertyList& properties) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", rgb_ok_);
+                if (!rgb_ok_) {
+                    cJSON_AddStringToObject(root, "error", "RGB strip not available (PY32 init failed?)");
+                    return root;
+                }
+                std::string json = properties["colors"].value<std::string>();
+                cJSON* arr = cJSON_Parse(json.c_str());
+                if (arr == nullptr || !cJSON_IsArray(arr)) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error",
+                        "colors must be a JSON array of [r,g,b] triples");
+                    if (arr != nullptr) cJSON_Delete(arr);
+                    return root;
+                }
+                int n = cJSON_GetArraySize(arr);
+                if (n > RGB_LED_COUNT) n = RGB_LED_COUNT;
+                bool parse_ok = true;
+                int written = 0;
+                for (int i = 0; i < n; i++) {
+                    cJSON* triple = cJSON_GetArrayItem(arr, i);
+                    if (!cJSON_IsArray(triple) || cJSON_GetArraySize(triple) < 3) {
+                        parse_ok = false;
+                        break;
+                    }
+                    cJSON* jr = cJSON_GetArrayItem(triple, 0);
+                    cJSON* jg = cJSON_GetArrayItem(triple, 1);
+                    cJSON* jb = cJSON_GetArrayItem(triple, 2);
+                    if (jr == nullptr || jg == nullptr || jb == nullptr) {
+                        parse_ok = false;
+                        break;
+                    }
+                    if (!io_expander_->SetLedColor((uint8_t)i,
+                                                   ClampByte(jr->valueint),
+                                                   ClampByte(jg->valueint),
+                                                   ClampByte(jb->valueint))) {
+                        parse_ok = false;
+                        break;
+                    }
+                    written++;
+                }
+                cJSON_Delete(arr);
+                bool ok_r = parse_ok ? io_expander_->RefreshLeds() : false;
+                cJSON_AddBoolToObject(root, "ok", parse_ok && ok_r);
+                cJSON_AddNumberToObject(root, "written", written);
+                if (!parse_ok) {
+                    cJSON_AddStringToObject(root, "error",
+                        "Each entry must be a [r,g,b] triple of integers");
+                }
+                ESP_LOGI(TAG, "set_many_leds: written=%d/%d ok=%d",
+                         written, n, parse_ok && ok_r);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.led.clear",
+            "Turn off all 12 RGB LEDs on the StackChan base. Updates immediately.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", rgb_ok_);
+                if (!rgb_ok_) {
+                    cJSON_AddStringToObject(root, "error", "RGB strip not available (PY32 init failed?)");
+                    return root;
+                }
+                uint8_t buf[RGB_LED_COUNT * 2] = {0};
+                bool ok_w = io_expander_->SetLedData(buf, sizeof(buf));
+                bool ok_r = ok_w ? io_expander_->RefreshLeds() : false;
+                cJSON_AddBoolToObject(root, "ok", ok_w && ok_r);
+                ESP_LOGI(TAG, "clear_leds: ok=%d", ok_w && ok_r);
                 return root;
             });
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -227,6 +227,74 @@ def create_server() -> Server:
                     "properties": {},
                 },
             ),
+            Tool(
+                name="set_led",
+                description=(
+                    "Set a single RGB LED on the StackChan base. There are 12 LEDs "
+                    "arranged in two rows of 6 (index 0..11). Updates immediately."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "description": "LED index (0..11)",
+                            "minimum": 0,
+                            "maximum": 11,
+                        },
+                        "r": {"type": "integer", "description": "Red 0..255", "minimum": 0, "maximum": 255},
+                        "g": {"type": "integer", "description": "Green 0..255", "minimum": 0, "maximum": 255},
+                        "b": {"type": "integer", "description": "Blue 0..255", "minimum": 0, "maximum": 255},
+                    },
+                    "required": ["index", "r", "g", "b"],
+                },
+            ),
+            Tool(
+                name="set_all_leds",
+                description="Set all 12 RGB LEDs on the StackChan base to the same color. Updates immediately.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "r": {"type": "integer", "description": "Red 0..255", "minimum": 0, "maximum": 255},
+                        "g": {"type": "integer", "description": "Green 0..255", "minimum": 0, "maximum": 255},
+                        "b": {"type": "integer", "description": "Blue 0..255", "minimum": 0, "maximum": 255},
+                    },
+                    "required": ["r", "g", "b"],
+                },
+            ),
+            Tool(
+                name="set_leds",
+                description=(
+                    "Set multiple RGB LEDs in one shot. 'colors' is an array of "
+                    "[r,g,b] triples starting at index 0 (e.g. [[255,0,0],[0,255,0]]). "
+                    "Up to 12 entries; extras are ignored, missing entries keep their "
+                    "previous color. Use this for animations / patterns to avoid 12x "
+                    "I2C round-trips."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "colors": {
+                            "type": "array",
+                            "description": "Array of [r,g,b] triples, each 0..255",
+                            "items": {
+                                "type": "array",
+                                "items": {"type": "integer", "minimum": 0, "maximum": 255},
+                                "minItems": 3,
+                                "maxItems": 3,
+                            },
+                            "minItems": 1,
+                            "maxItems": 12,
+                        },
+                    },
+                    "required": ["colors"],
+                },
+            ),
+            Tool(
+                name="clear_leds",
+                description="Turn off all 12 RGB LEDs on the StackChan base.",
+                inputSchema={"type": "object", "properties": {}},
+            ),
         ]
 
     @server.call_tool()
@@ -300,6 +368,26 @@ def create_server() -> Server:
             ),
             "get_touch_state": (
                 "self.touch.get_touch_state",
+                {},
+            ),
+            "set_led": (
+                "self.led.set_color",
+                arguments,
+            ),
+            "set_all_leds": (
+                "self.led.set_all",
+                arguments,
+            ),
+            # Firmware accepts colors as a JSON-encoded string (the on-device
+            # MCP layer has no array property type), so re-pack the Python
+            # list here. The schema we exposed above still lets the LLM
+            # think in real arrays.
+            "set_leds": (
+                "self.led.set_many",
+                {"colors": json.dumps(arguments.get("colors", []))},
+            ),
+            "clear_leds": (
+                "self.led.clear",
                 {},
             ),
         }


### PR DESCRIPTION
## Summary

Note: this PR was created with help of Claude code.


Add MCP control of the 12× WS2812C RGB LEDs on the StackChan base.

The strip is wired to the **PY32L020 IO expander** on its pin 13 (not an
ESP32 GPIO), sharing the AW88298 / Si12T I2C bus that the firmware
already talks to for `VM_EN` (servo power) and head-touch. The firmware
extends the existing in-tree `Py32IoExpander` helper with the same LED
API the M5 BSP exposes — `SetDriveMode`, `SetLedCount`, `SetLedColor`
(RGB888 → RGB565 packing per `((r&0xF8)<<8)|((g&0xFC)<<3)|(b>>3)`),
`SetLedData` (single-burst write of all 12 RGB565 pairs), and
`RefreshLeds` (read-modify-write so the count nibble survives the
bit-6 latch trigger). `InitializeIOExpander` configures pin 13 as
push-pull output with pull-up after the existing VM_EN block, sets
count = 12, waits the M5-prescribed 200 ms before the first refresh,
and clears the strip. An `rgb_ok_` flag tracks init success so the
tools degrade with `available=false` instead of cascading errors when
the PY32 is unreachable.

Four new ESP32 MCP tools, each implicitly latching so updates are
WYSIWYG:

- `self.led.set_color {index, r, g, b}`
- `self.led.set_all {r, g, b}`
- `self.led.set_many {colors}` (JSON-encoded `[[r,g,b], ...]`)
- `self.led.clear`

Four matching gateway-side surfaces with clean names:

- `set_led(index, r, g, b)`
- `set_all_leds(r, g, b)`
- `set_leds(colors)` — accepts a real JSON array on the gateway side
  and re-packs as a JSON string for the device, since the on-device
  MCP property layer only supports scalar types
- `clear_leds()`

The batch tool exists so animations / multi-color patterns are one
I2C burst + one refresh instead of 12 round-trips.

`docs/architecture.md` tool-mapping table updated; `CHANGELOG.md`
gains an `Added` entry under `[Unreleased]`.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (84 passed)
- [x] gateway: `uv run ruff check .` (clean)
- [x] firmware: run all checks and 

### Hardware

- [x ] Device boots without crash
- [ x] Existing MCP tools still work where affected: `move_head`,
      `take_photo`, `set_volume`, `get_head_angles`
- [ x] Existing touch/servo behavior still works where affected: tap,
      stroke, wobble
- [ x] New behavior verified on real hardware: run `set_all_leds(255,0,0)`,
      `set_led(6, 0, 255, 0)`, `set_leds([[255,0,0],[0,255,0],[0,0,255]])`,
      `clear_leds()` and confirm the 12-LED base ring follows each
      command with no flicker on unrelated indices.
- [ x] Confirm `get_status` still reports the device as connected and
      the four new tools appear in the device's discovery list.

## Breaking changes

None. The four new tools are purely additive on both the gateway and
the device. Existing tool names and semantics are unchanged.

## Related issues

None — opening as a standalone enhancement.