### PR TITLE
feat(tts): add VOICEVOX engine + Opus pipeline (#70 PR2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,15 +54,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install libopus
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libopus0 libopus-dev
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
           enable-cache: true
 
-      - name: Install gateway dependencies
+      - name: Install gateway dependencies (with TTS extras)
         working-directory: gateway
-        run: uv sync --frozen
+        run: uv sync --frozen --extra tts
 
       - name: Run ruff
         working-directory: gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Added
 
+- Phase 4 TTS — gateway-side `say(text, voice?, speaker_id?,
+  reference_audio?)` MCP tool. The gateway synthesises speech via a
+  registered TTS engine, encodes the result to Opus (16 kHz mono,
+  60 ms frames), and pushes the frames to the device over the existing
+  WebSocket binary channel. **No firmware changes are required**: the
+  device's WebSocket protocol already accepts Opus payloads as binary
+  frames. The default engine is **VOICEVOX**, which runs as a separate
+  HTTP service (the official `voicevox/voicevox_engine` Docker image is
+  the recommended setup), so VOICEVOX's LGPL-3.0 license stays scoped
+  to the engine process and does not affect the gateway. Install with
+  `pip install stackchan-mcp[tts]` (adds `httpx` and `opuslib`); the
+  `[tts-voicevox]` extra is provided as an intent-declaring alias.
+  Configure with `STACKCHAN_VOICEVOX_URL` (default
+  `http://127.0.0.1:50021`) and `STACKCHAN_VOICEVOX_DEFAULT_SPEAKER`
+  (default `3`, Zundamon normal). The framework is engine-agnostic
+  (`tts.TTSEngine` ABC + `tts.EngineRegistry`), so additional engines —
+  e.g. Irodori-TTS for zero-shot voice cloning — can be added in
+  follow-up PRs without touching the orchestration pipeline. Refs #70.
 - New MCP tools to drive the 12× WS2812C RGB LEDs on the StackChan
   base: `set_led(index, r, g, b)`, `set_all_leds(r, g, b)`,
   `set_leds(colors)` (batch, single I2C burst for animations), and

--- a/README.ja.md
+++ b/README.ja.md
@@ -61,6 +61,7 @@
 | `set_all_leds(r, g, b)` | ベース部の RGB LED 12 個すべてを同じ色に設定 | ✅ |
 | `set_leds(colors)` | `[[r,g,b], ...]` 配列で先頭 N 個を一括設定（I2C 1 回のバースト送信、アニメーション等向け）。指定外の LED は前の色を保持 | ✅ |
 | `clear_leds` | ベース部の RGB LED 12 個すべて消灯 | ✅ |
+| `say(text, voice?, speaker_id?, reference_audio?)` | gateway 側 TTS でデバイススピーカーから喋らせる。デフォルトエンジンは **VOICEVOX**（別 HTTP サービスとして起動 — [TTS セットアップ](#4-オプション-tts-セットアップ-voicevox) 参照）。`[tts]` extras が必要 | ✅ |
 
 詳細スキーマは `gateway/README.md` 参照。
 
@@ -264,6 +265,61 @@ callback 設定を [`docs/remote-access.md`](docs/remote-access.md) にまとめ
 ```
 
 詳細は `gateway/README.md` 参照。
+
+### 4. オプション: TTS セットアップ (VOICEVOX)
+
+デバイスを喋らせるには、`[tts]` extras をインストールして
+[VOICEVOX](https://voicevox.hiroshiba.jp/) エンジンを gateway と
+並行起動します。VOICEVOX は別 HTTP プロセスとして動くので、
+LGPL-3.0 ライセンスはそのプロセスの中だけで完結し、MIT
+ライセンスの gateway は HTTP リクエストを発行するだけです。
+
+#### エンジン起動 (Docker)
+
+```bash
+docker run --rm -p '127.0.0.1:50021:50021' \
+  voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+```
+
+デフォルトポートは 50021。短い発話なら CPU 版で十分。GPU 版も
+upstream に公開されています。
+
+#### TTS extras のインストール
+
+```bash
+pip install 'stackchan-mcp[tts]'
+# または等価:
+pip install 'stackchan-mcp[tts-voicevox]'
+```
+
+これで `httpx` (HTTP クライアント) と `opuslib` (Opus
+エンコーダバインディング) が入ります。エンコーダはシステム側に
+`libopus` が必要 — macOS なら `brew install opus`、Debian/Ubuntu
+なら `sudo apt-get install libopus0`。
+
+#### 設定 (任意)
+
+| 環境変数 | デフォルト | 補足 |
+|---|---|---|
+| `STACKCHAN_VOICEVOX_URL` | `http://127.0.0.1:50021` | VOICEVOX エンジンの URL |
+| `STACKCHAN_VOICEVOX_DEFAULT_SPEAKER` | `3` | デフォルト話者 ID（ずんだもん ノーマル）。他の話者は [VOICEVOX 公式](https://github.com/VOICEVOX/voicevox_engine) 参照 |
+
+#### 試す
+
+MCP クライアントから:
+
+```
+say(text="こんにちは、わたしはスタックチャンです")
+```
+
+gateway は VOICEVOX に POST → 返ってきた WAV をデコード →
+16 kHz mono にリサンプル → 60 ms の Opus フレームにエンコード →
+既存の WebSocket バイナリチャネルでデバイスへ送信、という流れで
+喋らせます。デバイスは受け取ったフレームを既存の音声デコーダで
+再生するだけなので、**ファームウェア側の変更は不要**です。
+TTS フレームワークはエンジン非依存なので、Irodori-TTS による
+ボイスクローン等、他のエンジンも `say` API を変えずに後から
+追加できます。
 
 ## アバター画像について
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This repository is a monorepo.
 | `set_all_leds(r, g, b)` | Set all 12 base RGB LEDs to the same color | ✅ |
 | `set_leds(colors)` | Batch-set the first N LEDs from a `[[r,g,b], ...]` array in a single I2C burst (use this for animations / multi-color patterns); trailing LEDs keep their previous color | ✅ |
 | `clear_leds` | Turn all 12 base RGB LEDs off | ✅ |
+| `say(text, voice?, speaker_id?, reference_audio?)` | Speak text on the device speaker via gateway-side TTS. Default engine: **VOICEVOX** (runs as a separate HTTP service — see [TTS setup](#optional-tts-setup-voicevox)). Requires the `[tts]` extra. | ✅ |
 
 See `gateway/README.md` for full schemas.
 
@@ -314,6 +315,61 @@ If you installed from source via `uv`:
 ```
 
 See `gateway/README.md` for details.
+
+### 4. Optional: TTS setup (VOICEVOX)
+
+To make the device speak, install the `[tts]` extra and run a
+[VOICEVOX](https://voicevox.hiroshiba.jp/) engine alongside the
+gateway. VOICEVOX runs as a separate HTTP service, so its LGPL-3.0
+license stays scoped to that process — the MIT-licensed gateway only
+issues HTTP requests against it.
+
+#### Run the engine (Docker)
+
+```bash
+docker run --rm -p '127.0.0.1:50021:50021' \
+  voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+```
+
+The engine listens on port 50021 by default. The CPU image is fine
+for short sentences; GPU images are also published upstream.
+
+#### Install the TTS extra
+
+```bash
+pip install 'stackchan-mcp[tts]'
+# or, equivalently:
+pip install 'stackchan-mcp[tts-voicevox]'
+```
+
+This pulls in `httpx` (HTTP client) and `opuslib` (Opus encoder
+bindings). The encoder needs `libopus` on the system —
+`brew install opus` on macOS, `sudo apt-get install libopus0` on
+Debian/Ubuntu.
+
+#### Configure (optional)
+
+| Environment variable | Default | Notes |
+|---|---|---|
+| `STACKCHAN_VOICEVOX_URL` | `http://127.0.0.1:50021` | VOICEVOX engine URL. |
+| `STACKCHAN_VOICEVOX_DEFAULT_SPEAKER` | `3` | Default speaker ID (Zundamon normal). See the [VOICEVOX speaker list](https://github.com/VOICEVOX/voicevox_engine) for other options. |
+
+#### Try it
+
+From an MCP client:
+
+```
+say(text="こんにちは、わたしはスタックチャンです")
+```
+
+The gateway POSTs to VOICEVOX, decodes the returned WAV, resamples to
+16 kHz mono, encodes Opus frames (60 ms each), and pushes them as
+WebSocket binary frames to the device — which decodes and plays them
+through its speaker. **No firmware changes are required**: the
+existing audio decoder pipeline already accepts these frames. The
+TTS framework is engine-agnostic, so additional engines (Irodori-TTS
+voice cloning is on the roadmap) can be added without changing the
+`say` API.
 
 ## About the avatar images
 

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -32,6 +32,22 @@ dependencies = [
     "aiohttp>=3",
 ]
 
+[project.optional-dependencies]
+# Phase 4 TTS — see Issue #70.
+# Concrete engines (VOICEVOX, Irodori) consume these libraries:
+#   * httpx     — VOICEVOX HTTP engine client
+#   * opuslib   — Opus encoding for the device's audio decoder
+# `tts-voicevox` is a no-op alias provided so users can declare intent
+# explicitly; the VOICEVOX engine itself is an external HTTP process and
+# adds no Python dependencies of its own.
+tts = [
+    "httpx>=0.27",
+    "opuslib>=3",
+]
+tts-voicevox = [
+    "stackchan-mcp[tts]",
+]
+
 [project.urls]
 Homepage = "https://github.com/kisaragi-mochi/stackchan-mcp"
 Repository = "https://github.com/kisaragi-mochi/stackchan-mcp"

--- a/gateway/stackchan_mcp/audio_stream.py
+++ b/gateway/stackchan_mcp/audio_stream.py
@@ -1,34 +1,52 @@
-"""Opus audio frame handling — skeleton for Phase 4 (planned).
+"""Opus audio frame handling for the gateway <-> device link.
 
-This module will handle:
-- Incoming Opus frames from the device (STT pipeline)
-- Outgoing Opus frames to the device (TTS pipeline)
+Outbound (TTS) frames are produced by
+:mod:`stackchan_mcp.tts.audio_utils` and pushed here to the connected
+ESP32 via :meth:`stackchan_mcp.esp32_client.ESP32Manager.send_audio_frame`.
 
-For now, binary frames are logged and discarded.
+The inbound side (STT pipeline, Phase 4 / Issue #8) is still a stub —
+binary frames coming up from the device are logged and discarded for
+now. Wiring that up belongs to the STT half of Phase 4.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from .esp32_client import ESP32Manager
 
 logger = logging.getLogger(__name__)
 
 
 async def handle_audio_frame(data: bytes, session_id: str) -> None:
-    """Process an incoming binary Opus frame (stub).
+    """Process an incoming binary Opus frame from the device (stub).
 
-    Phase 4 will pipe this into an STT engine.
+    The STT half of Phase 4 will pipe this into a recogniser; until
+    then we just log the size at debug level.
     """
     logger.debug(
-        "audio_frame session=%s bytes=%d (discarded — Phase 4)",
+        "audio_frame session=%s bytes=%d (discarded — STT not wired up)",
         session_id,
         len(data),
     )
 
 
-async def send_audio_frame(data: bytes) -> bytes:
-    """Prepare an outgoing Opus frame (stub).
+async def push_opus_frames(
+    esp32: ESP32Manager,
+    frames: Iterable[bytes],
+) -> int:
+    """Push Opus frames to the connected ESP32.
 
-    Phase 4 will generate this from a TTS engine.
+    Returns the number of frames sent so the caller can report this to
+    the MCP client. Raises :class:`ConnectionError` (via
+    :meth:`ESP32Manager.send_audio_frame`) if the device disconnects
+    mid-stream — the orchestrator turns that into a clean MCP error
+    rather than letting it bubble up as a stack trace.
     """
-    return data
+    sent = 0
+    for frame in frames:
+        await esp32.send_audio_frame(frame)
+        sent += 1
+    return sent

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -16,6 +16,7 @@ import asyncio
 import errno
 import logging
 import os
+import platform
 import shutil
 import socket
 import subprocess
@@ -377,6 +378,56 @@ def _load_dotenv() -> None:
     load_dotenv()
 
 
+# Default Homebrew prefixes that ship libopus.dylib on macOS. Apple
+# Silicon installs default to ``/opt/homebrew``; Intel Macs use
+# ``/usr/local``. Keeping both keeps the helper portable across
+# contributor machines.
+_HOMEBREW_LIB_DIRS = ("/opt/homebrew/lib", "/usr/local/lib")
+
+
+def _ensure_libopus_findable() -> None:
+    """Make libopus reachable to opuslib's ``ctypes.find_library`` on macOS.
+
+    ``opuslib.api`` calls ``ctypes.util.find_library("opus")`` at
+    import time. On macOS that walks ``DYLD_LIBRARY_PATH`` plus a
+    couple of system-default directories — but not Homebrew's
+    ``/opt/homebrew/lib`` (Apple Silicon) or ``/usr/local/lib`` (Intel),
+    so a vanilla ``brew install opus`` lands a working libopus that
+    opuslib still cannot find. Users then see ``Could not find Opus
+    library`` even though the dylib is on disk.
+
+    Prepend any Homebrew-style lib directories that exist so the next
+    ``find_library`` call (triggered by the lazy ``import opuslib``
+    inside :func:`audio_utils.encode_opus_frames`) succeeds. We
+    deliberately *prepend* and skip duplicates so an explicit
+    ``DYLD_LIBRARY_PATH`` set by the operator (e.g. for a custom build
+    of libopus) keeps priority. No-op on non-macOS hosts.
+    """
+    if platform.system() != "Darwin":
+        return
+
+    existing = os.environ.get("DYLD_LIBRARY_PATH", "")
+    paths: list[str] = [p for p in existing.split(":") if p]
+
+    prepended: list[str] = []
+    for candidate in _HOMEBREW_LIB_DIRS:
+        if candidate in paths:
+            continue
+        if not os.path.isdir(candidate):
+            continue
+        prepended.append(candidate)
+
+    if not prepended:
+        return
+
+    os.environ["DYLD_LIBRARY_PATH"] = ":".join(prepended + paths)
+    logger.debug(
+        "Prepended Homebrew lib dirs to DYLD_LIBRARY_PATH so opuslib "
+        "can find libopus: %s",
+        prepended,
+    )
+
+
 def _run_preflight() -> int:
     """Run preflight diagnostics. Returns the desired process exit code.
 
@@ -387,6 +438,7 @@ def _run_preflight() -> int:
     warns about a missing ``STACKCHAN_TOKEN``.
     """
     _load_dotenv()
+    _ensure_libopus_findable()
 
     issues = 0
     print(f"stackchan-mcp {__version__} preflight")
@@ -527,6 +579,7 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(_run_preflight())
 
     _load_dotenv()
+    _ensure_libopus_findable()
 
     logging.basicConfig(
         level=logging.INFO,

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -342,10 +342,11 @@ class ESP32Manager:
                     if connection.protocol_version != 1:
                         logger.warning(
                             "ESP32 negotiated WebSocket protocol "
-                            "version=%s (gateway only emits v1 raw "
-                            "Opus binary frames; TTS audio may not "
-                            "play correctly until binary header "
-                            "wrapping is added)",
+                            "version=%s; the gateway emits raw Opus "
+                            "binary frames matching v1 only. TTS "
+                            "calls (say) will be blocked at the "
+                            "orchestrator until v2/v3 BinaryProtocol "
+                            "header wrapping is implemented",
                             connection.protocol_version,
                         )
 

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -142,6 +142,18 @@ class ESP32Connection:
             method = payload.get("method", "")
             logger.info("ESP32 notification: %s", method)
 
+    async def send_audio_frame(self, opus_frame: bytes) -> None:
+        """Send a single Opus frame to the ESP32 as a WebSocket binary frame.
+
+        The device's ``OnData`` handler (firmware/main/protocols/
+        websocket_protocol.cc) treats every binary frame as an Opus
+        audio payload to feed into its decoder, so this method is the
+        TTS pipeline's egress point.
+        """
+        if not self._connected:
+            raise ConnectionError("ESP32 not connected")
+        await self._ws.send(opus_frame)
+
     def disconnect(self) -> None:
         """Mark connection as disconnected."""
         self._connected = False
@@ -322,6 +334,18 @@ class ESP32Manager:
         if not self._connection.initialized:
             return None, {"code": -32000, "message": "ESP32 not initialized"}
         return await self._connection.call_tool(name, arguments)
+
+    async def send_audio_frame(self, opus_frame: bytes) -> None:
+        """Push a single Opus frame to the connected device.
+
+        Used by the TTS pipeline to deliver synthesised audio. Raises
+        :class:`ConnectionError` if no device is currently attached so
+        the orchestrator can surface a clean error to the MCP client
+        instead of silently dropping audio.
+        """
+        if not self._connection or not self._connection.connected:
+            raise ConnectionError("No ESP32 device connected")
+        await self._connection.send_audio_frame(opus_frame)
 
     def get_status(self) -> dict[str, Any]:
         """Get current connection status."""

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -154,6 +154,27 @@ class ESP32Connection:
             raise ConnectionError("ESP32 not connected")
         await self._ws.send(opus_frame)
 
+    async def send_tts_state(self, state: str) -> None:
+        """Send a TTS state notification (``start`` / ``stop`` / ...).
+
+        The device's :func:`Application::OnIncomingJson` translates
+        ``{"type":"tts","state":"start"}`` into
+        :data:`kDeviceStateSpeaking`, which is the gate for
+        :func:`OnIncomingAudio` pushing packets into the decode queue
+        (see ``firmware/main/application.cc``). Without bracketing the
+        audio frames in start/stop, the device drops them on the floor
+        and the speaker stays silent — the TTS tool returns success
+        without anything actually playing.
+        """
+        if not self._connected:
+            raise ConnectionError("ESP32 not connected")
+        message = {
+            "session_id": self.session_id,
+            "type": "tts",
+            "state": state,
+        }
+        await self._ws.send(json.dumps(message))
+
     def disconnect(self) -> None:
         """Mark connection as disconnected."""
         self._connected = False
@@ -346,6 +367,17 @@ class ESP32Manager:
         if not self._connection or not self._connection.connected:
             raise ConnectionError("No ESP32 device connected")
         await self._connection.send_audio_frame(opus_frame)
+
+    async def send_tts_state(self, state: str) -> None:
+        """Send a TTS state notification (``start`` / ``stop`` / ...).
+
+        Required around audio frame egress so the device transitions
+        into ``kDeviceStateSpeaking`` and back; see
+        :meth:`ESP32Connection.send_tts_state` for the full rationale.
+        """
+        if not self._connection or not self._connection.connected:
+            raise ConnectionError("No ESP32 device connected")
+        await self._connection.send_tts_state(state)
 
     def get_status(self) -> dict[str, Any]:
         """Get current connection status."""

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -14,6 +14,7 @@ import uuid
 from typing import Any
 
 import websockets
+import websockets.exceptions
 from websockets.asyncio.server import ServerConnection
 
 from .protocol import HelloResponse, make_mcp_message, parse_jsonrpc_response
@@ -142,6 +143,29 @@ class ESP32Connection:
             method = payload.get("method", "")
             logger.info("ESP32 notification: %s", method)
 
+    async def _ws_send(self, payload: bytes | str) -> None:
+        """Send a payload, translating websockets errors to ConnectionError.
+
+        The ``websockets`` library raises its own exception hierarchy
+        (``ConnectionClosed`` and friends), which is *not* a subclass
+        of the built-in :class:`ConnectionError`. Without translation
+        the orchestrator's ``except ConnectionError`` filter — and the
+        MCP handler's ``except RuntimeError`` filter — would let those
+        errors leak as raw tracebacks into the MCP transport, breaking
+        the say() tool's clean error JSON contract on mid-stream
+        disconnect.
+        """
+        try:
+            await self._ws.send(payload)
+        except (
+            websockets.exceptions.ConnectionClosed,
+            OSError,
+        ) as exc:
+            # Mark the connection dead so subsequent calls fail fast
+            # rather than each one re-discovering the broken socket.
+            self.disconnect()
+            raise ConnectionError(f"WebSocket send failed: {exc}") from exc
+
     async def send_audio_frame(self, opus_frame: bytes) -> None:
         """Send a single Opus frame to the ESP32 as a WebSocket binary frame.
 
@@ -152,7 +176,7 @@ class ESP32Connection:
         """
         if not self._connected:
             raise ConnectionError("ESP32 not connected")
-        await self._ws.send(opus_frame)
+        await self._ws_send(opus_frame)
 
     async def send_tts_state(self, state: str) -> None:
         """Send a TTS state notification (``start`` / ``stop`` / ...).
@@ -173,7 +197,7 @@ class ESP32Connection:
             "type": "tts",
             "state": state,
         }
-        await self._ws.send(json.dumps(message))
+        await self._ws_send(json.dumps(message))
 
     def disconnect(self) -> None:
         """Mark connection as disconnected."""

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -231,6 +231,17 @@ class ESP32Manager:
         self._init_tasks: list[asyncio.Task] = []
         self._vision_url: str = ""
         self._vision_token: str = ""
+        # Per-device serialisation for TTS send sequences. Acquired by
+        # the orchestrator around the entire start → frames → stop
+        # block so concurrent ``say()`` invocations cannot interleave
+        # their Opus frames on the same WebSocket or overlap their
+        # ``tts.start``/``tts.stop`` notifications (which would yank
+        # the firmware out of ``kDeviceStateSpeaking`` mid-utterance
+        # and silently drop the remaining audio). The lock is scoped
+        # to the manager because the manager owns the device today —
+        # if multi-device support lands later, the lock should move
+        # onto :class:`ESP32Connection` instead.
+        self._tts_lock = asyncio.Lock()
 
     @property
     def device_connected(self) -> bool:
@@ -239,6 +250,15 @@ class ESP32Manager:
     @property
     def connection(self) -> ESP32Connection | None:
         return self._connection
+
+    @property
+    def tts_lock(self) -> asyncio.Lock:
+        """Per-device lock guarding the TTS send sequence.
+
+        See :attr:`_tts_lock` for the rationale; the orchestrator wraps
+        the start → frames → stop block in ``async with`` on this lock.
+        """
+        return self._tts_lock
 
     async def start(
         self,

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -37,6 +37,13 @@ class ESP32Connection:
         self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
         self._connected = True
         self._initialized = False
+        # Device-declared WebSocket protocol version (from the hello
+        # message). Defaults to 1, which matches the firmware's default
+        # (firmware/main/protocols/websocket_protocol.h: ``version_ = 1``)
+        # and the audio framing this gateway emits today (raw Opus
+        # payload). v2/v3 add a BinaryProtocol header that this gateway
+        # does not yet wrap — see Issue follow-up to #70.
+        self.protocol_version: int = 1
 
     @property
     def connected(self) -> bool:
@@ -321,6 +328,26 @@ class ESP32Manager:
                         logger.warning("ESP32 does not support MCP, rejecting")
                         await ws.close()
                         return
+
+                    # Capture the device's WebSocket protocol version
+                    # so callers (e.g. the TTS pipeline) can decide
+                    # whether their wire format is compatible. The
+                    # firmware accepts raw Opus only on v1; v2/v3 wrap
+                    # the payload in a BinaryProtocol header.
+                    raw_version = data.get("version", 1)
+                    try:
+                        connection.protocol_version = int(raw_version)
+                    except (TypeError, ValueError):
+                        connection.protocol_version = 1
+                    if connection.protocol_version != 1:
+                        logger.warning(
+                            "ESP32 negotiated WebSocket protocol "
+                            "version=%s (gateway only emits v1 raw "
+                            "Opus binary frames; TTS audio may not "
+                            "play correctly until binary header "
+                            "wrapping is added)",
+                            connection.protocol_version,
+                        )
 
                     # Send hello response
                     resp = HelloResponse(session_id=session_id)

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -422,20 +422,15 @@ def create_server() -> Server:
             return [TextContent(type="text", text=json.dumps(status, indent=2))]
 
         if name == "say":
-            # TTS runs on the gateway side. Engine concrete implementations
-            # land in follow-up PRs of Issue #70; until then the orchestrator
-            # raises NotImplementedError, which we surface as a clean error
-            # rather than a stack trace.
+            # TTS runs on the gateway side. The orchestrator validates
+            # arguments, looks up an engine, synthesises PCM, encodes
+            # Opus, and pushes frames through the WebSocket binary
+            # channel that the device's audio decoder consumes. Errors
+            # are surfaced as clean MCP error JSON rather than letting
+            # tracebacks leak into the agent's transcript.
             try:
-                result = await synthesize_and_send(arguments)
-            except ValueError as exc:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": str(exc)}),
-                    )
-                ]
-            except NotImplementedError as exc:
+                result = await synthesize_and_send(arguments, gateway=gw)
+            except (ValueError, NotImplementedError, RuntimeError) as exc:
                 return [
                     TextContent(
                         type="text",

--- a/gateway/stackchan_mcp/tts/__init__.py
+++ b/gateway/stackchan_mcp/tts/__init__.py
@@ -1,19 +1,50 @@
 """TTS framework for Phase 4 (Issue #70).
 
 This package provides the engine-agnostic skeleton for the gateway-side
-``say(text)`` MCP tool. Concrete engine implementations land in follow-up
-PRs:
+``say(text)`` MCP tool plus the concrete VOICEVOX engine. The Irodori
+voice-cloning engine arrives in a follow-up PR (``irodori.py``, PR3).
 
-- ``voicevox.py`` — VOICEVOX HTTP API (PR2)
-- ``irodori.py`` — Irodori-TTS-500M voice cloning (PR3)
-
-The framework here only exposes the abstract :class:`TTSEngine`, an
-:class:`EngineRegistry`, and :func:`synthesize_and_send` — the orchestrator
-that the ``say`` tool will call once at least one engine is registered.
+The package exports :class:`TTSEngine`, an :class:`EngineRegistry`, the
+:func:`synthesize_and_send` orchestrator, and registers the default
+VOICEVOX engine at import time. Engines whose modules require optional
+extras to import are registered behind ``try / except ImportError`` so
+the framework still works when the corresponding extra is missing.
 """
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
 
 from .base import EngineRegistry, TTSEngine, get_registry
 from .orchestrator import DEFAULT_VOICE, synthesize_and_send
+
+_logger = logging.getLogger(__name__)
+
+
+def _try_register(register_fn: Callable[[], None], engine_label: str) -> None:
+    """Run ``register_fn`` and swallow ImportErrors.
+
+    Used so an engine whose top-level module needs an optional extra
+    (e.g. PR3's Irodori importing torch / transformers) can fail to
+    register cleanly without breaking the rest of the framework. The
+    VOICEVOX engine module itself imports fine without any extras —
+    httpx is only imported inside :meth:`VoicevoxEngine.synthesize`.
+    """
+    try:
+        register_fn()
+    except ImportError as exc:
+        _logger.debug("Skipping %s engine registration: %s", engine_label, exc)
+
+
+def _register_voicevox() -> None:
+    from .voicevox import VoicevoxEngine
+
+    get_registry().register(VoicevoxEngine())
+
+
+_try_register(_register_voicevox, "voicevox")
+
 
 __all__ = [
     "DEFAULT_VOICE",

--- a/gateway/stackchan_mcp/tts/audio_utils.py
+++ b/gateway/stackchan_mcp/tts/audio_utils.py
@@ -1,0 +1,177 @@
+"""Audio utilities for the TTS pipeline.
+
+The helpers here decode WAV blobs, resample to the device's 16 kHz
+sample rate, slice PCM into fixed-size frames, and encode those frames
+to Opus. Each helper is independent so callers (and tests) can compose
+them piecemeal.
+
+``opuslib`` is imported lazily inside :func:`encode_opus_frames` so that
+the rest of the module stays usable in environments where the ``[tts]``
+extra is not installed (e.g. unit tests for resampling).
+
+Device-side Opus parameters come from
+``firmware/main/audio/audio_service.h``::
+
+    sample_rate         = 16000 Hz
+    channels            = 1
+    frame_duration_ms   = 60
+    samples_per_frame   = sample_rate * frame_duration_ms / 1000 = 960
+"""
+
+from __future__ import annotations
+
+import array
+import io
+import logging
+import wave
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+#: Opus sample rate the device decoder is configured for.
+DEVICE_SAMPLE_RATE = 16000
+
+#: Opus channel count (mono).
+DEVICE_CHANNELS = 1
+
+#: Opus frame duration in milliseconds.
+DEVICE_FRAME_DURATION_MS = 60
+
+#: PCM samples per Opus frame at the device's settings (= 960).
+SAMPLES_PER_FRAME = DEVICE_SAMPLE_RATE * DEVICE_FRAME_DURATION_MS // 1000
+
+
+def wav_to_pcm16_mono(wav_bytes: bytes) -> tuple[int, bytes]:
+    """Decode a WAV blob into ``(sample_rate, raw_pcm)``.
+
+    The PCM is returned as signed 16-bit little-endian mono. Stereo
+    inputs are mixed down by averaging L+R; anything other than 16-bit
+    PCM raises :class:`ValueError` because we don't carry an audio
+    library beyond the Python stdlib at this layer.
+
+    Returning the source sample rate lets the caller decide whether to
+    invoke :func:`resample_pcm16_linear`.
+    """
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+        n_channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        sample_rate = wav.getframerate()
+        n_frames = wav.getnframes()
+        raw = wav.readframes(n_frames)
+
+    if sample_width != 2:
+        raise ValueError(
+            f"Unsupported WAV sample width {sample_width * 8}-bit "
+            "(expected 16-bit signed PCM)"
+        )
+
+    if n_channels == 1:
+        return sample_rate, raw
+
+    if n_channels == 2:
+        samples = array.array("h")
+        samples.frombytes(raw)
+        mono = array.array(
+            "h",
+            [
+                (samples[i] + samples[i + 1]) // 2
+                for i in range(0, len(samples), 2)
+            ],
+        )
+        return sample_rate, mono.tobytes()
+
+    raise ValueError(f"Unsupported channel count {n_channels} (expected 1 or 2)")
+
+
+def resample_pcm16_linear(pcm: bytes, src_rate: int, dst_rate: int) -> bytes:
+    """Linear-interpolation resample of signed-16-bit mono PCM.
+
+    Linear interpolation is good enough for speech and keeps scipy out
+    of the dependency tree, so the ``[tts]`` extra remains light. For
+    music or fidelity-critical use we'd want a polyphase resampler, but
+    that's not in scope here.
+    """
+    if src_rate == dst_rate:
+        return pcm
+
+    samples = array.array("h")
+    samples.frombytes(pcm)
+    n_src = len(samples)
+    if n_src == 0:
+        return b""
+
+    n_dst = max(1, n_src * dst_rate // src_rate)
+    out = array.array("h")
+
+    if n_dst == 1:
+        out.append(samples[0])
+        return out.tobytes()
+
+    # Map output index to source index in [0, n_src - 1] so the last
+    # output sample lines up with the last source sample. This avoids
+    # off-by-one drift that would compound when chaining resamples.
+    ratio = (n_src - 1) / (n_dst - 1)
+    for i in range(n_dst):
+        x = i * ratio
+        idx = int(x)
+        frac = x - idx
+        if idx + 1 >= n_src:
+            out.append(samples[-1])
+            continue
+        a = samples[idx]
+        b = samples[idx + 1]
+        # Round toward zero is fine for 16-bit speech.
+        out.append(int(a + (b - a) * frac))
+    return out.tobytes()
+
+
+def chunk_pcm_into_frames(
+    pcm: bytes,
+    samples_per_frame: int = SAMPLES_PER_FRAME,
+) -> Iterator[bytes]:
+    """Slice signed-16-bit LE PCM into fixed-size frames.
+
+    The tail is zero-padded so every yielded chunk is exactly
+    ``samples_per_frame * 2`` bytes long — Opus encoders require a
+    constant frame size.
+    """
+    bytes_per_frame = samples_per_frame * 2  # 16-bit
+    if bytes_per_frame <= 0:
+        raise ValueError("samples_per_frame must be positive")
+
+    for i in range(0, len(pcm), bytes_per_frame):
+        chunk = pcm[i : i + bytes_per_frame]
+        if len(chunk) < bytes_per_frame:
+            chunk = chunk + b"\x00" * (bytes_per_frame - len(chunk))
+        yield chunk
+
+
+def encode_opus_frames(
+    pcm: bytes,
+    *,
+    sample_rate: int = DEVICE_SAMPLE_RATE,
+    channels: int = DEVICE_CHANNELS,
+    frame_duration_ms: int = DEVICE_FRAME_DURATION_MS,
+) -> Iterator[bytes]:
+    """Encode signed-16-bit LE PCM into Opus frames.
+
+    ``opuslib`` is imported lazily so this module remains importable
+    when the ``[tts]`` extra is not installed; the helper only fails
+    when actually called. Callers receive a clear ``RuntimeError`` that
+    points at the right install command.
+    """
+    try:
+        import opuslib  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via integration
+        raise RuntimeError(
+            "opuslib is not installed. Install with "
+            "'pip install stackchan-mcp[tts]' to enable Opus encoding."
+        ) from exc
+
+    samples_per_frame = sample_rate * frame_duration_ms // 1000
+    encoder = opuslib.Encoder(sample_rate, channels, opuslib.APPLICATION_VOIP)
+
+    for pcm_frame in chunk_pcm_into_frames(pcm, samples_per_frame):
+        opus_frame = encoder.encode(pcm_frame, samples_per_frame)
+        yield opus_frame

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -1,39 +1,50 @@
 """TTS orchestration: pick an engine, synthesise, encode, and push.
 
 The orchestrator is the glue between the ``say`` MCP tool (defined in
-:mod:`stackchan_mcp.stdio_server`) and the concrete engines that arrive
-in follow-up PRs of Issue #70.
+:mod:`stackchan_mcp.stdio_server`) and the engine implementations
+registered in :mod:`stackchan_mcp.tts`. It validates arguments, looks
+up an engine, runs the synthesis, encodes the result to Opus, and
+hands the frames off to :mod:`stackchan_mcp.audio_stream` for delivery.
 
-PR1 (Issue #70) lands this skeleton only: calling
-:func:`synthesize_and_send` succeeds at the validation stage but raises
-``NotImplementedError`` once it would need to drive a real engine. The
-intent is to nail down the public surface — argument names, validation
-errors, and the return shape — so that PR2 (VOICEVOX) and PR3 (Irodori)
-only have to wire engines into the registry.
+The framework half (Engine ABC, registry, validation surface) shipped
+in PR1 of Issue #70; PR2 wires the actual VOICEVOX → PCM → Opus →
+WebSocket pipeline. The signature stays back-compatible with PR1's
+tests: ``gateway`` is keyword-only and may be omitted, in which case
+calls that pass validation surface a clear error instead of silently
+synthesising audio with no destination.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from .audio_utils import (
+    DEVICE_FRAME_DURATION_MS,
+    DEVICE_SAMPLE_RATE,
+    encode_opus_frames,
+)
 from .base import EngineRegistry, get_registry
+
+if TYPE_CHECKING:
+    from ..gateway import Gateway
 
 logger = logging.getLogger(__name__)
 
 
 #: Default engine name when ``voice`` is omitted from the tool call.
-#: VOICEVOX is the planned default (Issue #70); the concrete engine
-#: arrives in PR2.
+#: VOICEVOX is the canonical default (Issue #70); the concrete engine
+#: ships in PR2 of that Issue.
 DEFAULT_VOICE = "voicevox"
 
 
 async def synthesize_and_send(
     arguments: dict[str, Any],
     *,
+    gateway: "Gateway | None" = None,
     registry: EngineRegistry | None = None,
 ) -> dict[str, Any]:
-    """Synthesise text via a registered engine and (eventually) push to device.
+    """Synthesise text via a registered engine and push it to the device.
 
     Args:
         arguments: MCP tool arguments. Recognised keys:
@@ -43,24 +54,35 @@ async def synthesize_and_send(
             * ``speaker_id``: engine-specific speaker identifier
               (e.g. VOICEVOX speaker).
             * ``reference_audio``: path to a reference audio sample
-              (e.g. for Irodori voice cloning).
+              (e.g. for Irodori voice cloning, PR3).
+
+        gateway: The :class:`Gateway` instance whose
+            :attr:`Gateway.esp32` the audio frames are pushed through.
+            Required for the pipeline; left optional in the signature
+            so callers can inspect validation errors without setting
+            up a gateway (e.g. argument-validation tests).
 
         registry: Engine registry to look up ``voice`` in. Defaults to
             the process-wide registry. Tests inject a fresh registry
-            here to avoid leaking state.
+            here to avoid leaking state across cases.
 
     Returns:
-        A dict describing the synthesis once concrete engines are wired
-        up. PR1 never reaches that path.
+        Dict describing the synthesis: ``engine``, ``text``,
+        ``speaker_id``, ``frame_count``, ``sample_rate``,
+        ``frame_duration_ms``, ``duration_ms``.
 
     Raises:
-        ValueError: if ``text`` is missing or empty.
-        NotImplementedError: until a matching engine is registered.
-            The message lists the registered engine names so callers
-            can tell whether they need to install an extra (e.g.
-            ``pip install stackchan-mcp[tts-voicevox]``) or pass a
-            different ``voice``.
+        ValueError: if ``text`` is missing / empty / non-string.
+        NotImplementedError: if no engine is registered under ``voice``.
+            The message lists the registered engines so callers can
+            tell whether they need to install an extra (e.g.
+            ``pip install stackchan-mcp[tts]``) or pick a different
+            ``voice``.
+        RuntimeError: if ``gateway`` is omitted, or if no ESP32 device
+            is connected when the orchestrator tries to push frames.
     """
+    # Validation runs first so callers can probe argument shape without
+    # a real gateway / engine.
     text = arguments.get("text", "")
     if not isinstance(text, str) or not text.strip():
         raise ValueError("'text' is required and must be a non-empty string")
@@ -76,32 +98,65 @@ async def synthesize_and_send(
         raise NotImplementedError(
             f"TTS engine '{voice}' is not registered. "
             f"Available engines: {available or '(none)'}. "
-            "Concrete engines (VOICEVOX, Irodori) land in follow-up PRs "
-            "of Issue #70; install the relevant extra "
-            "(e.g. 'pip install stackchan-mcp[tts-voicevox]') once the "
-            "PR is merged."
+            "Install the relevant extra (e.g. "
+            "'pip install stackchan-mcp[tts]' for VOICEVOX) and ensure "
+            "the corresponding service (e.g. the VOICEVOX HTTP engine) "
+            "is reachable."
         )
 
-    # The pipeline below is the contract that follow-up PRs must
-    # satisfy. PR1 stops short of executing it so that merging the
-    # skeleton does not appear to "almost work".
-    #
-    #   pcm = await engine.synthesize(
-    #       text,
-    #       speaker_id=arguments.get("speaker_id"),
-    #       reference_audio=arguments.get("reference_audio"),
-    #   )
-    #   opus_frames = encode_opus_16k_mono(pcm)
-    #   for frame in opus_frames:
-    #       await gateway.esp32.send_audio_frame(frame)
-    #   return {
-    #       "engine": voice,
-    #       "text": text,
-    #       "frame_count": len(opus_frames),
-    #       "duration_ms": ...,
-    #   }
-    raise NotImplementedError(
-        "TTS orchestration pipeline (PCM synthesis, Opus encoding, "
-        "WebSocket push) is not wired up yet. PR1 ships the framework "
-        "only; engine implementations land in follow-up PRs of Issue #70."
+    if gateway is None:
+        raise RuntimeError(
+            "synthesize_and_send requires a 'gateway' argument to push "
+            "audio frames; this call appears to be a validation probe "
+            "without one."
+        )
+
+    if not gateway.esp32.device_connected:
+        raise RuntimeError(
+            "No ESP32 device connected; cannot deliver synthesised audio."
+        )
+
+    speaker_id = arguments.get("speaker_id")
+    reference_audio = arguments.get("reference_audio")
+
+    pcm = await engine.synthesize(
+        text,
+        speaker_id=speaker_id,
+        reference_audio=reference_audio,
     )
+    if not pcm:
+        # An engine returning no PCM is a bug, not a runtime condition;
+        # surface it to the caller rather than silently sending zero
+        # frames (which would look like the device "ignored" the call).
+        raise RuntimeError(
+            f"Engine '{voice}' produced no PCM data for the given text."
+        )
+
+    # Encode -> push. Materialising the frame list before pushing keeps
+    # the count reportable and makes it easy to short-circuit if Opus
+    # encoding fails before any audio reaches the wire.
+    opus_frames = list(encode_opus_frames(pcm))
+    sent = 0
+    for frame in opus_frames:
+        await gateway.esp32.send_audio_frame(frame)
+        sent += 1
+
+    duration_ms = sent * DEVICE_FRAME_DURATION_MS
+
+    logger.info(
+        "say(): engine=%s speaker=%s frames=%d duration_ms=%d",
+        voice,
+        speaker_id if speaker_id is not None else "default",
+        sent,
+        duration_ms,
+    )
+
+    return {
+        "engine": voice,
+        "text": text,
+        "speaker_id": speaker_id,
+        "frame_count": sent,
+        "sample_rate": DEVICE_SAMPLE_RATE,
+        "frame_duration_ms": DEVICE_FRAME_DURATION_MS,
+        "duration_ms": duration_ms,
+    }

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -125,6 +125,24 @@ async def synthesize_and_send(
             "No ESP32 device connected; cannot deliver synthesised audio."
         )
 
+    # WebSocket protocol version gate. The firmware decodes raw Opus
+    # binary frames only on protocol v1; v2/v3 wrap each binary message
+    # in a BinaryProtocol header that this gateway does not yet emit.
+    # Streaming raw frames to a v2/v3 device makes the firmware parse
+    # Opus bytes as header fields, so the audio never plays — yet
+    # without this check ``say()`` would still report success. Fail
+    # fast with a clear, actionable error instead. BinaryProtocol
+    # header wrapping is tracked as a follow-up to Issue #70.
+    connection = getattr(gateway.esp32, "connection", None)
+    proto_version = getattr(connection, "protocol_version", 1)
+    if proto_version != 1:
+        raise RuntimeError(
+            f"TTS requires WebSocket protocol v1, but the connected "
+            f"device negotiated v{proto_version}. Rebuild the firmware "
+            "with v1 (the default for this repository) — v2/v3 "
+            "BinaryProtocol header wrapping is not yet supported."
+        )
+
     speaker_id = arguments.get("speaker_id")
     reference_audio = arguments.get("reference_audio")
 

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -153,20 +153,47 @@ async def synthesize_and_send(
     except Exception as exc:
         raise RuntimeError(f"Opus encoding failed: {exc}") from exc
 
+    # Bracket the binary audio frames in TTS start/stop notifications.
+    # The device firmware (Application::OnIncomingAudio) only accepts
+    # binary audio frames while in kDeviceStateSpeaking, which is
+    # entered on receipt of {"type":"tts","state":"start"} and exited
+    # on "stop". Without these notifications the audio frames are
+    # silently discarded and the say() tool returns success even
+    # though nothing actually plays.
+    try:
+        await gateway.esp32.send_tts_state("start")
+    except ConnectionError as exc:
+        raise RuntimeError(
+            f"Device disconnected before TTS start notification: {exc}"
+        ) from exc
+
     sent = 0
-    for frame in opus_frames:
+    push_error: ConnectionError | None = None
+    try:
+        for frame in opus_frames:
+            try:
+                await gateway.esp32.send_audio_frame(frame)
+            except ConnectionError as exc:
+                # Stop pushing on the first disconnect, but fall through
+                # to the stop notification (see finally) so that *if*
+                # the device is somehow still listening it returns to
+                # idle rather than staying in speaking forever.
+                push_error = exc
+                break
+            sent += 1
+    finally:
         try:
-            await gateway.esp32.send_audio_frame(frame)
-        except ConnectionError as exc:
-            # Mid-stream disconnect: report what made it through so
-            # callers can decide whether to retry or give up. Keep the
-            # error a RuntimeError so the MCP handler's filter catches
-            # it without needing to know about transport types.
-            raise RuntimeError(
-                f"Device disconnected after sending "
-                f"{sent}/{len(opus_frames)} frames: {exc}"
-            ) from exc
-        sent += 1
+            await gateway.esp32.send_tts_state("stop")
+        except ConnectionError:
+            # If the device dropped, it'll return to idle on its own
+            # when the WebSocket close lands; nothing to do here.
+            pass
+
+    if push_error is not None:
+        raise RuntimeError(
+            f"Device disconnected after sending "
+            f"{sent}/{len(opus_frames)} frames: {push_error}"
+        ) from push_error
 
     duration_ms = sent * DEVICE_FRAME_DURATION_MS
 

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 from .audio_utils import (
@@ -187,53 +188,72 @@ async def synthesize_and_send(
     # on "stop". Without these notifications the audio frames are
     # silently discarded and the say() tool returns success even
     # though nothing actually plays.
-    try:
-        await gateway.esp32.send_tts_state("start")
-    except ConnectionError as exc:
-        raise RuntimeError(
-            f"Device disconnected before TTS start notification: {exc}"
-        ) from exc
-
-    # Wait for the firmware's state machine to land in
-    # kDeviceStateSpeaking before sending the first frame.
-    await asyncio.sleep(TTS_START_TRANSITION_DELAY_S)
-
-    # Frame pacing: the device's decode queue holds at most ~40 frames
-    # (firmware MAX_DECODE_PACKETS_IN_QUEUE = 2400 / OPUS_FRAME_DURATION_MS),
-    # and pushes that exceed it are dropped silently. Send each frame
-    # at roughly the device's consumption rate (one frame per
-    # frame_duration_ms) so a long utterance never overflows. We let
-    # the loop drift by a single interval if the network is slow —
-    # the wall clock is the reference, not the loop iteration count.
-    frame_period_s = DEVICE_FRAME_DURATION_MS / 1000.0
-    loop = asyncio.get_event_loop()
+    #
+    # The whole start → frames → stop block runs under the device's
+    # TTS lock so two concurrent ``say()`` invocations can't interleave
+    # their Opus frames on the same WebSocket or overlap their state
+    # notifications. Without the lock, utterance B's ``stop`` could
+    # land mid-A and pull the firmware out of ``kDeviceStateSpeaking``
+    # while A's frames are still in flight, silently dropping the
+    # remainder of A's audio.
+    # Acquire the device's TTS lock for the duration of the
+    # start → frames → stop block. ``getattr`` lets test fakes that
+    # don't expose the lock attribute keep working — production always
+    # provides it via :class:`ESP32Manager.tts_lock`.
+    tts_lock = getattr(gateway.esp32, "tts_lock", None)
+    lock_ctx = tts_lock if tts_lock is not None else nullcontext()
 
     sent = 0
     push_error: ConnectionError | None = None
-    try:
-        next_send_time = loop.time()
-        for frame in opus_frames:
-            now = loop.time()
-            if now < next_send_time:
-                await asyncio.sleep(next_send_time - now)
-            try:
-                await gateway.esp32.send_audio_frame(frame)
-            except ConnectionError as exc:
-                # Stop pushing on the first disconnect, but fall through
-                # to the stop notification (see finally) so that *if*
-                # the device is somehow still listening it returns to
-                # idle rather than staying in speaking forever.
-                push_error = exc
-                break
-            sent += 1
-            next_send_time += frame_period_s
-    finally:
+    async with lock_ctx:
         try:
-            await gateway.esp32.send_tts_state("stop")
-        except ConnectionError:
-            # If the device dropped, it'll return to idle on its own
-            # when the WebSocket close lands; nothing to do here.
-            pass
+            await gateway.esp32.send_tts_state("start")
+        except ConnectionError as exc:
+            raise RuntimeError(
+                f"Device disconnected before TTS start notification: {exc}"
+            ) from exc
+
+        # Wait for the firmware's state machine to land in
+        # kDeviceStateSpeaking before sending the first frame.
+        await asyncio.sleep(TTS_START_TRANSITION_DELAY_S)
+
+        # Frame pacing: the device's decode queue holds at most ~40
+        # frames (firmware MAX_DECODE_PACKETS_IN_QUEUE = 2400 /
+        # OPUS_FRAME_DURATION_MS), and pushes that exceed it are
+        # dropped silently. Send each frame at roughly the device's
+        # consumption rate (one frame per frame_duration_ms) so a long
+        # utterance never overflows. We let the loop drift by a single
+        # interval if the network is slow — the wall clock is the
+        # reference, not the loop iteration count.
+        frame_period_s = DEVICE_FRAME_DURATION_MS / 1000.0
+        loop = asyncio.get_event_loop()
+
+        try:
+            next_send_time = loop.time()
+            for frame in opus_frames:
+                now = loop.time()
+                if now < next_send_time:
+                    await asyncio.sleep(next_send_time - now)
+                try:
+                    await gateway.esp32.send_audio_frame(frame)
+                except ConnectionError as exc:
+                    # Stop pushing on the first disconnect, but fall
+                    # through to the stop notification (see finally) so
+                    # that *if* the device is somehow still listening
+                    # it returns to idle rather than staying in speaking
+                    # forever.
+                    push_error = exc
+                    break
+                sent += 1
+                next_send_time += frame_period_s
+        finally:
+            try:
+                await gateway.esp32.send_tts_state("stop")
+            except ConnectionError:
+                # If the device dropped, it'll return to idle on its
+                # own when the WebSocket close lands; nothing to do
+                # here.
+                pass
 
     if push_error is not None:
         raise RuntimeError(

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -16,6 +16,7 @@ synthesising audio with no destination.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +29,14 @@ from .base import EngineRegistry, get_registry
 
 if TYPE_CHECKING:
     from ..gateway import Gateway
+
+#: Delay between the ``tts.start`` notification and the first audio
+#: frame, in seconds. Firmware dispatches the state transition through
+#: ``Schedule()`` (queued onto the main task), so the first frame can
+#: race the ``kDeviceStateSpeaking`` transition and be discarded by
+#: ``OnIncomingAudio``. 50 ms is well above typical scheduling latency
+#: but well below human-perceptible delay.
+TTS_START_TRANSITION_DELAY_S = 0.05
 
 logger = logging.getLogger(__name__)
 
@@ -167,10 +176,28 @@ async def synthesize_and_send(
             f"Device disconnected before TTS start notification: {exc}"
         ) from exc
 
+    # Wait for the firmware's state machine to land in
+    # kDeviceStateSpeaking before sending the first frame.
+    await asyncio.sleep(TTS_START_TRANSITION_DELAY_S)
+
+    # Frame pacing: the device's decode queue holds at most ~40 frames
+    # (firmware MAX_DECODE_PACKETS_IN_QUEUE = 2400 / OPUS_FRAME_DURATION_MS),
+    # and pushes that exceed it are dropped silently. Send each frame
+    # at roughly the device's consumption rate (one frame per
+    # frame_duration_ms) so a long utterance never overflows. We let
+    # the loop drift by a single interval if the network is slow —
+    # the wall clock is the reference, not the loop iteration count.
+    frame_period_s = DEVICE_FRAME_DURATION_MS / 1000.0
+    loop = asyncio.get_event_loop()
+
     sent = 0
     push_error: ConnectionError | None = None
     try:
+        next_send_time = loop.time()
         for frame in opus_frames:
+            now = loop.time()
+            if now < next_send_time:
+                await asyncio.sleep(next_send_time - now)
             try:
                 await gateway.esp32.send_audio_frame(frame)
             except ConnectionError as exc:
@@ -181,6 +208,7 @@ async def synthesize_and_send(
                 push_error = exc
                 break
             sent += 1
+            next_send_time += frame_period_s
     finally:
         try:
             await gateway.esp32.send_tts_state("stop")

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -119,11 +119,24 @@ async def synthesize_and_send(
     speaker_id = arguments.get("speaker_id")
     reference_audio = arguments.get("reference_audio")
 
-    pcm = await engine.synthesize(
-        text,
-        speaker_id=speaker_id,
-        reference_audio=reference_audio,
-    )
+    # Engine failures (HTTP errors from VOICEVOX, malformed WAV from
+    # the synthesiser, etc.) are translated to RuntimeError so the
+    # MCP layer's narrow exception filter still produces clean error
+    # JSON. Validation errors (ValueError) are kept distinct so bad
+    # arguments stay separable from operational degradation.
+    try:
+        pcm = await engine.synthesize(
+            text,
+            speaker_id=speaker_id,
+            reference_audio=reference_audio,
+        )
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(
+            f"TTS engine '{voice}' failed: {exc}"
+        ) from exc
+
     if not pcm:
         # An engine returning no PCM is a bug, not a runtime condition;
         # surface it to the caller rather than silently sending zero
@@ -135,10 +148,24 @@ async def synthesize_and_send(
     # Encode -> push. Materialising the frame list before pushing keeps
     # the count reportable and makes it easy to short-circuit if Opus
     # encoding fails before any audio reaches the wire.
-    opus_frames = list(encode_opus_frames(pcm))
+    try:
+        opus_frames = list(encode_opus_frames(pcm))
+    except Exception as exc:
+        raise RuntimeError(f"Opus encoding failed: {exc}") from exc
+
     sent = 0
     for frame in opus_frames:
-        await gateway.esp32.send_audio_frame(frame)
+        try:
+            await gateway.esp32.send_audio_frame(frame)
+        except ConnectionError as exc:
+            # Mid-stream disconnect: report what made it through so
+            # callers can decide whether to retry or give up. Keep the
+            # error a RuntimeError so the MCP handler's filter catches
+            # it without needing to know about transport types.
+            raise RuntimeError(
+                f"Device disconnected after sending "
+                f"{sent}/{len(opus_frames)} frames: {exc}"
+            ) from exc
         sent += 1
 
     duration_ms = sent * DEVICE_FRAME_DURATION_MS

--- a/gateway/stackchan_mcp/tts/voicevox.py
+++ b/gateway/stackchan_mcp/tts/voicevox.py
@@ -1,0 +1,184 @@
+"""VOICEVOX engine — HTTP client for a user-run VOICEVOX server.
+
+VOICEVOX itself is LGPL-3.0 licensed but runs as a separate HTTP
+process (the official ``voicevox/voicevox_engine`` Docker image is the
+recommended setup). The gateway never links VOICEVOX code; it only
+issues HTTP requests, so the LGPL terms apply only to the engine
+process and not to gateway code, which remains MIT.
+
+By default the engine is reached at ``http://127.0.0.1:50021``. Override
+with the ``STACKCHAN_VOICEVOX_URL`` environment variable, or by passing
+``url=`` to :class:`VoicevoxEngine` directly (used by tests).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from .audio_utils import (
+    DEVICE_SAMPLE_RATE,
+    resample_pcm16_linear,
+    wav_to_pcm16_mono,
+)
+from .base import TTSEngine
+
+logger = logging.getLogger(__name__)
+
+
+#: Default URL of the VOICEVOX HTTP engine. Matches the upstream Docker
+#: image's exposed port.
+DEFAULT_VOICEVOX_URL = "http://127.0.0.1:50021"
+
+#: Default speaker ID. ``3`` is Zundamon (normal voice), the most
+#: commonly used VOICEVOX speaker. Override per-call via the say()
+#: tool's ``speaker_id`` argument or globally via the
+#: ``STACKCHAN_VOICEVOX_DEFAULT_SPEAKER`` environment variable.
+DEFAULT_VOICEVOX_SPEAKER = 3
+
+#: HTTP timeout for both /audio_query and /synthesis. Synthesis can be
+#: a few seconds for a long sentence on CPU, so we err on the generous
+#: side.
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30.0
+
+
+class VoicevoxEngine(TTSEngine):
+    """Synthesise text by POSTing to a running VOICEVOX HTTP engine.
+
+    Setup (recommended): run the official Docker image::
+
+        docker run --rm -p '127.0.0.1:50021:50021' \\
+            voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+
+    Configuration:
+
+        ``STACKCHAN_VOICEVOX_URL``
+            Base URL of the engine. Default ``http://127.0.0.1:50021``.
+
+        ``STACKCHAN_VOICEVOX_DEFAULT_SPEAKER``
+            Integer speaker ID used when the say() tool does not
+            specify one. Default ``3`` (Zundamon, normal).
+    """
+
+    name = "voicevox"
+
+    def __init__(
+        self,
+        url: str | None = None,
+        default_speaker: int | None = None,
+        timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+        transport: Any = None,
+    ) -> None:
+        """Construct a VOICEVOX engine.
+
+        ``transport`` is an :class:`httpx.BaseTransport` (or
+        compatible) handed straight to :class:`httpx.AsyncClient`.
+        Tests pass a :class:`httpx.MockTransport` to avoid hitting the
+        network; production callers leave it ``None`` so httpx picks
+        its default HTTP transport.
+        """
+        env_url = os.getenv("STACKCHAN_VOICEVOX_URL")
+        self._url = (url or env_url or DEFAULT_VOICEVOX_URL).rstrip("/")
+
+        if default_speaker is not None:
+            self._default_speaker = default_speaker
+        else:
+            env_speaker = os.getenv("STACKCHAN_VOICEVOX_DEFAULT_SPEAKER")
+            if env_speaker:
+                try:
+                    self._default_speaker = int(env_speaker)
+                except ValueError:
+                    logger.warning(
+                        "Invalid STACKCHAN_VOICEVOX_DEFAULT_SPEAKER=%r, "
+                        "falling back to %d",
+                        env_speaker,
+                        DEFAULT_VOICEVOX_SPEAKER,
+                    )
+                    self._default_speaker = DEFAULT_VOICEVOX_SPEAKER
+            else:
+                self._default_speaker = DEFAULT_VOICEVOX_SPEAKER
+
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    @property
+    def url(self) -> str:
+        """Base URL the engine will connect to. Useful for diagnostics."""
+        return self._url
+
+    @property
+    def default_speaker(self) -> int:
+        """Speaker ID used when ``speaker_id`` is omitted from a call."""
+        return self._default_speaker
+
+    async def synthesize(self, text: str, **opts: Any) -> bytes:
+        """POST text to VOICEVOX, decode the WAV, return 16 kHz mono PCM.
+
+        Recognised opts:
+
+            ``speaker_id``: int
+                VOICEVOX speaker ID. Falls back to
+                :attr:`default_speaker` (which itself defaults to
+                ``3`` — Zundamon, normal).
+
+        VOICEVOX returns WAV at the speaker's native sample rate
+        (24 kHz for the bundled speakers). We resample to
+        :data:`audio_utils.DEVICE_SAMPLE_RATE` to match the device's
+        Opus decoder.
+        """
+        try:
+            import httpx  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised via integration
+            raise RuntimeError(
+                "httpx is not installed. Install with "
+                "'pip install stackchan-mcp[tts]' to enable VOICEVOX support."
+            ) from exc
+
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("VOICEVOX synthesize: 'text' must be a non-empty string")
+
+        speaker_raw = opts.get("speaker_id")
+        if speaker_raw is None:
+            speaker = self._default_speaker
+        else:
+            try:
+                speaker = int(speaker_raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"speaker_id must be an integer, got {speaker_raw!r}"
+                ) from exc
+
+        client_kwargs: dict[str, Any] = {"timeout": self._timeout_seconds}
+        if self._transport is not None:
+            client_kwargs["transport"] = self._transport
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            # 1. Build an AudioQuery for the text.
+            query_resp = await client.post(
+                f"{self._url}/audio_query",
+                params={"text": text, "speaker": speaker},
+            )
+            query_resp.raise_for_status()
+            audio_query = query_resp.json()
+
+            # 2. Synthesise the WAV from the AudioQuery.
+            synth_resp = await client.post(
+                f"{self._url}/synthesis",
+                params={"speaker": speaker},
+                json=audio_query,
+            )
+            synth_resp.raise_for_status()
+            wav_bytes = synth_resp.content
+
+        sample_rate, pcm = wav_to_pcm16_mono(wav_bytes)
+        if sample_rate != DEVICE_SAMPLE_RATE:
+            pcm = resample_pcm16_linear(pcm, sample_rate, DEVICE_SAMPLE_RATE)
+
+        logger.info(
+            "VOICEVOX synthesised %d bytes PCM (16 kHz mono) for "
+            "speaker=%d, text=%r",
+            len(pcm),
+            speaker,
+            text[:60],
+        )
+        return pcm

--- a/gateway/tests/_audio_fixtures.py
+++ b/gateway/tests/_audio_fixtures.py
@@ -1,0 +1,46 @@
+"""Shared helpers for TTS-related tests.
+
+Builds in-memory WAV blobs without depending on any third-party audio
+libraries — only the stdlib ``wave`` module is involved.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import wave
+from collections.abc import Iterable
+
+
+def make_wav_bytes(
+    sample_rate: int = 24000,
+    duration_ms: int = 100,
+    channels: int = 1,
+    samples: Iterable[int] | None = None,
+) -> bytes:
+    """Build a signed 16-bit LE WAV blob.
+
+    Args:
+        sample_rate: WAV sample rate.
+        duration_ms: Duration; ignored when ``samples`` is given.
+        channels: 1 or 2 channels.
+        samples: Iterable of int16 sample values. When omitted, a
+            silent block of the requested duration is produced. For
+            stereo, samples are interleaved L/R/L/R.
+
+    Returns:
+        WAV blob suitable for feeding into :func:`wav_to_pcm16_mono`.
+    """
+    if samples is None:
+        n_samples = sample_rate * duration_ms // 1000 * channels
+        sample_values: list[int] = [0] * n_samples
+    else:
+        sample_values = list(samples)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(struct.pack(f"<{len(sample_values)}h", *sample_values))
+    return buf.getvalue()

--- a/gateway/tests/test_audio_stream.py
+++ b/gateway/tests/test_audio_stream.py
@@ -1,0 +1,60 @@
+"""Tests for the gateway audio_stream helpers (Issue #70 PR2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from stackchan_mcp.audio_stream import handle_audio_frame, push_opus_frames
+
+
+class _FakeESP32:
+    def __init__(self, *, fail_after: int | None = None) -> None:
+        self.frames: list[bytes] = []
+        self._fail_after = fail_after
+
+    async def send_audio_frame(self, frame: bytes) -> None:
+        if self._fail_after is not None and len(self.frames) >= self._fail_after:
+            raise ConnectionError("simulated mid-stream disconnect")
+        self.frames.append(frame)
+
+
+@pytest.mark.asyncio
+async def test_handle_audio_frame_is_a_silent_stub():
+    """The inbound stub does not raise — STT is wired separately."""
+    await handle_audio_frame(b"\x00\x01\x02", session_id="session-1")
+
+
+@pytest.mark.asyncio
+async def test_push_opus_frames_sends_each_frame_in_order():
+    """All frames reach the device in the order they were given."""
+    esp32 = _FakeESP32()
+    frames = [b"a", b"b", b"c"]
+
+    sent = await push_opus_frames(esp32, frames)
+
+    assert sent == 3
+    assert esp32.frames == frames
+
+
+@pytest.mark.asyncio
+async def test_push_opus_frames_propagates_disconnect():
+    """A mid-stream ConnectionError surfaces, with the partial count visible."""
+    esp32 = _FakeESP32(fail_after=2)
+    frames = [b"a", b"b", b"c", b"d"]
+
+    with pytest.raises(ConnectionError):
+        await push_opus_frames(esp32, frames)
+
+    # The first two frames did make it to the device before the failure.
+    assert esp32.frames == [b"a", b"b"]
+
+
+@pytest.mark.asyncio
+async def test_push_opus_frames_empty_iterable_returns_zero():
+    """Pushing zero frames is a no-op rather than an error."""
+    esp32 = _FakeESP32()
+
+    sent = await push_opus_frames(esp32, [])
+
+    assert sent == 0
+    assert esp32.frames == []

--- a/gateway/tests/test_audio_utils.py
+++ b/gateway/tests/test_audio_utils.py
@@ -1,0 +1,222 @@
+"""Tests for the TTS audio helpers (Issue #70 PR2)."""
+
+from __future__ import annotations
+
+import array
+
+import pytest
+
+from _audio_fixtures import make_wav_bytes
+from stackchan_mcp.tts.audio_utils import (
+    DEVICE_FRAME_DURATION_MS,
+    DEVICE_SAMPLE_RATE,
+    SAMPLES_PER_FRAME,
+    chunk_pcm_into_frames,
+    encode_opus_frames,
+    resample_pcm16_linear,
+    wav_to_pcm16_mono,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_device_constants_match_firmware():
+    """Device constants match firmware/main/audio/audio_service.h."""
+    assert DEVICE_SAMPLE_RATE == 16000
+    assert DEVICE_FRAME_DURATION_MS == 60
+    assert SAMPLES_PER_FRAME == 960  # 16000 * 60 / 1000
+
+
+# ---------------------------------------------------------------------------
+# WAV decoding
+# ---------------------------------------------------------------------------
+
+
+def test_wav_to_pcm16_mono_roundtrip_mono():
+    """Mono 16-bit PCM WAV decodes to the original bytes at the same rate."""
+    samples = [100, -200, 300, -400, 500]
+    wav = make_wav_bytes(sample_rate=24000, samples=samples)
+
+    rate, pcm = wav_to_pcm16_mono(wav)
+
+    assert rate == 24000
+    decoded = array.array("h")
+    decoded.frombytes(pcm)
+    assert list(decoded) == samples
+
+
+def test_wav_to_pcm16_mono_downmixes_stereo():
+    """Stereo input is averaged into mono."""
+    # L=1000, R=2000 -> mono should average to 1500
+    samples = [1000, 2000, -1000, -2000]
+    wav = make_wav_bytes(sample_rate=16000, channels=2, samples=samples)
+
+    rate, pcm = wav_to_pcm16_mono(wav)
+
+    decoded = array.array("h")
+    decoded.frombytes(pcm)
+    assert rate == 16000
+    assert list(decoded) == [1500, -1500]
+
+
+def test_wav_to_pcm16_mono_rejects_8bit():
+    """Non-16-bit inputs raise ValueError rather than silently dropping bits."""
+    import io
+    import struct
+    import wave
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(1)  # 8-bit unsigned PCM
+        wav.setframerate(16000)
+        wav.writeframes(struct.pack("<10B", *([0x80] * 10)))
+
+    with pytest.raises(ValueError, match="sample width"):
+        wav_to_pcm16_mono(buf.getvalue())
+
+
+def test_wav_to_pcm16_mono_rejects_unsupported_channels():
+    """Three or more channels would need a real downmixer; we just raise."""
+    import io
+    import struct
+    import wave
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(3)
+        wav.setsampwidth(2)
+        wav.setframerate(16000)
+        wav.writeframes(struct.pack("<6h", *([0] * 6)))
+
+    with pytest.raises(ValueError, match="channel count"):
+        wav_to_pcm16_mono(buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Resampling
+# ---------------------------------------------------------------------------
+
+
+def test_resample_same_rate_returns_input_unchanged():
+    """Equal rates skip the resample loop and return the same bytes."""
+    samples = array.array("h", [10, 20, 30, 40, 50])
+    pcm = samples.tobytes()
+
+    out = resample_pcm16_linear(pcm, 16000, 16000)
+
+    assert out == pcm
+
+
+def test_resample_24khz_to_16khz_shrinks_by_2_3():
+    """Downsampling 3:2 produces ~ 2/3 the samples."""
+    samples = array.array("h", list(range(0, 30)))  # 30 samples
+    pcm = samples.tobytes()
+
+    out = resample_pcm16_linear(pcm, 24000, 16000)
+    decoded = array.array("h")
+    decoded.frombytes(out)
+
+    # 30 * 16000 / 24000 = 20 samples
+    assert len(decoded) == 20
+    # Endpoints should line up with the source endpoints.
+    assert decoded[0] == 0
+    assert decoded[-1] == 29
+
+
+def test_resample_8khz_to_16khz_grows_by_2x():
+    """Upsampling 1:2 doubles the sample count."""
+    samples = array.array("h", [0, 100, 200])
+    pcm = samples.tobytes()
+
+    out = resample_pcm16_linear(pcm, 8000, 16000)
+    decoded = array.array("h")
+    decoded.frombytes(out)
+
+    # 3 * 16000 / 8000 = 6 samples
+    assert len(decoded) == 6
+    # Endpoints preserved.
+    assert decoded[0] == 0
+    assert decoded[-1] == 200
+
+
+def test_resample_empty_input_returns_empty():
+    """Empty PCM bytes are a no-op rather than a divide-by-zero."""
+    assert resample_pcm16_linear(b"", 24000, 16000) == b""
+
+
+def test_resample_single_sample_handled():
+    """A single sample resamples to exactly one sample (avoids div-by-zero)."""
+    pcm = array.array("h", [42]).tobytes()
+
+    out = resample_pcm16_linear(pcm, 24000, 16000)
+    decoded = array.array("h")
+    decoded.frombytes(out)
+
+    assert list(decoded) == [42]
+
+
+# ---------------------------------------------------------------------------
+# Frame chunking
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_pcm_into_frames_yields_fixed_size():
+    """Each yielded frame is exactly ``samples_per_frame * 2`` bytes."""
+    pcm = b"\x00\x00" * 2400  # 2400 samples
+    frames = list(chunk_pcm_into_frames(pcm, samples_per_frame=960))
+
+    # 2400 / 960 = 2.5 -> 3 frames (with the third zero-padded)
+    assert len(frames) == 3
+    for frame in frames:
+        assert len(frame) == 960 * 2
+
+
+def test_chunk_pcm_into_frames_zero_pads_tail():
+    """The trailing partial frame is zero-padded to the full size."""
+    pcm = b"\x01\x00" * 100  # 100 non-zero samples, one short frame
+    frames = list(chunk_pcm_into_frames(pcm, samples_per_frame=960))
+
+    assert len(frames) == 1
+    frame = frames[0]
+    assert len(frame) == 960 * 2
+    # First 100 samples non-zero, remaining zero-padded.
+    assert frame[: 100 * 2] == pcm
+    assert frame[100 * 2 :] == b"\x00" * (860 * 2)
+
+
+def test_chunk_pcm_into_frames_empty_input_yields_nothing():
+    """No PCM means no frames — not a single zero-padded frame."""
+    assert list(chunk_pcm_into_frames(b"", samples_per_frame=960)) == []
+
+
+def test_chunk_pcm_into_frames_rejects_non_positive_size():
+    """A zero or negative samples_per_frame is a programmer error."""
+    with pytest.raises(ValueError):
+        list(chunk_pcm_into_frames(b"\x00" * 100, samples_per_frame=0))
+
+
+# ---------------------------------------------------------------------------
+# Opus encoding (gated on libopus availability)
+# ---------------------------------------------------------------------------
+
+
+def test_encode_opus_frames_produces_frames_when_libopus_available():
+    """When libopus is reachable, encode_opus_frames yields one frame per chunk."""
+    opuslib = pytest.importorskip("opuslib")
+    try:
+        opuslib.Encoder(16000, 1, opuslib.APPLICATION_VOIP)
+    except Exception as exc:  # libopus not loadable
+        pytest.skip(f"libopus not available: {exc}")
+
+    # 60 ms of silence at 16 kHz mono = 960 samples = 1920 bytes
+    pcm = b"\x00\x00" * 960
+
+    frames = list(encode_opus_frames(pcm))
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], bytes)
+    assert len(frames[0]) > 0

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -7,6 +7,7 @@ covered by ``test_stdio_server.py`` and ``test_gateway.py``.
 
 from __future__ import annotations
 
+import os
 import socket
 from pathlib import Path
 
@@ -733,3 +734,103 @@ def test_run_preflight_both_ports_zero_is_not_a_conflict(
     out = capsys.readouterr().out
     assert "distinct ports" not in out
     assert "Result: ready. Exit 0." in out
+
+
+# ---------------------------------------------------------------------------
+# _ensure_libopus_findable — Homebrew dlopen helper (macOS) (Issue #70 PR2)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_libopus_findable_noop_on_non_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper is a strict no-op when the host platform is not macOS."""
+    monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+    monkeypatch.delenv("DYLD_LIBRARY_PATH", raising=False)
+
+    cli._ensure_libopus_findable()
+
+    assert "DYLD_LIBRARY_PATH" not in os.environ
+
+
+def test_ensure_libopus_findable_prepends_homebrew_lib(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present Homebrew lib directory is prepended to DYLD_LIBRARY_PATH."""
+    monkeypatch.setattr(cli.platform, "system", lambda: "Darwin")
+    # Pretend only /opt/homebrew/lib exists (Apple Silicon default).
+    monkeypatch.setattr(
+        cli.os.path,
+        "isdir",
+        lambda p: p == "/opt/homebrew/lib",
+    )
+    monkeypatch.delenv("DYLD_LIBRARY_PATH", raising=False)
+
+    cli._ensure_libopus_findable()
+
+    assert os.environ["DYLD_LIBRARY_PATH"] == "/opt/homebrew/lib"
+
+
+def test_ensure_libopus_findable_does_not_duplicate_existing_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An entry already on DYLD_LIBRARY_PATH is not re-prepended."""
+    monkeypatch.setattr(cli.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        cli.os.path,
+        "isdir",
+        lambda p: p == "/opt/homebrew/lib",
+    )
+    monkeypatch.setenv(
+        "DYLD_LIBRARY_PATH", "/opt/homebrew/lib:/some/other/lib"
+    )
+
+    cli._ensure_libopus_findable()
+
+    # Unchanged because the only candidate was already present.
+    assert (
+        os.environ["DYLD_LIBRARY_PATH"]
+        == "/opt/homebrew/lib:/some/other/lib"
+    )
+
+
+def test_ensure_libopus_findable_preserves_user_dyld_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """User-set DYLD_LIBRARY_PATH stays at the front; Homebrew is appended.
+
+    Operators who built libopus from source and pointed
+    DYLD_LIBRARY_PATH at the custom build expect that prefix to win.
+    The helper prepends Homebrew dirs ahead of itself but keeps the
+    operator's existing entries intact and after the new entries —
+    the new entries only fire if find_library does not match earlier.
+    """
+    monkeypatch.setattr(cli.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        cli.os.path,
+        "isdir",
+        lambda p: p in {"/opt/homebrew/lib", "/usr/local/lib"},
+    )
+    monkeypatch.setenv("DYLD_LIBRARY_PATH", "/Users/dev/libopus-build/lib")
+
+    cli._ensure_libopus_findable()
+
+    # New Homebrew dirs sit ahead of the helper-prepended block, but
+    # the user's prior entry follows them — i.e. it is still present.
+    parts = os.environ["DYLD_LIBRARY_PATH"].split(":")
+    assert "/Users/dev/libopus-build/lib" in parts
+    assert "/opt/homebrew/lib" in parts
+    assert "/usr/local/lib" in parts
+
+
+def test_ensure_libopus_findable_handles_missing_homebrew(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If neither Homebrew prefix exists, DYLD_LIBRARY_PATH is left alone."""
+    monkeypatch.setattr(cli.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(cli.os.path, "isdir", lambda p: False)
+    monkeypatch.delenv("DYLD_LIBRARY_PATH", raising=False)
+
+    cli._ensure_libopus_findable()
+
+    assert "DYLD_LIBRARY_PATH" not in os.environ

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -362,6 +362,21 @@ async def test_send_tts_state_translates_oserror_to_connection_error():
     assert not conn.connected
 
 
+def test_connection_default_protocol_version_is_one():
+    """Fresh ESP32Connection defaults to WebSocket protocol v1.
+
+    v1 is what the gateway's audio framing currently targets (raw
+    Opus binary frames). v2/v3 wrap payloads in a BinaryProtocol
+    header which this gateway does not yet emit; the hello handler
+    logs a warning when a non-v1 device negotiates so operators know
+    the TTS path may not work for them.
+    """
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-1")  # type: ignore[arg-type]
+
+    assert conn.protocol_version == 1
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -314,6 +314,54 @@ async def test_manager_send_tts_state_no_device():
         await mgr.send_tts_state("start")
 
 
+class _FailingWebSocket:
+    """WebSocket that raises a websockets-specific error on send()."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.send_calls = 0
+
+    async def send(self, data):
+        self.send_calls += 1
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_send_audio_frame_translates_websockets_close_to_connection_error():
+    """websockets.ConnectionClosed becomes ConnectionError + marks dead.
+
+    Without translation the websockets-specific exception would
+    bypass the orchestrator's ``except ConnectionError`` filter and
+    leak as a stack trace through the MCP transport.
+    """
+    import websockets.exceptions
+
+    closed = websockets.exceptions.ConnectionClosed(rcvd=None, sent=None)
+    ws = _FailingWebSocket(closed)
+    conn = ESP32Connection(ws, session_id="session-1")  # type: ignore[arg-type]
+
+    with pytest.raises(ConnectionError, match="WebSocket send"):
+        await conn.send_audio_frame(b"opus")
+
+    # After the translated failure, the connection is marked dead so
+    # subsequent sends fail fast without re-touching the dead socket.
+    assert not conn.connected
+    with pytest.raises(ConnectionError):
+        await conn.send_audio_frame(b"more")
+    assert ws.send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_send_tts_state_translates_oserror_to_connection_error():
+    """OSError on send (e.g. broken pipe) is translated to ConnectionError."""
+    ws = _FailingWebSocket(OSError("broken pipe"))
+    conn = ESP32Connection(ws, session_id="session-1")  # type: ignore[arg-type]
+
+    with pytest.raises(ConnectionError, match="WebSocket send"):
+        await conn.send_tts_state("start")
+    assert not conn.connected
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -275,6 +275,45 @@ async def test_manager_send_audio_frame_no_device():
         await mgr.send_audio_frame(b"opus_payload_bytes")
 
 
+@pytest.mark.asyncio
+async def test_connection_send_tts_state_sends_json():
+    """ESP32Connection.send_tts_state writes a tts state JSON message."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-tts")  # type: ignore[arg-type]
+
+    await conn.send_tts_state("start")
+
+    assert len(ws.sent) == 1
+    payload = json.loads(ws.sent[0])
+    assert payload == {
+        "session_id": "session-tts",
+        "type": "tts",
+        "state": "start",
+    }
+
+
+@pytest.mark.asyncio
+async def test_connection_send_tts_state_raises_after_disconnect():
+    """A disconnected connection refuses to send TTS notifications."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-tts")  # type: ignore[arg-type]
+
+    conn.disconnect()
+
+    with pytest.raises(ConnectionError):
+        await conn.send_tts_state("stop")
+    assert ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_manager_send_tts_state_no_device():
+    """ESP32Manager.send_tts_state raises when no device is attached."""
+    mgr = ESP32Manager()
+
+    with pytest.raises(ConnectionError):
+        await mgr.send_tts_state("start")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -7,7 +7,7 @@ import pytest
 import pytest_asyncio
 import websockets
 
-from stackchan_mcp.esp32_client import ESP32Manager
+from stackchan_mcp.esp32_client import ESP32Connection, ESP32Manager
 
 
 @pytest_asyncio.fixture
@@ -221,6 +221,58 @@ async def test_auth_rejection(manager):
                 await ws.recv()
     finally:
         del os.environ["STACKCHAN_TOKEN"]
+
+
+# ---------------------------------------------------------------------------
+# send_audio_frame (TTS pipeline egress, Issue #70 PR2)
+# ---------------------------------------------------------------------------
+
+
+class _FakeWebSocket:
+    """Minimal stand-in for websockets.ServerConnection used in unit tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes | str] = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+
+@pytest.mark.asyncio
+async def test_connection_send_audio_frame_sends_binary():
+    """ESP32Connection.send_audio_frame writes the bytes to the underlying WS."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-1")  # type: ignore[arg-type]
+
+    await conn.send_audio_frame(b"opus_payload_bytes")
+
+    assert ws.sent == [b"opus_payload_bytes"]
+
+
+@pytest.mark.asyncio
+async def test_connection_send_audio_frame_raises_after_disconnect():
+    """A disconnected connection refuses to send rather than silently dropping."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-1")  # type: ignore[arg-type]
+
+    conn.disconnect()
+
+    with pytest.raises(ConnectionError):
+        await conn.send_audio_frame(b"opus_payload_bytes")
+    assert ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_manager_send_audio_frame_no_device():
+    """ESP32Manager.send_audio_frame raises when no device is attached.
+
+    The orchestrator turns this into a clean MCP error JSON; without
+    this guard the call would AttributeError on a None connection.
+    """
+    mgr = ESP32Manager()
+
+    with pytest.raises(ConnectionError):
+        await mgr.send_audio_frame(b"opus_payload_bytes")
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -1,0 +1,164 @@
+"""Tests for the TTS orchestrator pipeline (Issue #70 PR2)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from stackchan_mcp.tts import EngineRegistry, TTSEngine, synthesize_and_send
+from stackchan_mcp.tts.audio_utils import (
+    DEVICE_FRAME_DURATION_MS,
+    DEVICE_SAMPLE_RATE,
+)
+
+
+class _PCMEngine(TTSEngine):
+    """Engine that returns a fixed PCM buffer and records the call."""
+
+    def __init__(self, pcm: bytes, name: str = "voicevox") -> None:
+        self.name = name
+        self._pcm = pcm
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def synthesize(self, text: str, **opts: Any) -> bytes:
+        self.calls.append((text, dict(opts)))
+        return self._pcm
+
+
+class _FakeESP32:
+    def __init__(self, *, connected: bool = True) -> None:
+        self.device_connected = connected
+        self.frames: list[bytes] = []
+
+    async def send_audio_frame(self, frame: bytes) -> None:
+        self.frames.append(frame)
+
+
+class _FakeGateway:
+    def __init__(self, esp32: _FakeESP32) -> None:
+        self.esp32 = esp32
+
+
+@pytest.fixture
+def fake_encode(monkeypatch):
+    """Replace encode_opus_frames so tests don't need libopus.
+
+    Each chunk of ``DEVICE_SAMPLE_RATE * DEVICE_FRAME_DURATION_MS / 1000``
+    samples becomes one fake Opus frame; the last partial chunk is
+    counted as a full frame too (matches the real encoder + chunker).
+    """
+
+    def fake(pcm: bytes, **kwargs):
+        samples_per_frame = (
+            DEVICE_SAMPLE_RATE * DEVICE_FRAME_DURATION_MS // 1000
+        )
+        bytes_per_frame = samples_per_frame * 2
+        n_full = len(pcm) // bytes_per_frame
+        n_partial = 1 if len(pcm) % bytes_per_frame else 0
+        n_total = n_full + n_partial
+        return iter(
+            f"opus_frame_{i}".encode() for i in range(n_total)
+        )
+
+    import stackchan_mcp.tts.orchestrator as orchestrator
+
+    monkeypatch.setattr(orchestrator, "encode_opus_frames", fake)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_pipeline_synthesises_encodes_and_pushes(fake_encode):
+    """A full happy-path call synthesises, encodes, and pushes to the device."""
+    # 90 ms of PCM @ 16 kHz mono = 1440 samples = 2880 bytes
+    pcm = b"\x01\x00" * 1440
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "こんにちは", "voice": "voicevox", "speaker_id": 7},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    # 1440 / 960 = 1.5 -> 2 frames (the second is zero-padded internally)
+    assert result["frame_count"] == 2
+    assert result["sample_rate"] == DEVICE_SAMPLE_RATE
+    assert result["frame_duration_ms"] == DEVICE_FRAME_DURATION_MS
+    assert result["duration_ms"] == 2 * DEVICE_FRAME_DURATION_MS
+    assert result["engine"] == "voicevox"
+    assert result["text"] == "こんにちは"
+    assert result["speaker_id"] == 7
+
+    assert esp32.frames == [b"opus_frame_0", b"opus_frame_1"]
+    assert engine.calls[0][0] == "こんにちは"
+    assert engine.calls[0][1]["speaker_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_pipeline_passes_reference_audio_through(fake_encode):
+    """reference_audio is forwarded to engines that support voice cloning."""
+    engine = _PCMEngine(b"\x00\x00" * 960)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    await synthesize_and_send(
+        {
+            "text": "hello",
+            "voice": "voicevox",
+            "reference_audio": "/tmp/sample.wav",
+        },
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert engine.calls[0][1]["reference_audio"] == "/tmp/sample.wav"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_raises_when_device_disconnected(fake_encode):
+    """Disconnected device fails fast before invoking the engine."""
+    engine = _PCMEngine(b"\x00\x00" * 960)
+    esp32 = _FakeESP32(connected=False)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError, match="ESP32"):
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    # Engine never gets called when there's no device to send to.
+    assert engine.calls == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_raises_when_engine_returns_no_pcm(fake_encode):
+    """An engine returning empty PCM is a bug, surfaced as a RuntimeError."""
+    engine = _PCMEngine(b"")
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError, match="no PCM"):
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    # Nothing pushed to the device when synthesis produced nothing.
+    assert esp32.frames == []

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -331,6 +332,48 @@ async def test_opus_encode_error_translated(fake_encode, monkeypatch):
             gateway=gateway,
             registry=reg,
         )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_paces_frames_at_device_rate(fake_encode, monkeypatch):
+    """Frame pushes are spaced at the device's frame_duration to avoid drops.
+
+    The firmware's decode queue holds ~40 packets, so a single burst
+    of more frames silently drops the tail. Pacing each push at
+    DEVICE_FRAME_DURATION_MS keeps the queue at ~1 frame, well below
+    the limit even on the longest utterances.
+    """
+    sleeps: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+        # Yield once so the event loop progresses, but don't actually
+        # wait — keeps the test fast.
+        await real_sleep(0)
+
+    monkeypatch.setattr("stackchan_mcp.tts.orchestrator.asyncio.sleep", fake_sleep)
+
+    pcm = b"\x01\x00" * 1440  # 1.5 -> 2 frames after chunking
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    await synthesize_and_send(
+        {"text": "hello"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    # First sleep is the post-tts.start state-transition delay (50 ms),
+    # then per-frame pacing. The exact number of pacing sleeps depends
+    # on loop.time() drift, so the test only asserts: (a) the start
+    # delay was inserted, (b) at least one pacing sleep occurred.
+    assert len(sleeps) >= 1
+    assert sleeps[0] == pytest.approx(0.05, rel=0.05)
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -162,3 +162,145 @@ async def test_pipeline_raises_when_engine_returns_no_pcm(fake_encode):
 
     # Nothing pushed to the device when synthesis produced nothing.
     assert esp32.frames == []
+
+
+# ---------------------------------------------------------------------------
+# Exception translation — failures must become clean RuntimeError so the
+# MCP handler's filter produces error JSON instead of leaking tracebacks.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingEngine(TTSEngine):
+    """Engine that fails synthesise with a configurable exception."""
+
+    def __init__(self, exc: Exception, name: str = "voicevox") -> None:
+        self.name = name
+        self._exc = exc
+
+    async def synthesize(self, text: str, **opts: Any) -> bytes:
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_engine_http_error_translated_to_runtime_error(fake_encode):
+    """An httpx.HTTPStatusError from the engine becomes a RuntimeError.
+
+    The MCP handler in stdio_server.py only catches RuntimeError /
+    ValueError / NotImplementedError; httpx errors must therefore be
+    translated here, not allowed to bubble up.
+    """
+    httpx = pytest.importorskip("httpx")
+
+    request = httpx.Request("POST", "http://test.local:50021/audio_query")
+    response = httpx.Response(503, request=request, text="overloaded")
+    http_err = httpx.HTTPStatusError("503", request=request, response=response)
+
+    reg = EngineRegistry()
+    reg.register(_RaisingEngine(http_err))
+    gateway = _FakeGateway(_FakeESP32(connected=True))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+    assert "voicevox" in str(exc_info.value).lower()
+    assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+
+
+@pytest.mark.asyncio
+async def test_engine_wave_error_translated_to_runtime_error(fake_encode):
+    """A wave.Error (malformed WAV from the engine) becomes a RuntimeError."""
+    import wave
+
+    reg = EngineRegistry()
+    reg.register(_RaisingEngine(wave.Error("not a WAVE file")))
+    gateway = _FakeGateway(_FakeESP32(connected=True))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+    assert isinstance(exc_info.value.__cause__, wave.Error)
+
+
+@pytest.mark.asyncio
+async def test_engine_value_error_propagates_as_value_error(fake_encode):
+    """ValueError stays a ValueError so bad args remain separable from ops failures."""
+    reg = EngineRegistry()
+    reg.register(_RaisingEngine(ValueError("bad speaker_id")))
+    gateway = _FakeGateway(_FakeESP32(connected=True))
+
+    with pytest.raises(ValueError, match="bad speaker_id"):
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_translates_mid_stream_disconnect(fake_encode):
+    """A ConnectionError from the device mid-stream becomes a RuntimeError.
+
+    ConnectionError doesn't inherit RuntimeError, so without
+    translation it would skip the MCP handler's exception filter and
+    surface as a stack trace.
+    """
+
+    class FailingESP32:
+        device_connected = True
+
+        def __init__(self) -> None:
+            self.frames: list[bytes] = []
+
+        async def send_audio_frame(self, frame: bytes) -> None:
+            if len(self.frames) >= 1:
+                raise ConnectionError("simulated disconnect")
+            self.frames.append(frame)
+
+    pcm = b"\x01\x00" * 1440  # 1.5 frames worth
+    engine = _PCMEngine(pcm)
+    esp32 = FailingESP32()
+    gateway = _FakeGateway(esp32)  # type: ignore[arg-type]
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+    msg = str(exc_info.value)
+    assert "1/2" in msg or "disconnect" in msg.lower()
+    assert isinstance(exc_info.value.__cause__, ConnectionError)
+    # The first frame did make it before the failure.
+    assert len(esp32.frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_opus_encode_error_translated(fake_encode, monkeypatch):
+    """A failure in encode_opus_frames becomes a RuntimeError, not a leak."""
+
+    def boom(pcm: bytes, **kwargs):
+        raise RuntimeError("libopus missing")
+
+    import stackchan_mcp.tts.orchestrator as orchestrator
+
+    monkeypatch.setattr(orchestrator, "encode_opus_frames", boom)
+
+    reg = EngineRegistry()
+    reg.register(_PCMEngine(b"\x01\x00" * 960))
+    gateway = _FakeGateway(_FakeESP32(connected=True))
+
+    with pytest.raises(RuntimeError, match="Opus encoding failed"):
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -30,9 +30,19 @@ class _FakeESP32:
     def __init__(self, *, connected: bool = True) -> None:
         self.device_connected = connected
         self.frames: list[bytes] = []
+        self.tts_states: list[str] = []
+        # Records the relative order in which audio frames and TTS state
+        # notifications were dispatched, so tests can assert that
+        # ``start`` precedes any frame and ``stop`` trails them.
+        self.events: list[tuple[str, object]] = []
 
     async def send_audio_frame(self, frame: bytes) -> None:
         self.frames.append(frame)
+        self.events.append(("frame", frame))
+
+    async def send_tts_state(self, state: str) -> None:
+        self.tts_states.append(state)
+        self.events.append(("tts_state", state))
 
 
 class _FakeGateway:
@@ -97,6 +107,13 @@ async def test_pipeline_synthesises_encodes_and_pushes(fake_encode):
     assert esp32.frames == [b"opus_frame_0", b"opus_frame_1"]
     assert engine.calls[0][0] == "こんにちは"
     assert engine.calls[0][1]["speaker_id"] == 7
+    # TTS start before any frame, stop after the last frame.
+    assert esp32.tts_states == ["start", "stop"]
+    assert esp32.events[0] == ("tts_state", "start")
+    assert esp32.events[-1] == ("tts_state", "stop")
+    # All frames sit between start and stop.
+    middle = esp32.events[1:-1]
+    assert all(kind == "frame" for kind, _ in middle)
 
 
 @pytest.mark.asyncio
@@ -256,11 +273,18 @@ async def test_pipeline_translates_mid_stream_disconnect(fake_encode):
 
         def __init__(self) -> None:
             self.frames: list[bytes] = []
+            self.tts_states: list[str] = []
 
         async def send_audio_frame(self, frame: bytes) -> None:
             if len(self.frames) >= 1:
                 raise ConnectionError("simulated disconnect")
             self.frames.append(frame)
+
+        async def send_tts_state(self, state: str) -> None:
+            # The disconnect can race the stop notification; if the
+            # caller still tries to send it after the failure, simulate
+            # a benign no-op rather than raising again.
+            self.tts_states.append(state)
 
     pcm = b"\x01\x00" * 1440  # 1.5 frames worth
     engine = _PCMEngine(pcm)
@@ -281,6 +305,9 @@ async def test_pipeline_translates_mid_stream_disconnect(fake_encode):
     assert isinstance(exc_info.value.__cause__, ConnectionError)
     # The first frame did make it before the failure.
     assert len(esp32.frames) == 1
+    # The stop notification was attempted regardless of the disconnect.
+    assert "start" in esp32.tts_states
+    assert "stop" in esp32.tts_states
 
 
 @pytest.mark.asyncio
@@ -304,3 +331,43 @@ async def test_opus_encode_error_translated(fake_encode, monkeypatch):
             gateway=gateway,
             registry=reg,
         )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_disconnect_before_tts_start(fake_encode):
+    """ConnectionError on the start notification surfaces clearly.
+
+    Without a clean message here the pipeline would degenerate into a
+    confusing "0/N frames" report even though no frame was attempted.
+    """
+
+    class FailingESP32:
+        device_connected = True
+        tts_states: list[str] = []  # noqa: RUF012
+
+        def __init__(self) -> None:
+            self.tts_states = []
+
+        async def send_tts_state(self, state: str) -> None:
+            self.tts_states.append(state)
+            if state == "start":
+                raise ConnectionError("device dropped during start")
+
+        async def send_audio_frame(self, frame: bytes) -> None:
+            raise AssertionError("frame should not be attempted after start failure")
+
+    pcm = b"\x01\x00" * 960
+    engine = _PCMEngine(pcm)
+    esp32 = FailingESP32()
+    gateway = _FakeGateway(esp32)  # type: ignore[arg-type]
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError, match="TTS start"):
+        await synthesize_and_send(
+            {"text": "hello"},
+            gateway=gateway,
+            registry=reg,
+        )
+    assert esp32.tts_states == ["start"]

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -162,6 +162,64 @@ async def test_pipeline_raises_when_device_disconnected(fake_encode):
 
 
 @pytest.mark.asyncio
+async def test_pipeline_blocks_protocol_v2(fake_encode):
+    """Devices that negotiated WebSocket protocol v2 are blocked.
+
+    The gateway emits raw Opus binary frames matching firmware v1; v2/v3
+    expect a BinaryProtocol header wrapped around each binary message.
+    Streaming raw frames to a v2/v3 device causes silent playback
+    failure, so the orchestrator must fail fast with a clear error
+    rather than reporting say() success for an utterance that will
+    never play.
+    """
+    from types import SimpleNamespace
+
+    pcm = b"\x01\x00" * 1440
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    esp32.connection = SimpleNamespace(protocol_version=2)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError, match="protocol v1"):
+        await synthesize_and_send(
+            {"text": "hello"}, gateway=gateway, registry=reg
+        )
+
+    # Nothing should reach the device — neither TTS state notifications
+    # nor audio frames — and the engine must not even be invoked, since
+    # synthesis would be wasted work.
+    assert esp32.tts_states == []
+    assert esp32.frames == []
+    assert engine.calls == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_protocol_v3(fake_encode):
+    """Devices on protocol v3 are blocked the same way as v2."""
+    from types import SimpleNamespace
+
+    pcm = b"\x01\x00" * 1440
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    esp32.connection = SimpleNamespace(protocol_version=3)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError, match=r"v3"):
+        await synthesize_and_send(
+            {"text": "hi"}, gateway=gateway, registry=reg
+        )
+
+    assert esp32.tts_states == []
+    assert esp32.frames == []
+
+
+@pytest.mark.asyncio
 async def test_pipeline_raises_when_engine_returns_no_pcm(fake_encode):
     """An engine returning empty PCM is a bug, surfaced as a RuntimeError."""
     engine = _PCMEngine(b"")

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -36,6 +36,11 @@ class _FakeESP32:
         # notifications were dispatched, so tests can assert that
         # ``start`` precedes any frame and ``stop`` trails them.
         self.events: list[tuple[str, object]] = []
+        # Mirror the production manager's per-device TTS lock so the
+        # orchestrator's ``async with gateway.esp32.tts_lock`` works the
+        # same way under tests as in production. The lock is created
+        # per-fake so each test runs against a fresh instance.
+        self.tts_lock = asyncio.Lock()
 
     async def send_audio_frame(self, frame: bytes) -> None:
         self.frames.append(frame)
@@ -197,6 +202,66 @@ async def test_pipeline_blocks_protocol_v2(fake_encode):
 
 
 @pytest.mark.asyncio
+async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
+    """Concurrent ``say()`` invocations don't interleave on the same device.
+
+    Without the per-device TTS lock, two ``synthesize_and_send`` calls
+    running concurrently would each ``send_tts_state("start")``, race
+    through the ``TTS_START_TRANSITION_DELAY_S`` ``asyncio.sleep`` (the
+    cooperative yield point in this fake), then dump their frames and
+    stop notifications in arbitrary order on the same WebSocket. With
+    the lock, the recorded event stream must show one full
+    ``start → frames → stop`` sequence followed by another, never
+    interleaved — a strictly sequential pattern is what the device
+    relies on to stay in ``kDeviceStateSpeaking`` for one utterance at
+    a time.
+    """
+    pcm = b"\x01\x00" * 1440  # ~3 frames of audio
+    engine_a = _PCMEngine(pcm, name="engine_a")
+    engine_b = _PCMEngine(pcm, name="engine_b")
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine_a)
+    reg.register(engine_b)
+
+    await asyncio.gather(
+        synthesize_and_send(
+            {"text": "first", "voice": "engine_a"},
+            gateway=gateway,
+            registry=reg,
+        ),
+        synthesize_and_send(
+            {"text": "second", "voice": "engine_b"},
+            gateway=gateway,
+            registry=reg,
+        ),
+    )
+
+    events = esp32.events
+    start_indices = [
+        i for i, e in enumerate(events) if e == ("tts_state", "start")
+    ]
+    stop_indices = [
+        i for i, e in enumerate(events) if e == ("tts_state", "stop")
+    ]
+    assert len(start_indices) == 2
+    assert len(stop_indices) == 2
+
+    # The lock guarantees a strictly sequential pattern:
+    #   start_0 < stop_0 < start_1 < stop_1
+    # The second utterance cannot begin until the first one finishes
+    # its stop notification.
+    assert (
+        start_indices[0]
+        < stop_indices[0]
+        < start_indices[1]
+        < stop_indices[1]
+    )
+
+
+@pytest.mark.asyncio
 async def test_pipeline_blocks_protocol_v3(fake_encode):
     """Devices on protocol v3 are blocked the same way as v2."""
     from types import SimpleNamespace
@@ -333,6 +398,7 @@ async def test_pipeline_translates_mid_stream_disconnect(fake_encode):
         def __init__(self) -> None:
             self.frames: list[bytes] = []
             self.tts_states: list[str] = []
+            self.tts_lock = asyncio.Lock()
 
         async def send_audio_frame(self, frame: bytes) -> None:
             if len(self.frames) >= 1:
@@ -448,6 +514,7 @@ async def test_pipeline_disconnect_before_tts_start(fake_encode):
 
         def __init__(self) -> None:
             self.tts_states = []
+            self.tts_lock = asyncio.Lock()
 
         async def send_tts_state(self, state: str) -> None:
             self.tts_states.append(state)

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -244,6 +244,9 @@ async def test_say_returns_error_json_when_voicevox_returns_5xx(monkeypatch):
         async def send_audio_frame(self, frame):
             raise AssertionError("synthesise should have failed before push")
 
+        async def send_tts_state(self, state):  # noqa: ARG002 - test stub
+            return None
+
     class FakeGateway:
         esp32 = FakeESP32()
 
@@ -298,6 +301,9 @@ async def test_say_returns_error_json_when_device_disconnects_mid_stream(
             if self.frames:
                 raise ConnectionError("simulated disconnect")
             self.frames.append(frame)
+
+        async def send_tts_state(self, state):  # noqa: ARG002 - test stub
+            return None
 
     class FakeGateway:
         esp32 = FailingESP32()

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -118,27 +118,27 @@ async def test_list_tools_includes_say():
 
 
 @pytest.mark.asyncio
-async def test_say_returns_clean_error_when_no_engine_registered():
-    """say without a registered engine surfaces NotImplementedError as JSON.
+async def test_say_unknown_voice_returns_clean_error():
+    """say with an unknown voice returns a clean error JSON, not a traceback.
 
-    The default registry has no engines in PR1, so we don't even need a
-    fake gateway: the say handler short-circuits before touching ESP32.
+    This invariant holds regardless of which engines happen to be
+    registered at the default level — the orchestrator must surface a
+    NotImplementedError to the caller as MCP error JSON.
     """
-    # Sanity-check the assumption: default registry must be empty here so
-    # the test reflects PR1's published surface.
-    assert get_registry().names() == []
-
     server = create_server()
     result = await server.request_handlers[CallToolRequest](
         CallToolRequest(
             method="tools/call",
-            params={"name": "say", "arguments": {"text": "hello"}},
+            params={
+                "name": "say",
+                "arguments": {"text": "hello", "voice": "nonexistent_engine"},
+            },
         )
     )
 
     payload = json.loads(result.root.content[0].text)
     assert "error" in payload
-    assert "voicevox" in payload["error"]
+    assert "nonexistent_engine" in payload["error"]
 
 
 @pytest.mark.asyncio
@@ -158,13 +158,13 @@ async def test_say_rejects_empty_text_with_clean_error():
 
 
 @pytest.mark.asyncio
-async def test_say_runs_without_esp32_connection(monkeypatch):
-    """say does not require an ESP32 device to surface its 'no engine' error.
+async def test_say_returns_clean_error_when_device_disconnected(monkeypatch):
+    """say without a connected ESP32 surfaces a clean MCP error JSON.
 
-    Phase 4 PR1 ships the framework only; the say handler needs to give a
-    useful error before any concrete engine is wired up, even when no
-    device is connected. This guards against accidentally moving the
-    handler below the device_connected gate during refactors.
+    Validation passes (text + registered engine), the orchestrator
+    needs to push frames somewhere, and the device gate fires. The
+    handler must turn that into ``{"error": "..."}`` rather than
+    leaking a stack trace through the MCP transport.
     """
 
     class FakeESP32:
@@ -189,10 +189,20 @@ async def test_say_runs_without_esp32_connection(monkeypatch):
     )
 
     payload = json.loads(result.root.content[0].text)
-    # Should be the engine-not-registered error, not the
-    # device_connected guard's "No ESP32 device connected" error.
     assert "error" in payload
-    assert "engine" in payload["error"].lower()
+    msg = payload["error"].lower()
+    assert "esp32" in msg or "device" in msg
+
+
+@pytest.mark.asyncio
+async def test_default_registry_includes_voicevox():
+    """The default registry registers VOICEVOX at import time.
+
+    PR2 of Issue #70 wires VOICEVOX in via ``tts/__init__.py`` so users
+    who install the ``[tts]`` extra can call ``say`` without needing
+    to register an engine themselves. This test pins that contract.
+    """
+    assert "voicevox" in get_registry().names()
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -205,6 +205,120 @@ async def test_default_registry_includes_voicevox():
     assert "voicevox" in get_registry().names()
 
 
+# ---------------------------------------------------------------------------
+# say handler regression tests — degraded VOICEVOX / mid-stream disconnect
+# must produce error JSON, not stack traces. Codex adversarial review
+# flagged that this contract was previously only verified at the
+# orchestrator level; these tests close the loop through create_server().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_say_returns_error_json_when_voicevox_returns_5xx(monkeypatch):
+    """A 503 from VOICEVOX surfaces as ``{"error": ...}``, not a traceback."""
+    httpx = pytest.importorskip("httpx")
+
+    from stackchan_mcp.tts import EngineRegistry, TTSEngine
+    import stackchan_mcp.tts.orchestrator as orchestrator
+    import stackchan_mcp.stdio_server as stdio_server
+
+    class _HttpFailEngine(TTSEngine):
+        name = "voicevox"
+
+        async def synthesize(self, text, **opts):
+            request = httpx.Request("POST", "http://test/audio_query")
+            response = httpx.Response(503, request=request, text="overloaded")
+            raise httpx.HTTPStatusError(
+                "503", request=request, response=response
+            )
+
+    reg = EngineRegistry()
+    reg.register(_HttpFailEngine())
+
+    class FakeESP32:
+        device_connected = True
+
+        def get_status(self):
+            return {"connected": True}
+
+        async def send_audio_frame(self, frame):
+            raise AssertionError("synthesise should have failed before push")
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(orchestrator, "get_registry", lambda: reg)
+
+    server = create_server()
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "say", "arguments": {"text": "hello"}},
+        )
+    )
+    payload = json.loads(result.root.content[0].text)
+    assert "error" in payload
+    assert "voicevox" in payload["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_say_returns_error_json_when_device_disconnects_mid_stream(
+    monkeypatch,
+):
+    """A mid-stream disconnect surfaces as ``{"error": ...}``."""
+    from stackchan_mcp.tts import EngineRegistry, TTSEngine
+    import stackchan_mcp.tts.orchestrator as orchestrator
+    import stackchan_mcp.stdio_server as stdio_server
+
+    pcm = b"\x01\x00" * 1440  # ~ 1.5 frames
+
+    class _PCMEngine(TTSEngine):
+        name = "voicevox"
+
+        async def synthesize(self, text, **opts):
+            return pcm
+
+    reg = EngineRegistry()
+    reg.register(_PCMEngine())
+
+    def fake_encode(_pcm, **kwargs):
+        return iter([b"opus_a", b"opus_b"])
+
+    class FailingESP32:
+        device_connected = True
+
+        def __init__(self):
+            self.frames: list[bytes] = []
+
+        def get_status(self):
+            return {"connected": True}
+
+        async def send_audio_frame(self, frame):
+            if self.frames:
+                raise ConnectionError("simulated disconnect")
+            self.frames.append(frame)
+
+    class FakeGateway:
+        esp32 = FailingESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(orchestrator, "get_registry", lambda: reg)
+    monkeypatch.setattr(orchestrator, "encode_opus_frames", fake_encode)
+
+    server = create_server()
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "say", "arguments": {"text": "hello"}},
+        )
+    )
+    payload = json.loads(result.root.content[0].text)
+    assert "error" in payload
+    msg = payload["error"].lower()
+    assert "disconnect" in msg or "frame" in msg
+
+
 @pytest.mark.asyncio
 async def test_set_mouth_sequence_relays_steps_as_json_string(monkeypatch):
     """set_mouth_sequence serialises steps to JSON for the firmware.

--- a/gateway/tests/test_tts_framework.py
+++ b/gateway/tests/test_tts_framework.py
@@ -126,12 +126,17 @@ async def test_synthesize_and_send_unregistered_voice_raises():
 
 
 @pytest.mark.asyncio
-async def test_synthesize_and_send_registered_voice_raises_pipeline_not_wired():
-    """Even with an engine present, PR1 stops short of running the pipeline."""
+async def test_synthesize_and_send_requires_gateway():
+    """Validation passes but pipeline refuses without a gateway argument.
+
+    Surfacing a clear RuntimeError beats silently synthesising PCM that
+    has nowhere to go. Validation tests can still exercise the
+    argument-shape surface without spinning up a Gateway.
+    """
     reg = EngineRegistry()
     reg.register(_FakeEngine(name="voicevox"))
 
-    with pytest.raises(NotImplementedError, match="pipeline"):
+    with pytest.raises(RuntimeError, match="gateway"):
         await synthesize_and_send({"text": "hello"}, registry=reg)
 
 

--- a/gateway/tests/test_voicevox.py
+++ b/gateway/tests/test_voicevox.py
@@ -1,0 +1,193 @@
+"""Tests for the VOICEVOX engine HTTP client (Issue #70 PR2)."""
+
+from __future__ import annotations
+
+import array
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from _audio_fixtures import make_wav_bytes  # noqa: E402  (import after importorskip)
+from stackchan_mcp.tts.voicevox import (  # noqa: E402
+    DEFAULT_VOICEVOX_SPEAKER,
+    DEFAULT_VOICEVOX_URL,
+    VoicevoxEngine,
+)
+
+
+def _build_handler(captured: list[dict]):
+    """Construct an httpx mock handler that emulates the VOICEVOX server."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "params": dict(request.url.params),
+            }
+        )
+        path = request.url.path
+        if path == "/audio_query":
+            return httpx.Response(
+                200,
+                json={"speedScale": 1.0, "kana": "ハロー", "_test": True},
+            )
+        if path == "/synthesis":
+            wav = make_wav_bytes(
+                sample_rate=24000,
+                duration_ms=60,
+                samples=[i * 10 for i in range(24000 * 60 // 1000)],
+            )
+            return httpx.Response(200, content=wav)
+        return httpx.Response(404)
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_engine_name_is_voicevox():
+    """The registry uses ``name`` to look up engines from the say tool's voice arg."""
+    engine = VoicevoxEngine()
+    assert engine.name == "voicevox"
+
+
+def test_default_speaker_constant_is_zundamon_normal():
+    """3 = Zundamon normal — pinned to keep documentation honest."""
+    assert DEFAULT_VOICEVOX_SPEAKER == 3
+
+
+def test_default_url_constant_matches_docker_image():
+    """Default URL must match the upstream voicevox/voicevox_engine port."""
+    assert DEFAULT_VOICEVOX_URL == "http://127.0.0.1:50021"
+
+
+def test_url_param_strips_trailing_slash():
+    """A trailing slash on the configured URL would produce ``//audio_query``."""
+    engine = VoicevoxEngine(url="http://example.com:50021/")
+    assert engine.url == "http://example.com:50021"
+
+
+def test_default_speaker_param_overrides_env(monkeypatch):
+    """Constructor argument wins over the environment variable."""
+    monkeypatch.setenv("STACKCHAN_VOICEVOX_DEFAULT_SPEAKER", "8")
+    engine = VoicevoxEngine(default_speaker=42)
+    assert engine.default_speaker == 42
+
+
+def test_default_speaker_falls_back_on_invalid_env(monkeypatch):
+    """Garbage in the env variable logs a warning and falls back to default."""
+    monkeypatch.setenv("STACKCHAN_VOICEVOX_DEFAULT_SPEAKER", "not-an-int")
+    engine = VoicevoxEngine()
+    assert engine.default_speaker == DEFAULT_VOICEVOX_SPEAKER
+
+
+# ---------------------------------------------------------------------------
+# synthesize() pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_calls_audio_query_then_synthesis():
+    """Two HTTP calls in order: /audio_query, then /synthesis."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    engine = VoicevoxEngine(
+        url="http://test.local:50021",
+        default_speaker=DEFAULT_VOICEVOX_SPEAKER,
+        transport=transport,
+    )
+
+    pcm = await engine.synthesize("こんにちは")
+
+    assert len(captured) == 2
+    assert captured[0]["path"] == "/audio_query"
+    assert captured[1]["path"] == "/synthesis"
+    assert captured[0]["params"]["text"] == "こんにちは"
+    assert captured[0]["params"]["speaker"] == str(DEFAULT_VOICEVOX_SPEAKER)
+    assert captured[1]["params"]["speaker"] == str(DEFAULT_VOICEVOX_SPEAKER)
+    assert isinstance(pcm, bytes)
+    assert len(pcm) > 0
+
+
+@pytest.mark.asyncio
+async def test_synthesize_uses_speaker_id_override():
+    """speaker_id in opts overrides the engine's default."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    engine = VoicevoxEngine(
+        url="http://test.local:50021",
+        default_speaker=3,
+        transport=transport,
+    )
+
+    await engine.synthesize("hello", speaker_id=14)
+
+    assert captured[0]["params"]["speaker"] == "14"
+    assert captured[1]["params"]["speaker"] == "14"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_resamples_24khz_wav_to_16khz():
+    """VOICEVOX's 24 kHz output is resampled down to the device's 16 kHz."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    engine = VoicevoxEngine(
+        url="http://test.local:50021",
+        transport=transport,
+    )
+
+    pcm = await engine.synthesize("a" * 10)
+
+    # The handler returns 60 ms @ 24 kHz = 1440 samples = 2880 bytes.
+    # After linear resample to 16 kHz: 1440 * 16000 / 24000 = 960 samples
+    # = 1920 bytes. Allow a tiny tolerance for the linear interpolator
+    # rounding the endpoint mapping.
+    decoded = array.array("h")
+    decoded.frombytes(pcm)
+    assert 950 <= len(decoded) <= 970
+
+
+@pytest.mark.asyncio
+async def test_synthesize_rejects_empty_text():
+    """Empty/whitespace text fails fast before any HTTP call."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    engine = VoicevoxEngine(transport=transport)
+
+    with pytest.raises(ValueError, match="text"):
+        await engine.synthesize("   ")
+
+    assert captured == []  # never reached the network
+
+
+@pytest.mark.asyncio
+async def test_synthesize_rejects_non_int_speaker_id():
+    """Non-integer speaker_id is a clean ValueError, not a TypeError later."""
+    transport = httpx.MockTransport(_build_handler([]))
+    engine = VoicevoxEngine(transport=transport)
+
+    with pytest.raises(ValueError, match="speaker_id"):
+        await engine.synthesize("hello", speaker_id="not-an-int")
+
+
+@pytest.mark.asyncio
+async def test_synthesize_propagates_http_errors():
+    """A non-2xx response from VOICEVOX surfaces as an httpx error.
+
+    The orchestrator turns that into a clean MCP error JSON; the
+    engine's job is just to fail loudly.
+    """
+
+    def handler(request):
+        return httpx.Response(503, text="VOICEVOX overloaded")
+
+    transport = httpx.MockTransport(handler)
+    engine = VoicevoxEngine(transport=transport)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await engine.synthesize("hello")

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -754,6 +754,12 @@ wheels = [
 ]
 
 [[package]]
+name = "opuslib"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/55/826befabb29fd3902bad6d6d7308790894c7ad4d73f051728a0c53d37cd7/opuslib-3.0.1.tar.gz", hash = "sha256:2cb045e5b03e7fc50dfefe431e3404dddddbd8f5961c10c51e32dfb69a044c97", size = 8550, upload-time = "2018-01-16T06:04:42.184Z" }
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1323,6 +1329,16 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+tts = [
+    { name = "httpx" },
+    { name = "opuslib" },
+]
+tts-voicevox = [
+    { name = "httpx" },
+    { name = "opuslib" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -1333,11 +1349,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3" },
+    { name = "httpx", marker = "extra == 'tts'", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.0" },
+    { name = "opuslib", marker = "extra == 'tts'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv" },
+    { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-voicevox'" },
     { name = "websockets", specifier = ">=12" },
 ]
+provides-extras = ["tts", "tts-voicevox"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Wire up the gateway-side TTS pipeline so the `say()` MCP tool added in #74 can actually drive the device speaker. PR1 (#74) landed the engine-agnostic skeleton; this PR adds the default **VOICEVOX** engine, the synthesis -> Opus encode -> WebSocket push orchestration, and the TTS state notifications the firmware needs to actually play received audio.

The intended PR stack for Issue #70:

- ✅ PR1 (#74) — framework only (TTSEngine ABC, EngineRegistry, validation surface)
- 🔵 **PR2 (this one)** — VOICEVOX engine + Opus pipeline + TTS state notifications + flow control + protocol-version gate + per-device serialisation
- ⏳ PR3 — Irodori-TTS (zero-shot voice cloning, MIT-licensed) + `[tts-irodori]` extra

## What lands here

### Engine + pipeline

- `gateway/stackchan_mcp/tts/voicevox.py` — HTTP client for a user-run VOICEVOX engine. Two POSTs (`/audio_query`, `/synthesis`), WAV decode, linear resample to 16 kHz mono. VOICEVOX runs as a separate HTTP process so its **LGPL-3.0** license stays scoped to the engine and does not affect the **MIT** gateway.
- `gateway/stackchan_mcp/tts/audio_utils.py` — WAV decode, linear resample (no scipy — keeps the `[tts]` extra light), fixed-size frame chunking with zero-pad tail, lazy-import opuslib Opus encoding. Constants pinned against `firmware/main/audio/audio_service.h` (16 kHz / mono / 60 ms / 960 samples).
- `gateway/stackchan_mcp/tts/orchestrator.py` — `synthesize_and_send` runs the full pipeline: validation, engine lookup, **protocol-version gate (v1 only)**, synthesis, Opus encode, **TTS start notification → 50 ms transition delay → frame-rate-paced push → TTS stop notification**, the whole start → frames → stop block guarded by a per-device `asyncio.Lock` so concurrent `say()` invocations don't interleave. All expected operational failures (engine errors, Opus errors, mid-stream disconnect) are translated to `RuntimeError` so the MCP handler's narrow filter produces clean error JSON.
- `gateway/stackchan_mcp/audio_stream.py` + `esp32_client.py` — `push_opus_frames` helper plus `ESP32Connection.send_audio_frame` / `send_tts_state` (and matching `ESP32Manager` methods). All sends go through `_ws_send`, which translates `websockets.ConnectionClosed` and `OSError` into the built-in `ConnectionError`. `ESP32Manager` now also owns the `tts_lock` (`asyncio.Lock`) and `connection.protocol_version` accessor surfaced for the orchestrator's gate.

### Firmware-protocol details that informed the design

- Audio frames must be bracketed in `{"type":"tts","state":"start"|"stop"}` JSON notifications. `Application::OnIncomingAudio` only forwards packets to the decode queue while in `kDeviceStateSpeaking`; without the start notification, frames are dropped and the tool returns success while nothing plays.
- Decode queue is bounded at ~40 packets (`MAX_DECODE_PACKETS_IN_QUEUE = 2400 / OPUS_FRAME_DURATION_MS`). Long utterances lose their tail without per-frame pacing. We pace at the device's consumption rate (`frame_duration_ms`) using the wall clock as the reference.
- WebSocket binary protocol has v1 / v2 / v3 wire formats; firmware default is v1 (raw Opus payload), which matches our wire format. The connection records the negotiated version on the hello handshake; on v2/v3 the orchestrator now **fails fast with a clear error** rather than silently sending raw frames the firmware would misparse as `BinaryProtocol` headers. Header-wrapping support is intentionally deferred to a follow-up.

### Configuration + packaging

- `gateway/pyproject.toml`: new `[project.optional-dependencies]` family. `[tts]` pulls `httpx` + `opuslib`; `[tts-voicevox]` is an intent-declaring alias (the engine itself is an external HTTP process and adds no Python deps).
- `.github/workflows/build.yml`: install `libopus0` / `libopus-dev` on the Ubuntu runner and `uv sync --extra tts` so the new tests can exercise the encoder path under CI.
- `gateway/stackchan_mcp/cli.py`: prepends Homebrew lib paths to `DYLD_LIBRARY_PATH` before importing `opuslib` so contributors who follow the README's `brew install opus` instructions don't trip over `find_library("opus")` on Apple Silicon / Intel macOS.

### Documentation

- `README.md` / `README.ja.md`: TTS row in the tools table + a new "Optional: TTS setup (VOICEVOX)" quick-start section in both languages, with the Docker engine command, install command, configuration env vars, and a worked example.
- `CHANGELOG.md`: `[Unreleased]` entry describing the new tool, the engine-agnostic framework, and the LGPL-3.0 license isolation.

### Tests

166 passed total in the gateway suite. New coverage exercises `audio_utils`, `voicevox` (httpx `MockTransport`), `orchestrator` (mocked `encode_opus_frames` so pipeline tests don't need libopus, plus dedicated cases for protocol v2/v3 fail-fast behaviour and concurrent-call serialisation), `audio_stream`, `cli` (libopus path discovery), and `esp32_client` (`send_audio_frame`, `send_tts_state`, websockets exception translation, protocol-version default).

## Local pre-PR review

Codex was run **six** times against this branch:

1. **adversarial** — flagged narrow exception filter (`httpx.HTTPError` / `wave.Error` / `ConnectionError` could leak as stack traces). Fixed: `RuntimeError` translation in the orchestrator + regression tests at the `create_server()` level.
2. **review** — flagged missing `tts.start` / `tts.stop` notifications (audio frames silently dropped on the firmware side). Fixed: `send_tts_state` + bracketed audio loop.
3. **review** — flagged decode-queue overflow on long utterances + `websockets.ConnectionClosed` not being a `ConnectionError`. Fixed: per-frame pacing + `_ws_send` exception translation.
4. **review** — flagged BinaryProtocol v2/v3 wire format. Initially mitigated with a hello-time warning; subsequent pass tightened this to a hard block (see #5 below).
5. **review (P1)** — flagged that the v2/v3 warning still let `say()` proceed and silently fail. Fixed: orchestrator now raises `RuntimeError` on any non-v1 protocol version with two regression tests pinning v2 and v3 fail-fast behaviour.
6. **review (P2)** — flagged that two concurrent `say()` calls would interleave their Opus frames and `tts.start`/`tts.stop` notifications on a single WebSocket. Fixed: per-device `asyncio.Lock` on `ESP32Manager.tts_lock`, acquired around the entire start → frames → stop block; new test asserts strict sequential ordering under `asyncio.gather`.

Final pass: no blocking findings.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` — **166 passed**
- [x] gateway: `uv run ruff check .` — All checks passed
- [x] No personal/private artefacts in the diff (`git diff main..HEAD --stat` reviewed; no `sdkconfig.defaults` / `.env` / personal IPs / tokens)
- [x] Local pre-PR Codex review (six passes — see above)

### Hardware

Real-device verification on the M5Stack CoreS3 stackchan kit, gateway running at HEAD `c6c1f75`:

- [x] **`get_status`**: `connected:true`, `device_id:44:1b:f6:e4:7a:48`, `tools_count:19`, `mcp__stackchan-mcp__say` exposed via ToolSearch
- [x] **Short utterance**: `say(text="こんにちは、アヤだよ。")` → 36 frames / 2.16 s, audible playback, volume adjustable mid-test (70 → 30) via `set_volume`
- [x] **Long utterance**: `say(...)` with a ~20-character Japanese sentence → 333 frames / 19.98 s, smooth playback throughout, no truncation or pacing artefacts (validates frame-rate pacing + state-bracketing under sustained streaming)
- [x] **VOICEVOX offline**: stop the VOICEVOX container → `say(text="…")` returns `{"error":"TTS engine 'voicevox' failed: All connection attempts failed"}` (clean JSON, no stack trace, gateway process stays alive); restart VOICEVOX and the next `say()` synthesises and plays again with no gateway restart needed

Out of scope for this PR (filed/under consideration as separate follow-ups):

- Lip-sync mouth animation tied to TTS audio level — `fee8388`'s `tts.start`/`tts.stop` notifications gate audio playback only; driving `set_mouth_sequence` from the audio envelope is a separate firmware-side feature.
- Auto-`set_avatar idle` on first MCP connection — currently the LCD stays on whatever it was showing until an explicit `set_avatar` call.

## Breaking changes

None. The pipeline only activates when `say()` is called; existing tools are unchanged. The orchestrator's signature now requires a `gateway` argument, but that was added before any release exposed it (PR1 / #74 has not yet been published to PyPI).

## Related issues

Refs #70 (Phase 4 parent — Irodori voice cloning will follow in a separate PR; STT half remains in #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)