### PR TITLE
fix(firmware): #80 clamp pitch to hardware-safe sub-range to prevent servo end-stop damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Firmware
+
+- **Hardware safety**: clamp `set_head_angles` pitch parameter to a
+  hardware-safe sub-range (`0..+30°`) to prevent driving the SCS0009 servo
+  into its mechanical end-stop. M5Stack docs explicitly warn that operating
+  the Y-axis outside the recommended range may cause servo stall and
+  permanent damage; on the CoreS3 + SCS0009 hardware this firmware targets,
+  the mechanical end-stop sits at approximately `pitch=-1°` (validated on
+  a real unit during #79). The MCP property declaration keeps the
+  `-30..+30°` numerical range for backward compatibility, but the handler
+  silently raises sub-zero requests with an `ESP_LOGW` warning. README
+  gains a new "Hardware safety notes" section. Refs #80.
+
 ## [0.5.0] - 2026-05-10
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -361,6 +361,25 @@ python scripts/avatar_convert/convert_avatars.py
 - 大角度急逆転 (±60° → -60° 等) でサーボハングする場合あり (Motion::update_task の補間移植で改善予定)
 - タッチセンサ (Si12T) のぽん判定取りこぼし (感度レジスタ調整余地)
 
+## ハードウェア安全上の注意
+
+> ⚠️ **Y軸 (pitch) の安全範囲**
+
+M5Stack 公式ドキュメントには以下の警告があります:
+
+> The movement angle of the StackChan Y-axis servo (vertical direction) is recommended to be controlled within 5 ~ 85°. Operating at extreme angles may cause **servo stall and permanent damage**.
+> — https://docs.m5stack.com/en/StackChan
+>
+> (StackChan の Y 軸サーボの可動角度は 5°〜85° の範囲内に制御することを推奨します。極端な角度で動作させると **サーボストール や 永久故障** を引き起こす可能性があります。)
+
+このファームウェアが対象とする M5Stack CoreS3 + SCS0009 ハードウェアでは、**下方向の機械的エンドストップがファームウェア座標系の `pitch=-1°` 付近にある** ことを実機で確認しています（テストユニットで検証）。それより低い値（例: `pitch=-5`、`pitch=-10`）を要求するとサーボのギアが物理的なストッパーに当たり、「カチッ」と音がします。
+
+これを防ぐため、`set_head_angles` MCP ツールは Property 宣言上の範囲は `-30..+30°` のままですが、**handler 側で `pitch` を `0..+30°` に clamp** します。`0°` 未満のリクエストは `0°` に引き上げられます（`ESP_LOGW` 付き）。Property 宣言の数値範囲は後方互換性のためそのまま維持していますが、今後は `0..+30°` を target にしてください。
+
+X 軸（yaw、`-90..+90°`）には同等のハードウェア制限はなく、宣言範囲全体を使えます。
+
+詳細な背景・検証ノートは [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80) を参照してください。
+
 ## ライセンス
 
 このリポジトリはデュアルライセンス構成です。

--- a/README.md
+++ b/README.md
@@ -406,6 +406,23 @@ Expected PNG filenames under `~/.stackchan/avatar/`:
 
 Do not commit personal PNGs, generated local avatar files, photos, or other user-specific assets.
 
+## Hardware safety notes
+
+> ⚠️ **Y-axis (pitch) safe range**
+
+M5Stack's official documentation explicitly warns:
+
+> The movement angle of the StackChan Y-axis servo (vertical direction) is recommended to be controlled within 5 ~ 85°. Operating at extreme angles may cause **servo stall and permanent damage**.
+> — https://docs.m5stack.com/en/StackChan
+
+On the M5Stack CoreS3 + SCS0009 hardware that this firmware targets, the **mechanical end-stop on the down direction sits very close to this firmware's pitch coordinate of `-1°`** (validated on a real unit). Driving below that value (e.g. `pitch=-5`, `pitch=-10`) presses the servo gear into the physical stopper and produces an audible click.
+
+To prevent that, the `set_head_angles` MCP tool **clamps pitch to `0..+30°`** internally even though the declared property range is `-30..+30°`. Requests below `0°` are silently raised to `0°` (with an `ESP_LOGW`); the original out-of-range numerical bounds are kept on the property declaration only for backward compatibility with older callers — please target `0..+30°` going forward.
+
+The X-axis (yaw, `-90..+90°`) is not subject to a comparable hardware restriction and remains usable across its full declared range.
+
+See [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80) for the engineering background and validation notes.
+
 ## Known issues
 
 - The servo bus may hang on large-angle abrupt reversals (e.g. +60° → -60°). A fix is in progress via Motion::update_task interpolation.

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -605,6 +605,24 @@ private:
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
 
+    // Issue #80: pitch hardware-safe range. The mechanical end-stop on the
+    // M5Stack CoreS3 + SCS0009 hardware sits very close to pitch=-1°, and
+    // M5Stack's official docs warn that operating the Y-axis outside the
+    // recommended 5°-85° range may cause servo stall and permanent damage
+    // (https://docs.m5stack.com/en/StackChan). On this firmware's coordinate
+    // system, pitch=0 leaves ~1° margin above the validated end-stop.
+    //
+    // Defense-in-depth: we enforce this range at every servo-write boundary
+    //   1. PitchDegToPos() clamps its input (covers motion-task interpolation
+    //      and any future caller that bypasses the MCP layer).
+    //   2. The start-up restore from ReadPos clamps the recovered angle so
+    //      a device booting with the head physically pushed below 0° does
+    //      not carry that negative starting angle into motion interpolation.
+    //   3. The set_head_angles MCP handler additionally clamps the request
+    //      target so the original out-of-range value is logged.
+    static constexpr int SAFE_PITCH_MIN = 0;
+    static constexpr int SAFE_PITCH_MAX = 30;
+
     static int YawDegToPos(int deg) {
         int pos = 460 + deg * 16 / 5;
         if (pos < 0) pos = 0;
@@ -613,6 +631,11 @@ private:
     }
 
     static int PitchDegToPos(int deg) {
+        // Issue #80: defense-in-depth — clamp at the servo-write boundary so
+        // motion-task interpolation and any other future caller cannot
+        // bypass the input-layer clamp.
+        if (deg < SAFE_PITCH_MIN) deg = SAFE_PITCH_MIN;
+        if (deg > SAFE_PITCH_MAX) deg = SAFE_PITCH_MAX;
         int pos = 620 + deg * 16 / 5;
         if (pos < 0) pos = 0;
         if (pos > 1000) pos = 1000;
@@ -992,9 +1015,17 @@ private:
                 ESP_LOGW(TAG, "Failed to ReadPos(yaw); current_deg stays at 0");
             }
             if (pitch_pos_actual >= 0) {
-                pitch_motion_.current_deg = (pitch_pos_actual - 620) * 5 / 16;
-                ESP_LOGI(TAG, "Restored pitch_motion_.current_deg=%d from ReadPos=%d",
-                         pitch_motion_.current_deg, pitch_pos_actual);
+                int restored_pitch = (pitch_pos_actual - 620) * 5 / 16;
+                // Issue #80: if the device booted with the head physically
+                // pushed below the safe range (e.g. previous unsafe firmware
+                // or manual handling), don't carry that negative starting
+                // angle into motion interpolation — clamp before storing so
+                // subsequent interpolation runs only over safe positions.
+                if (restored_pitch < SAFE_PITCH_MIN) restored_pitch = SAFE_PITCH_MIN;
+                if (restored_pitch > SAFE_PITCH_MAX) restored_pitch = SAFE_PITCH_MAX;
+                pitch_motion_.current_deg = restored_pitch;
+                ESP_LOGI(TAG, "Restored pitch_motion_.current_deg=%d from ReadPos=%d (clamped to safe range %d..%d)",
+                         pitch_motion_.current_deg, pitch_pos_actual, SAFE_PITCH_MIN, SAFE_PITCH_MAX);
             } else {
                 ESP_LOGW(TAG, "Failed to ReadPos(pitch); current_deg stays at 0");
             }
@@ -2007,15 +2038,32 @@ private:
 
         // Set head angles (yaw, pitch in degrees)
         // SCS0009: 1 step = 0.3125 degrees, so 1 degree = 3.2 steps (= 16/5)
-        // yaw: -90..90 degrees, pitch: -30..30 degrees
+        // yaw: -90..90 degrees, pitch: -30..30 (declared) but the handler
+        // clamps to a hardware-safe sub-range — see SAFE_PITCH_MIN/MAX below
+        // and Issue #80.
         mcp_server.AddTool(
             "self.robot.set_head_angles",
-            "Set the head angles of the robot. yaw: horizontal (-90 to 90), pitch: vertical (-30 to 30).",
+            "Set the head angles of the robot. yaw: horizontal (-90 to 90), pitch: vertical (recommended 0 to 30; the lower half of the -30..0 range may hit the mechanical end-stop on M5Stack CoreS3 + SCS0009 hardware and risks servo stall — see README \"Hardware safety notes\").",
             PropertyList({Property("yaw", kPropertyTypeInteger, 0, -90, 90),
                           Property("pitch", kPropertyTypeInteger, 0, -30, 30)}),
             [this](const PropertyList& properties) -> ReturnValue {
                 int yaw = properties["yaw"].value<int>();
                 int pitch = properties["pitch"].value<int>();
+                // Issue #80: clamp the requested pitch to the hardware-safe
+                // sub-range. PitchDegToPos() clamps again at the servo-write
+                // boundary (defense-in-depth), but doing it here too lets us
+                // log when the original request was out of range. See the
+                // SAFE_PITCH_MIN/MAX comment block above for rationale.
+                if (pitch < SAFE_PITCH_MIN) {
+                    ESP_LOGW(TAG, "set_head_angles: pitch=%d below SAFE_PITCH_MIN=%d, clamping (servo end-stop protection)",
+                             pitch, SAFE_PITCH_MIN);
+                    pitch = SAFE_PITCH_MIN;
+                }
+                if (pitch > SAFE_PITCH_MAX) {
+                    ESP_LOGW(TAG, "set_head_angles: pitch=%d above SAFE_PITCH_MAX=%d, clamping",
+                             pitch, SAFE_PITCH_MAX);
+                    pitch = SAFE_PITCH_MAX;
+                }
                 int yaw_pos = YawDegToPos(yaw);
                 int pitch_pos = PitchDegToPos(pitch);
                 WriteHeadAngles(yaw, pitch);


### PR DESCRIPTION
## Summary

The `set_head_angles` MCP tool advertised its pitch range as `-30..+30°`, but on the M5Stack CoreS3 + SCS0009 hardware this firmware targets, the **mechanical end-stop on the down direction sits very close to `pitch=-1°`** (validated on a real unit during #79 validation). Driving below that value presses the servo gear into the physical stopper and produces an audible click — exactly the failure mode [M5Stack docs warn about](https://docs.m5stack.com/en/StackChan):

> The movement angle of the StackChan Y-axis servo (vertical direction) is recommended to be controlled within 5 ~ 85°. Operating at extreme angles may cause **servo stall and permanent damage**.

This PR introduces a **defense-in-depth pitch clamp at every servo-write boundary** so no code path — current or future — can drive the servo below `SAFE_PITCH_MIN`.

## Why

Servo stall is a **physical-damage** failure mode called out explicitly in upstream hardware documentation. A maintainer's unit hit the stopper during the #79 validation that surfaced this issue; without this fix any caller (LLM agent, dashboard, future MCP tool) that sends `pitch < 0` risks repeating the impact.

## Changes

- Class-scope `static constexpr SAFE_PITCH_MIN = 0` / `SAFE_PITCH_MAX = 30` so every member function references the same bounds.
- `PitchDegToPos()` clamps its `deg` argument before computing the raw position. This protects the **motion-task interpolation path** (which feeds every intermediate `WritePos` with `new_pitch_current`) and any future caller that bypasses the MCP layer.
- Start-up `ReadPos` restore clamps `restored_pitch` before storing into `pitch_motion_.current_deg`, so a device booting with the head physically pushed below 0° (older firmware, manual handling) does not carry that negative starting angle into motion interpolation.
- `set_head_angles` MCP handler clamps the request target with an `ESP_LOGW` warning when the original request was out of range; the property declaration keeps `-30..+30` for backward compatibility.
- MCP tool description string updated to advertise the recommended range and reference the README hardware-safety note.
- `README.md` / `README.ja.md`: new "Hardware safety notes" section with the M5Stack docs quote, the validated end-stop position, and a cross-reference to this issue.
- `CHANGELOG.md`: Firmware entry under `[Unreleased]`.

The `-30..+30` numerical range on the property declaration is preserved intentionally — older callers continue to work without a hard rejection; the firmware silently narrows the request and logs the discrepancy. yaw remains unrestricted (M5Stack docs explicitly state X-axis needs no restriction).

## Validation

### Real-device test (M5Stack CoreS3 + SCS0009 ×2)

Same hardware unit that took the impact during #79 validation:

| Request | Result | Expected |
|---|---|---|
| `move_head(pitch=-10)` | `pitch_pos=620` (mid-position, clamp output), `motion_started=0` | No end-stop hit, no servo motion needed |
| `move_head(pitch=+15)` | 14° actual | Within SCS0009 ±1° mechanical tolerance — normal-range motion intact |

### Code review

`codex adversarial-review` approved after defense-in-depth fix. Initial pass flagged that target-only clamping leaves the motion-task interpolation path exposed (intermediate `WritePos` calls between `current_deg` and target can include negative values when starting from a sub-zero physical position); the class-scope helper + `PitchDegToPos` clamp + restore-time clamp closes that gap.

## Test plan

- [x] Real-device flash & test: `move_head(pitch=-10)` clamped at safe lower bound, no end-stop hit
- [x] Real-device flash & test: `move_head(pitch=+15)` reaches target within tolerance
- [x] codex adversarial-review: `approve` / ship verdict
- [x] Personal-config / private-data leak check: clean

## Optional follow-up (not blocking)

Surface `requested_pitch` vs `applied_pitch` in the JSON response for caller-side visibility. Tracked separately if needed; not in scope for this hot fix.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)