### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-10
+
 ### Added
 
 - Phase 4 TTS — gateway-side `say(text, voice?, speaker_id?,

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1319,7 +1319,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts the v0.5.0 PyPI release of the gateway. Promotes the
`[Unreleased]` section of `CHANGELOG.md` to `[0.5.0] - 2026-05-10`,
bumps `gateway/pyproject.toml` from `0.4.0` to `0.5.0`, and refreshes
the matching `uv.lock` self-entry. After merge, the `v0.5.0` tag
will point at the merge commit; `.github/workflows/publish.yml`
runs the build/lint/test pipeline and publishes to PyPI via Trusted
Publishing.

## What's in v0.5.0

Two user-facing additions accumulated in `[Unreleased]` since v0.4.0:

- **Phase 4 TTS** (#75 / Issue #70 PR2) — gateway-side `say(text, voice?,
  speaker_id?, reference_audio?)` MCP tool. Synthesises via VOICEVOX
  (separate Docker engine, LGPL-3.0 stays scoped to that process),
  encodes to Opus (16 kHz / mono / 60 ms frames), and streams to the
  device over the existing WebSocket. New optional extras
  `stackchan-mcp[tts]` and `stackchan-mcp[tts-voicevox]`. No firmware
  changes required.
- **LED MCP tools** (#68) — `set_led`, `set_all_leds`, `set_leds`
  (atomic batch + single I2C burst), `clear_leds` for the 12× WS2812C
  RGB strip on the StackChan base, driven via the PY32L020 IO
  expander. `available=false` graceful degrade when the expander
  init failed.

Both are minor SemVer additions (no breaking changes), so v0.4.0 → v0.5.0.

## Test plan

- [x] No personal/private artefacts in the diff (only CHANGELOG.md /
      gateway/pyproject.toml / gateway/uv.lock)
- [x] uv.lock matches the bumped pyproject.toml version (`uv lock` ran
      cleanly, recorded `Updated stackchan-mcp v0.4.0 -> v0.5.0`)
- [x] CHANGELOG section follows the existing date format and ordering
- [ ] CI green on this PR
- [ ] After merge: tag `v0.5.0` push triggers PyPI publish; `pip install
      stackchan-mcp==0.5.0` resolves once the publish job completes
- [ ] GitHub Release v0.5.0 created with the CHANGELOG section as body

🤖 Generated with [Claude Code](https://claude.com/claude-code)