### PR TITLE
feat(tts): add Phase 4 say() framework (#70 PR1)

### DIFF
--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -15,6 +15,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from .gateway import get_gateway
+from .tts import synthesize_and_send
 
 logger = logging.getLogger(__name__)
 
@@ -359,6 +360,54 @@ def create_server() -> Server:
                 description="Turn off all 12 RGB LEDs on the StackChan base.",
                 inputSchema={"type": "object", "properties": {}},
             ),
+            Tool(
+                name="say",
+                description=(
+                    "Speak the given text on the device speaker via gateway-side "
+                    "TTS (Phase 4, Issue #70). The gateway synthesises audio, "
+                    "encodes it to Opus, and pushes frames over the existing "
+                    "WebSocket — the device firmware does not change. Engine is "
+                    "selectable via 'voice' (default 'voicevox'). "
+                    "NOTE: this build ships the framework only; concrete engines "
+                    "(VOICEVOX, Irodori) land in follow-up PRs and require the "
+                    "matching optional extra (e.g. "
+                    "'pip install stackchan-mcp[tts-voicevox]'). Calling this tool "
+                    "before an engine is registered returns a clear error."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": "Text to speak. Must be non-empty.",
+                        },
+                        "voice": {
+                            "type": "string",
+                            "description": (
+                                "Engine identifier (e.g. 'voicevox', 'irodori'). "
+                                "Default 'voicevox'."
+                            ),
+                            "default": "voicevox",
+                        },
+                        "speaker_id": {
+                            "type": "integer",
+                            "description": (
+                                "Engine-specific speaker identifier "
+                                "(e.g. a VOICEVOX speaker ID)."
+                            ),
+                        },
+                        "reference_audio": {
+                            "type": "string",
+                            "description": (
+                                "Path to a reference audio file used by "
+                                "voice-cloning engines (e.g. Irodori). "
+                                "Ignored by engines that do not support it."
+                            ),
+                        },
+                    },
+                    "required": ["text"],
+                },
+            ),
         ]
 
     @server.call_tool()
@@ -371,6 +420,29 @@ def create_server() -> Server:
             # get_status is handled locally — no ESP32 needed
             status = gw.esp32.get_status()
             return [TextContent(type="text", text=json.dumps(status, indent=2))]
