### PR TITLE
feat(ci): add firmware-release workflow for pre-built binaries (#12)

### DIFF
--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -100,10 +100,14 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
+          # `actions/upload-artifact@v4` preserves the common-ancestor
+          # directory layout (here: `firmware/`), so the downloaded
+          # artifact under `dist/` keeps the `build/` and `releases/`
+          # subdirectories from the build job.
           files: |
-            dist/merged-binary.bin
-            dist/xiaozhi.bin
-            dist/v*_stackchan.zip
+            dist/build/merged-binary.bin
+            dist/build/xiaozhi.bin
+            dist/releases/v*_stackchan.zip
           body: |
             Pre-built firmware binaries for the M5Stack StackChan kit.
             Flash with `esptool.py` — no ESP-IDF / Docker setup needed.

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -1,0 +1,125 @@
+name: Firmware Release
+
+# Triggers:
+# - push:    tag `firmware-v*` → build + publish a GitHub Release with the
+#            firmware binaries attached as assets.
+# - manual:  workflow_dispatch → build-only smoke test (no publish). Useful
+#            for verifying the workflow itself or any change to it before
+#            cutting a real tag.
+on:
+  push:
+    tags:
+      - "firmware-v*"
+  workflow_dispatch:
+
+# Default permissions: nothing. Each job opts in to what it needs. The
+# release job is the only one that requires `contents: write`.
+permissions: {}
+
+# Only one run at a time per ref. Tag pushes never collide with each
+# other, but workflow_dispatch on the same branch can.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build firmware
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build firmware with ESP-IDF Docker image
+        # Same build command the regular CI Build workflow uses, so a
+        # tag-driven release artifact is byte-identical to what the PR
+        # checks already validate.
+        working-directory: firmware
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD":/project \
+            -w /project \
+            espressif/idf:v5.5.2 \
+            python ./scripts/release.py stackchan
+
+      - name: Verify firmware artifacts
+        # `merged-binary.bin` is the clean-install image (write at 0x0,
+        # resets NVS). `xiaozhi.bin` is the app-only image produced by
+        # `idf.py build` (write at 0x20000, preserves NVS / Wi-Fi). Both
+        # ship as release assets so end users and existing-device users
+        # can pick the right path. The zip is a convenience archive of
+        # `merged-binary.bin` named after the project version.
+        run: |
+          set -euo pipefail
+          test -f firmware/build/merged-binary.bin
+          test -f firmware/build/xiaozhi.bin
+          ls firmware/releases/v*_stackchan.zip
+
+      - name: Upload firmware artifacts
+        # Uploaded for both tag-push and workflow_dispatch so a manual
+        # run can still be inspected end-to-end. The release job below
+        # is the only step gated on the tag-push event.
+        uses: actions/upload-artifact@v4
+        with:
+          name: stackchan-firmware-${{ github.sha }}
+          retention-days: 14
+          path: |
+            firmware/build/merged-binary.bin
+            firmware/build/xiaozhi.bin
+            firmware/releases/v*_stackchan.zip
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    # Tag-only publish. workflow_dispatch invocations stop at the build
+    # job above, so manual runs cannot accidentally release. The
+    # `startsWith(...)` guard makes the intent explicit and survives
+    # future trigger additions.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/firmware-v')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: stackchan-firmware-${{ github.sha }}
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: |
+            dist/merged-binary.bin
+            dist/xiaozhi.bin
+            dist/v*_stackchan.zip
+          body: |
+            Pre-built firmware binaries for the M5Stack StackChan kit.
+            Flash with `esptool.py` — no ESP-IDF / Docker setup needed.
+
+            ### Quick flash (clean install — resets NVS / Wi-Fi config)
+
+            ```bash
+            esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+              write_flash 0x0 merged-binary.bin
+            ```
+
+            ### App-only update (preserves NVS — keeps your Wi-Fi setup)
+
+            ```bash
+            esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+              write_flash 0x20000 xiaozhi.bin
+            ```
+
+            See [README.md](https://github.com/kisaragi-mochi/stackchan-mcp/blob/main/README.md) / [README.ja.md](https://github.com/kisaragi-mochi/stackchan-mcp/blob/main/README.ja.md) for the full setup guide.

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,6 +64,26 @@
 
 ### 1. ファームウェア書き込み (CoreS3)
 
+書き込み方法は 2 通り。エンドユーザーには **オプション A**（事前ビルド済みバイナリ）が手早く、ツールチェーンのセットアップ不要。コントリビュータがソースからビルドしたい場合は **オプション B**。
+
+#### オプション A: 事前ビルド済みバイナリを焼く（エンドユーザー向け、推奨）
+
+[Releases ページ](https://github.com/kisaragi-mochi/stackchan-mcp/releases) から最新の `firmware-v*` リリースを開き、`merged-binary.bin`（必要なら `xiaozhi.bin` も）をダウンロード。あとは `esptool.py` で焼くだけ:
+
+```bash
+# 新規インストール（NVS が消えるので Wi-Fi 設定はやり直し）:
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+  write_flash 0x0 merged-binary.bin
+
+# アプリだけ更新（NVS 保持 — Wi-Fi 設定そのまま）:
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+  write_flash 0x20000 xiaozhi.bin
+```
+
+ESP-IDF や Docker のセットアップは不要。
+
+#### オプション B: ソースから Docker でビルド（コントリビュータ向け）
+
 ```bash
 cd firmware
 docker run --rm -v $PWD:/project -w /project espressif/idf:v5.5.2 \
@@ -75,7 +95,7 @@ esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 build/merged-binary.bin
 ```
 
-WiFi 設定は ESP32 が起動後にスマホで設定 UI に接続して行う (xiaozhi-esp32 標準フロー)。
+書き込み後、WiFi 設定は ESP32 が起動してから行う — スマホで設定 UI に接続（xiaozhi-esp32 標準フロー）。
 
 ### WebSocket gateway URL と認証トークンの設定
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ See `gateway/README.md` for full schemas.
 
 ### 1. Flash the firmware (CoreS3)
 
+There are two paths. **Option A** is recommended for first-time users — no toolchain setup needed. **Option B** is for contributors who want to build from source.
+
+#### Option A: Flash a pre-built binary (recommended for end users)
+
+Download the latest firmware bundle from the [Releases page](https://github.com/kisaragi-mochi/stackchan-mcp/releases) — pick the most recent `firmware-v*` release and grab `merged-binary.bin` (and optionally `xiaozhi.bin`). Then flash with `esptool.py`:
+
+```bash
+# Clean install (resets NVS — Wi-Fi settings will need to be re-entered):
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+  write_flash 0x0 merged-binary.bin
+
+# Or, app-only update (preserves NVS — keeps your Wi-Fi setup):
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
+  write_flash 0x20000 xiaozhi.bin
+```
+
+No ESP-IDF or Docker setup needed.
+
+#### Option B: Build from source with Docker (for contributors)
+
 ```bash
 cd firmware
 docker run --rm -v $PWD:/project -w /project espressif/idf:v5.5.2 \
@@ -75,7 +95,7 @@ esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 build/merged-binary.bin
 ```
 
-WiFi configuration happens after the ESP32 boots — connect from a smartphone to its setup UI (the xiaozhi-esp32 standard flow).
+After flashing, WiFi configuration happens on first boot — connect from a smartphone to the setup UI (the xiaozhi-esp32 standard flow).
 
 ### Configuring the WebSocket gateway URL and auth token
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the StackChan firmware via the same `espressif/idf:v5.5.2` path the regular Build workflow uses, and publishes `merged-binary.bin` + `xiaozhi.bin` as release assets on `firmware-v*` tag push. End users can flash without setting up ESP-IDF / Docker.

- Build path matches the regular CI Build workflow (byte-identical artifacts).
- Both clean-install (`merged-binary.bin` at `0x0`, NVS reset) and app-only update (`xiaozhi.bin` at `0x20000`, NVS-preserving) binaries ship as separate assets so first-time users and existing-device users can both flash in one step.
- `workflow_dispatch` runs the build job only (no publish), so the workflow itself can be smoke-tested before cutting a real tag.
- README.md / README.ja.md add an "Option A: pre-built binary" path alongside the existing "Option B: build from source" instructions.

## Test plan

### Code-level

- [ ] gateway: `uv run pytest` — _N/A, no gateway changes_
- [ ] gateway: `uv run ruff check .` — _N/A, no gateway changes_
- [ ] firmware: `python ./scripts/release.py stackchan` — _N/A, no firmware code changes_
- [x] Not applicable / not run: workflow-only change. The build path inside the new workflow is identical to the existing `build.yml` `firmware-build` job, which CI already exercises on every PR.

### Hardware

- [x] Not applicable / hardware not available: This PR does not change firmware code or any artifact contents. The first hardware-level validation happens the first time a `firmware-v*` tag is cut and the resulting `merged-binary.bin` is flashed; that flash path is identical to today's build-from-source flow.

### Workflow validation (post-merge)

After merge, verify the workflow itself by:
1. Running `workflow_dispatch` from the Actions tab on \`main\` → \`build\` job succeeds, artifact \`stackchan-firmware-<sha>\` uploaded.
2. Cutting the first tag (e.g. \`firmware-v1.0.0\`) and pushing → \`release\` job runs, GitHub Release page shows \`merged-binary.bin\`, \`xiaozhi.bin\`, and \`v*_stackchan.zip\` attached.

## Breaking changes

None.

## Related issues

Closes #12