### PR TITLE
docs(readme): add LED tools to README tool tables

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,6 +57,10 @@
 | `set_mouth(state)` | 口開閉（one-shot、次の呼び出しまで保持） | ✅ |
 | `set_mouth_sequence(steps)` | TTS リップシンク用に `{shape, duration_ms}` のリストをデバイス側でキュー再生（ステップごとの WebSocket RTT ゆらぎなし） | ✅ |
 | `check_vm_en` | サーボ電源 (VM EN HIGH) 状態確認 | ✅ |
+| `set_led(index, r, g, b)` | ベース部の RGB LED 12 個のうち 1 個を指定 (index `0..11`、各チャネル `0..255`) | ✅ |
+| `set_all_leds(r, g, b)` | ベース部の RGB LED 12 個すべてを同じ色に設定 | ✅ |
+| `set_leds(colors)` | `[[r,g,b], ...]` 配列で先頭 N 個を一括設定（I2C 1 回のバースト送信、アニメーション等向け）。指定外の LED は前の色を保持 | ✅ |
+| `clear_leds` | ベース部の RGB LED 12 個すべて消灯 | ✅ |
 
 詳細スキーマは `gateway/README.md` 参照。
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ This repository is a monorepo.
 | `set_mouth(state)` | Mouth open/close (one-shot, held until next call) | ✅ |
 | `set_mouth_sequence(steps)` | Queue and play a list of `{shape, duration_ms}` steps locally for TTS lip-sync — no per-step WebSocket RTT jitter | ✅ |
 | `check_vm_en` | Check servo power supply (VM EN HIGH) state | ✅ |
+| `set_led(index, r, g, b)` | Set one of the 12 base RGB LEDs (index `0..11`, channels `0..255`) | ✅ |
+| `set_all_leds(r, g, b)` | Set all 12 base RGB LEDs to the same color | ✅ |
+| `set_leds(colors)` | Batch-set the first N LEDs from a `[[r,g,b], ...]` array in a single I2C burst (use this for animations / multi-color patterns); trailing LEDs keep their previous color | ✅ |
+| `clear_leds` | Turn all 12 base RGB LEDs off | ✅ |
 
 See `gateway/README.md` for full schemas.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -160,6 +160,16 @@ Same shape, under `mcpServers`.
 | `set_mouth(state)` | Mouth shape (`closed` / `half` / `open` / `e` / `u`), one-shot, held until next call |
 | `set_mouth_sequence(steps)` | Queue and play a list of `{shape, duration_ms}` steps locally for TTS lip-sync. The firmware walks the queue without per-step network RTT. Calling `set_mouth`, `set_avatar`, or this tool again interrupts the in-flight sequence; autonomous blink is paused while a sequence is playing. |
 | `check_vm_en` | Read PY32 VM EN GPIO state (servo power supply diagnostic) |
+| `set_led(index, r, g, b)` | Set one of the 12 base RGB LEDs by index (`0..11`); channels `0..255`. Updates immediately. |
+| `set_all_leds(r, g, b)` | Set all 12 base RGB LEDs to the same color. Updates immediately. |
+| `set_leds(colors)` | Batch-set the first N LEDs from a `[[r,g,b], ...]` array (1..12 entries). Single I2C burst + one latch — use this for animations / multi-color patterns instead of N individual `set_led` calls. Trailing LEDs (beyond `len(colors)`) keep their previous color. Validation is atomic: a malformed entry rejects the whole call without mutating any LED. |
+| `clear_leds` | Turn all 12 base RGB LEDs off. |
+
+The 12 base LEDs are 12× WS2812C wired to the PY32L020 IO expander
+(expander pin 13, not an ESP32 GPIO), so all four LED tools share the
+PY32 I2C bus with the servo-power and Si12T touch paths. If the PY32
+init fails at boot, the LED tools degrade with `available=false`
+instead of cascading errors.
 
 The mapping from these names to ESP32-side `self.*` MCP tools is in
 `stackchan_mcp/stdio_server.py`.


### PR DESCRIPTION
## Summary

Follow-up to #68. The four LED tools landed on `main` and are
documented in `docs/architecture.md` and `CHANGELOG.md`, but the
user-facing tool tables in the three READMEs were not updated. This
PR adds matching rows so the LEDs show up alongside the other tools
in the entry-point docs.

- `README.md` (English root) — 4 rows added at the end of the table
- `README.ja.md` (Japanese root) — 4 matching rows, kept in sync per
  CONTRIBUTING.md's "top-level user guide is maintained in both
  English and Japanese" rule
- `gateway/README.md` — 4 rows plus a short note that all four LEDs
  share the PY32 I2C bus and degrade with `available=false` when
  the expander init fails (this file is the per-tool detail
  reference, so it gets the longer descriptions; the `set_leds`
  entry calls out the single-burst + atomic-validation properties)

No code changes.

## Test plan

### Code-level

- [ ] gateway: `uv run pytest` — not run (no behavior change)
- [ ] gateway: `uv run ruff check .` — not run (no Python files
      changed)
- [ ] firmware: `python ./scripts/release.py stackchan` — not
      applicable (docs only)
- [x] Not applicable / not run: docs-only PR, no code changes

### Hardware

- [x] Not applicable / hardware not available: docs-only change

## Breaking changes

None.

## Related issues

Refs #68.