+
+        if name == "say":
+            # TTS runs on the gateway side. Engine concrete implementations
+            # land in follow-up PRs of Issue #70; until then the orchestrator
+            # raises NotImplementedError, which we surface as a clean error
+            # rather than a stack trace.
+            try:
+                result = await synthesize_and_send(arguments)
+            except ValueError as exc:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"error": str(exc)}),
+                    )
+                ]
+            except NotImplementedError as exc:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"error": str(exc)}),
+                    )
+                ]
+            return [TextContent(type="text", text=json.dumps(result))]
 
         if not gw.esp32.device_connected:
             return [

--- a/gateway/stackchan_mcp/tts/__init__.py
+++ b/gateway/stackchan_mcp/tts/__init__.py
@@ -1,0 +1,24 @@
+"""TTS framework for Phase 4 (Issue #70).
+
+This package provides the engine-agnostic skeleton for the gateway-side
+``say(text)`` MCP tool. Concrete engine implementations land in follow-up
+PRs:
+
+- ``voicevox.py`` — VOICEVOX HTTP API (PR2)
+- ``irodori.py`` — Irodori-TTS-500M voice cloning (PR3)
+
+The framework here only exposes the abstract :class:`TTSEngine`, an
+:class:`EngineRegistry`, and :func:`synthesize_and_send` — the orchestrator
+that the ``say`` tool will call once at least one engine is registered.
+"""
+
+from .base import EngineRegistry, TTSEngine, get_registry
+from .orchestrator import DEFAULT_VOICE, synthesize_and_send
+
+__all__ = [
+    "DEFAULT_VOICE",
+    "EngineRegistry",
+    "TTSEngine",
+    "get_registry",
+    "synthesize_and_send",
+]

--- a/gateway/stackchan_mcp/tts/base.py
+++ b/gateway/stackchan_mcp/tts/base.py
@@ -1,0 +1,86 @@
+"""TTS engine abstraction.
+
+Each concrete engine produces 16 kHz mono PCM bytes from input text.
+Opus encoding for transmission to the device, and the WebSocket push,
+are handled by :mod:`stackchan_mcp.tts.orchestrator` so engines stay
+focused on synthesis.
+
+This module is intentionally dependency-free: it must import cleanly
+without ``httpx`` / ``opuslib`` / ``torch`` so that callers can introspect
+the registered engines (e.g. for ``get_status``) even when the optional
+``[tts]`` / ``[tts-irodori]`` extras are not installed.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class TTSEngine(ABC):
+    """Abstract base for TTS engines.
+
+    Subclasses must set :attr:`name` to a stable identifier (matched
+    against the ``voice`` argument of the ``say`` MCP tool) and implement
+    :meth:`synthesize`.
+    """
+
+    #: Stable identifier used to look this engine up in the registry.
+    #: Concrete subclasses must override with a non-empty string.
+    name: str = ""
+
+    @abstractmethod
+    async def synthesize(self, text: str, **opts: Any) -> bytes:
+        """Synthesise ``text`` into 16 kHz mono PCM (signed 16-bit LE).
+
+        Args:
+            text: Text to synthesise. Implementations should reject
+                empty strings.
+            **opts: Engine-specific options (e.g. ``speaker_id`` for
+                VOICEVOX, ``reference_audio`` for Irodori). Engines
+                should ignore unknown options rather than raise, so that
+                the ``say`` tool can pass a uniform argument set.
+
+        Returns:
+            Raw PCM bytes at 16 kHz, mono, signed 16-bit little-endian.
+            The orchestrator handles Opus encoding and frame chunking
+            before pushing to the device.
+        """
+
+
+class EngineRegistry:
+    """Tracks available TTS engines by name.
+
+    Concrete engines register themselves at import time when their
+    optional dependencies are satisfied (see
+    :mod:`stackchan_mcp.tts.voicevox` and friends in follow-up PRs).
+    """
+
+    def __init__(self) -> None:
+        self._engines: dict[str, TTSEngine] = {}
+
+    def register(self, engine: TTSEngine) -> None:
+        """Register ``engine`` under ``engine.name``.
+
+        Replaces any previously registered engine with the same name —
+        this is intentional so tests can inject fakes.
+        """
+        if not engine.name:
+            raise ValueError("TTSEngine.name must be a non-empty string")
+        self._engines[engine.name] = engine
+
+    def get(self, name: str) -> TTSEngine | None:
+        """Return the engine registered under ``name``, or ``None``."""
+        return self._engines.get(name)
+
+    def names(self) -> list[str]:
+        """Return all registered engine names, sorted alphabetically."""
+        return sorted(self._engines.keys())
+
+
+_default_registry = EngineRegistry()
+
+
+def get_registry() -> EngineRegistry:
+    """Return the process-wide default :class:`EngineRegistry`."""
+    return _default_registry

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -1,0 +1,107 @@
+"""TTS orchestration: pick an engine, synthesise, encode, and push.
+
+The orchestrator is the glue between the ``say`` MCP tool (defined in
+:mod:`stackchan_mcp.stdio_server`) and the concrete engines that arrive
+in follow-up PRs of Issue #70.
+
+PR1 (Issue #70) lands this skeleton only: calling
+:func:`synthesize_and_send` succeeds at the validation stage but raises
+``NotImplementedError`` once it would need to drive a real engine. The
+intent is to nail down the public surface — argument names, validation
+errors, and the return shape — so that PR2 (VOICEVOX) and PR3 (Irodori)
+only have to wire engines into the registry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .base import EngineRegistry, get_registry
+
+logger = logging.getLogger(__name__)
+
+
+#: Default engine name when ``voice`` is omitted from the tool call.
+#: VOICEVOX is the planned default (Issue #70); the concrete engine
+#: arrives in PR2.
+DEFAULT_VOICE = "voicevox"
+
+
+async def synthesize_and_send(
+    arguments: dict[str, Any],
+    *,
+    registry: EngineRegistry | None = None,
+) -> dict[str, Any]:
+    """Synthesise text via a registered engine and (eventually) push to device.
+
+    Args:
+        arguments: MCP tool arguments. Recognised keys:
+
+            * ``text`` (required): non-empty string to speak.
+            * ``voice``: engine name; defaults to :data:`DEFAULT_VOICE`.
+            * ``speaker_id``: engine-specific speaker identifier
+              (e.g. VOICEVOX speaker).
+            * ``reference_audio``: path to a reference audio sample
+              (e.g. for Irodori voice cloning).
+
+        registry: Engine registry to look up ``voice`` in. Defaults to
+            the process-wide registry. Tests inject a fresh registry
+            here to avoid leaking state.
+
+    Returns:
+        A dict describing the synthesis once concrete engines are wired
+        up. PR1 never reaches that path.
+
+    Raises:
+        ValueError: if ``text`` is missing or empty.
+        NotImplementedError: until a matching engine is registered.
+            The message lists the registered engine names so callers
+            can tell whether they need to install an extra (e.g.
+            ``pip install stackchan-mcp[tts-voicevox]``) or pass a
+            different ``voice``.
+    """
+    text = arguments.get("text", "")
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("'text' is required and must be a non-empty string")
+
+    voice_raw = arguments.get("voice", DEFAULT_VOICE)
+    voice = voice_raw if isinstance(voice_raw, str) and voice_raw else DEFAULT_VOICE
+
+    reg = registry if registry is not None else get_registry()
+    engine = reg.get(voice)
+
+    if engine is None:
+        available = reg.names()
+        raise NotImplementedError(
+            f"TTS engine '{voice}' is not registered. "
+            f"Available engines: {available or '(none)'}. "
+            "Concrete engines (VOICEVOX, Irodori) land in follow-up PRs "
+            "of Issue #70; install the relevant extra "
+            "(e.g. 'pip install stackchan-mcp[tts-voicevox]') once the "
+            "PR is merged."
+        )
+
+    # The pipeline below is the contract that follow-up PRs must
+    # satisfy. PR1 stops short of executing it so that merging the
+    # skeleton does not appear to "almost work".
+    #
+    #   pcm = await engine.synthesize(
+    #       text,
+    #       speaker_id=arguments.get("speaker_id"),
+    #       reference_audio=arguments.get("reference_audio"),
+    #   )
+    #   opus_frames = encode_opus_16k_mono(pcm)
+    #   for frame in opus_frames:
+    #       await gateway.esp32.send_audio_frame(frame)
+    #   return {
+    #       "engine": voice,
+    #       "text": text,
+    #       "frame_count": len(opus_frames),
+    #       "duration_ms": ...,
+    #   }
+    raise NotImplementedError(
+        "TTS orchestration pipeline (PCM synthesis, Opus encoding, "
+        "WebSocket push) is not wired up yet. PR1 ships the framework "
+        "only; engine implementations land in follow-up PRs of Issue #70."
+    )

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -6,6 +6,7 @@ import pytest
 from mcp.types import CallToolRequest, ListToolsRequest
 
 from stackchan_mcp.stdio_server import create_server
+from stackchan_mcp.tts import get_registry
 
 
 def test_create_server():
@@ -94,6 +95,104 @@ async def test_list_tools_includes_set_mouth_sequence():
     assert item_schema["properties"]["duration_ms"]["minimum"] == 10
     assert item_schema["properties"]["duration_ms"]["maximum"] == 10000
     assert set(item_schema["required"]) == {"shape", "duration_ms"}
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_say():
+    """say is exposed to MCP clients with text required."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tool = next((t for t in result.root.tools if t.name == "say"), None)
+    assert tool is not None, "say tool should be registered"
+
+    schema = tool.inputSchema
+    assert schema["properties"]["text"]["type"] == "string"
+    assert "voice" in schema["properties"]
+    assert "speaker_id" in schema["properties"]
+    assert "reference_audio" in schema["properties"]
+    assert schema["required"] == ["text"]
+
+
+@pytest.mark.asyncio
+async def test_say_returns_clean_error_when_no_engine_registered():
+    """say without a registered engine surfaces NotImplementedError as JSON.
+
+    The default registry has no engines in PR1, so we don't even need a
+    fake gateway: the say handler short-circuits before touching ESP32.
+    """
+    # Sanity-check the assumption: default registry must be empty here so
+    # the test reflects PR1's published surface.
+    assert get_registry().names() == []
+
+    server = create_server()
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "say", "arguments": {"text": "hello"}},
+        )
+    )
+
+    payload = json.loads(result.root.content[0].text)
+    assert "error" in payload
+    assert "voicevox" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_say_rejects_empty_text_with_clean_error():
+    """say with empty text returns a clean ValueError-shaped error."""
+    server = create_server()
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "say", "arguments": {"text": ""}},
+        )
+    )
+
+    payload = json.loads(result.root.content[0].text)
+    assert "error" in payload
+    assert "text" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_say_runs_without_esp32_connection(monkeypatch):
+    """say does not require an ESP32 device to surface its 'no engine' error.
+
+    Phase 4 PR1 ships the framework only; the say handler needs to give a
+    useful error before any concrete engine is wired up, even when no
+    device is connected. This guards against accidentally moving the
+    handler below the device_connected gate during refactors.
+    """
+
+    class FakeESP32:
+        device_connected = False
+
+        def get_status(self):
+            return {"connected": False}
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "say", "arguments": {"text": "hello"}},
+        )
+    )
+
+    payload = json.loads(result.root.content[0].text)
+    # Should be the engine-not-registered error, not the
+    # device_connected guard's "No ESP32 device connected" error.
+    assert "error" in payload
+    assert "engine" in payload["error"].lower()
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_tts_framework.py
+++ b/gateway/tests/test_tts_framework.py
@@ -1,0 +1,168 @@
+"""Tests for the TTS framework skeleton (Issue #70 PR1).
+
+Concrete engine implementations land in follow-up PRs; here we only
+exercise the abstract base, the registry, and the orchestrator's
+validation / error surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stackchan_mcp.tts import (
+    DEFAULT_VOICE,
+    EngineRegistry,
+    TTSEngine,
+    get_registry,
+    synthesize_and_send,
+)
+
+
+class _FakeEngine(TTSEngine):
+    """Minimal in-test engine used to exercise registry behaviour."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def synthesize(self, text: str, **opts: object) -> bytes:
+        self.calls.append((text, dict(opts)))
+        return b""
+
+
+def test_tts_engine_is_abstract():
+    """TTSEngine cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        TTSEngine()  # type: ignore[abstract]
+
+
+def test_registry_rejects_engine_with_empty_name():
+    """Registering an engine without a name is a programmer error."""
+    reg = EngineRegistry()
+    engine = _FakeEngine(name="")
+    with pytest.raises(ValueError):
+        reg.register(engine)
+
+
+def test_registry_register_get_names_roundtrip():
+    """register/get/names form a consistent set."""
+    reg = EngineRegistry()
+    engine = _FakeEngine(name="voicevox")
+
+    reg.register(engine)
+
+    assert reg.get("voicevox") is engine
+    assert reg.get("nonexistent") is None
+    assert reg.names() == ["voicevox"]
+
+
+def test_registry_register_replaces_same_name():
+    """Re-registering the same name swaps the engine — useful for tests."""
+    reg = EngineRegistry()
+    first = _FakeEngine(name="voicevox")
+    second = _FakeEngine(name="voicevox")
+
+    reg.register(first)
+    reg.register(second)
+
+    assert reg.get("voicevox") is second
+    assert reg.names() == ["voicevox"]
+
+
+def test_registry_names_are_sorted():
+    """names() is sorted so callers (e.g. error messages) get a stable order."""
+    reg = EngineRegistry()
+    reg.register(_FakeEngine(name="zeta"))
+    reg.register(_FakeEngine(name="alpha"))
+    reg.register(_FakeEngine(name="mu"))
+
+    assert reg.names() == ["alpha", "mu", "zeta"]
+
+
+def test_get_registry_returns_singleton():
+    """The default registry is process-wide (a singleton)."""
+    assert get_registry() is get_registry()
+
+
+def test_default_voice_constant():
+    """The default voice is the planned VOICEVOX engine."""
+    assert DEFAULT_VOICE == "voicevox"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_rejects_missing_text():
+    """No text -> ValueError before any engine lookup."""
+    reg = EngineRegistry()
+    with pytest.raises(ValueError, match="text"):
+        await synthesize_and_send({}, registry=reg)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_rejects_empty_text():
+    """Whitespace-only text is rejected the same as empty."""
+    reg = EngineRegistry()
+    with pytest.raises(ValueError, match="text"):
+        await synthesize_and_send({"text": "   "}, registry=reg)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_rejects_non_string_text():
+    """Non-string text -> ValueError (defensive against bad MCP clients)."""
+    reg = EngineRegistry()
+    with pytest.raises(ValueError, match="text"):
+        await synthesize_and_send({"text": 42}, registry=reg)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_unregistered_voice_raises():
+    """Unregistered voice -> NotImplementedError, listing what's available."""
+    reg = EngineRegistry()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send({"text": "hello"}, registry=reg)
+
+    msg = str(exc_info.value)
+    assert "voicevox" in msg
+    assert "(none)" in msg
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_registered_voice_raises_pipeline_not_wired():
+    """Even with an engine present, PR1 stops short of running the pipeline."""
+    reg = EngineRegistry()
+    reg.register(_FakeEngine(name="voicevox"))
+
+    with pytest.raises(NotImplementedError, match="pipeline"):
+        await synthesize_and_send({"text": "hello"}, registry=reg)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_voice_default_falls_back():
+    """Empty/missing 'voice' falls back to DEFAULT_VOICE."""
+    reg = EngineRegistry()
+
+    # Empty string voice -> default
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send({"text": "hello", "voice": ""}, registry=reg)
+    assert DEFAULT_VOICE in str(exc_info.value)
+
+    # Non-string voice -> default (not a TypeError)
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send({"text": "hello", "voice": 123}, registry=reg)
+    assert DEFAULT_VOICE in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_lists_available_engines_in_error():
+    """Error message names what *is* registered so callers can pick correctly."""
+    reg = EngineRegistry()
+    reg.register(_FakeEngine(name="alpha"))
+    reg.register(_FakeEngine(name="beta"))
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send(
+            {"text": "hello", "voice": "voicevox"}, registry=reg
+        )
+
+    msg = str(exc_info.value)
+    assert "alpha" in msg
+    assert "beta" in msg


### PR DESCRIPTION
## Summary

Land the gateway-side TTS skeleton for Phase 4 (Issue #70) so concrete engines can be reviewed in isolation:

- `gateway/stackchan_mcp/tts/`: `TTSEngine` ABC, `EngineRegistry`, and the `synthesize_and_send` orchestrator. Validates `text` / `voice` and raises `NotImplementedError` (listing registered engines) until a concrete engine is wired up.
- `gateway/stackchan_mcp/stdio_server.py`: register the `say` MCP tool and route it to the orchestrator before the `device_connected` gate, so the error surface stays useful even with no ESP32 attached.
- `gateway/tests/test_tts_framework.py` + additions to `gateway/tests/test_stdio_server.py`: 18 new tests covering the abstract base, the registry, the orchestrator validation, and the `say` tool wiring.

The intended PR stack for Issue #70:

- **PR1 (this one)** — framework only. No new runtime dependencies, no extras.
- PR2 — VOICEVOX engine + `[tts]` / `[tts-voicevox]` extras (httpx, opuslib). Wires `audio_stream.send_audio_frame` to push Opus frames over the existing device WebSocket.
- PR3 — Irodori-TTS engine + `[tts-irodori]` extra (torch, transformers).

## Why slice it this way

Issue #70 covers a fairly large surface (engine abstraction, two concrete engines, Opus encoding, WebSocket push). Reviewing all of that in one PR would mix architectural decisions with engine-specific dependency choices. Landing the skeleton first lets the registry / orchestrator API stabilise before either engine PR proposes a concrete pipeline implementation.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` — 104 passed (18 new for the framework)
- [x] gateway: `uv run ruff check .` — All checks passed
- [x] No new runtime dependencies added; the `[tts]` extras family lands alongside the engines that actually need them
- [x] Local pre-PR review (codex) — no findings

### Hardware

- [x] Not applicable / hardware not available: PR1 is framework-only and never reaches the device. The `say` tool returns a clean error JSON when called with no engine registered, which is the published behaviour for this build.

## Breaking changes

None. `say` is a brand-new tool; existing tools are unchanged.

## Related issues

Refs #70 (Phase 4 parent — STT half remains in #8)