### PR TITLE
feat(firmware): #79 add MIT FeetechScs as opt-in alternative to GPL SCServo_lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Add opt-in MIT-licensed servo driver alternative
+  (`firmware/components/feetech_scs/`, vendored from
+  [necobit/feetech_scs_esp_idf](https://github.com/necobit/feetech_scs_esp_idf)
+  at commit `38a91984`). Build with Kconfig
+  `CONFIG_STACKCHAN_SERVO_FEETECH=y` to exclude the GPL-3.0 SCServo_lib
+  sources and produce a fully MIT-licensed firmware binary. The default
+  keeps the existing GPL-3.0 SCServo_lib driver for stability until
+  real-device validation completes. Refs #79.
 - **Hardware safety**: clamp `set_head_angles` pitch parameter to a
   hardware-safe sub-range (`0..+30°`) to prevent driving the SCS0009 servo
   into its mechanical end-stop. M5Stack docs explicitly warn that operating

--- a/README.ja.md
+++ b/README.ja.md
@@ -393,6 +393,16 @@ X 軸（yaw、`-90..+90°`）には同等のハードウェア制限はなく、
 
 一方、`gateway/` は独立した Python プロセスで、ESP32 とはネットワーク経由 (WebSocket) でしか通信しないため、**MIT License** のまま利用・派生できます。
 
+> **MIT 単一ライセンス firmware ビルドのオプション (experimental, [#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79) 以降):**
+> SCServo_lib のクリーンルーム MIT 代替実装
+> ([`necobit/feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf)、
+> `firmware/components/feetech_scs/` 配下に vendor 取り込み) を opt-in
+> として Kconfig で選べます。`CONFIG_STACKCHAN_SERVO_FEETECH=y` でビルド
+> すると GPL-3.0 の SCServo_lib ソースがビルドから除外され、MIT 単一
+> ライセンスの firmware バイナリが生成されます。デフォルトは
+> `SCServo_lib` のまま (実機検証完了まで)、状況は #79 でトラッキング
+> しています。
+
 ### upstream
 
 `firmware/` は [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) のフォーク ([kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32)) を git subtree で取り込んでいます。upstream 同期手順は [`docs/firmware-sync.md`](docs/firmware-sync.md) を参照してください。SCServo_lib は公式 [stack-chan](https://github.com/mongonta0716/stack-chan) (タカヲさん) から移植したファームウェアコンポーネントです。

--- a/README.md
+++ b/README.md
@@ -441,6 +441,15 @@ This split exists because Feetech's SCServo SDK is distributed under GPL-3.0. Th
 
 The `gateway/` runs as an independent Python process and only talks to the ESP32 over the network (WebSocket), so it stays usable and derivable under the **MIT License**.
 
+> **Optional MIT-only firmware build (experimental, since [#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79)):**
+> A clean-room MIT alternative to SCServo_lib
+> ([`necobit/feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf),
+> vendored under `firmware/components/feetech_scs/`) is available as an
+> opt-in via Kconfig. Building with `CONFIG_STACKCHAN_SERVO_FEETECH=y`
+> excludes the GPL-3.0 SCServo_lib sources, producing a fully
+> MIT-licensed firmware binary. The default remains `SCServo_lib` until
+> real-device validation completes; track #79 for status.
+
 ### upstream
 
 `firmware/` is taken in via git subtree from [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) — specifically the [kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32) fork. See [`docs/firmware-sync.md`](docs/firmware-sync.md) for the upstream sync playbook. SCServo_lib is a firmware component ported from the official [stack-chan](https://github.com/mongonta0716/stack-chan) (Takawo-san) repository.

--- a/firmware/components/feetech_scs/CMakeLists.txt
+++ b/firmware/components/feetech_scs/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS        "feetech_scs.cpp"
+    INCLUDE_DIRS "."
+    REQUIRES    driver
+)

--- a/firmware/components/feetech_scs/LICENSE
+++ b/firmware/components/feetech_scs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 necobit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/firmware/components/feetech_scs/README.md
+++ b/firmware/components/feetech_scs/README.md
@@ -1,0 +1,70 @@
+# feetech_scs (vendored)
+
+MIT-licensed Feetech SCS0009 / SCSCL serial servo driver for ESP-IDF, vendored
+from upstream as a clean-room alternative to the GPL-3.0 `SCServo_lib` shipped
+in `firmware/main/boards/stackchan/`.
+
+## Source
+
+- Upstream: <https://github.com/necobit/feetech_scs_esp_idf>
+- Commit:   `38a91984be0d30abbff30d2f56dd3072f2905faf` (initial provisional
+            release, 2026-05-10)
+- License:  MIT — see `LICENSE` in this directory (verbatim copy of upstream
+            `LICENSE`).
+
+The upstream source header (`feetech_scs.cpp`) explicitly states the
+implementation is a **clean-room reimplementation from the public Feetech
+SCS0009 datasheet** with **no code derived from the GPLv3 SCServo_lib**.
+
+## Local modifications
+
+This vendor copy is **not byte-for-byte identical** to upstream. The
+following local patches have been applied; each is planned to be sent
+back to upstream as an Issue/PR once real-device validation is complete:
+
+1. **`uart_wait_tx_done()` between TX and RX in `write_reg` / `read_reg`**
+   ([#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79)).
+   Upstream starts reading the bus immediately after `uart_write_bytes`,
+   which only enqueues the bytes into the UART driver buffer. On a
+   half-duplex servo bus this lets our own outgoing bytes clip the ACK
+   packet and produces spurious bus-error returns. The original
+   `SCServo_lib` mirrors a TX-drain wait via
+   `SCSerial::wFlushSCS` (`uart_wait_tx_done(..., 100ms)`); we
+   reproduce that here. Tagged in the source with
+   `// Local patch (issue #79):` markers for easy diffing against
+   upstream.
+
+The `LICENSE` file remains verbatim from upstream — MIT license
+attribution is preserved.
+
+## Why vendored
+
+The upstream project is currently in provisional release state. Vendoring a
+pinned commit lets us:
+
+1. Audit the exact bytes that ship in firmware builds.
+2. Iterate on integration locally (Kconfig, build glue) without waiting for
+   upstream changes.
+3. Feed verification findings back upstream as Issues / PRs.
+
+Once upstream stabilizes, this can be migrated to a `submodule` or
+`idf_component.yml` managed dependency.
+
+## Updating
+
+To refresh this vendor copy from upstream:
+
+```bash
+cd firmware/components/feetech_scs
+curl -L https://raw.githubusercontent.com/necobit/feetech_scs_esp_idf/<sha>/feetech_scs.h -o feetech_scs.h
+curl -L https://raw.githubusercontent.com/necobit/feetech_scs_esp_idf/<sha>/feetech_scs.cpp -o feetech_scs.cpp
+curl -L https://raw.githubusercontent.com/necobit/feetech_scs_esp_idf/<sha>/CMakeLists.txt -o CMakeLists.txt
+curl -L https://raw.githubusercontent.com/necobit/feetech_scs_esp_idf/<sha>/LICENSE -o LICENSE
+```
+
+Update the commit SHA in this README's "Source" section to match.
+
+## Tracking issue
+
+See [`#79`](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79) for the
+evaluation status, validation plan, and migration roadmap to MIT-only firmware.

--- a/firmware/components/feetech_scs/feetech_scs.cpp
+++ b/firmware/components/feetech_scs/feetech_scs.cpp
@@ -1,0 +1,231 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Clean-room reimplementation of the SCSCL protocol layer from the public
+ * Feetech SCS0009 datasheet. No code from the GPLv3 SCServo_lib is used.
+ */
+#include "feetech_scs.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_log.h>
+#include <cstring>
+#include <algorithm>
+
+static const char* TAG = "FeetechScs";
+
+namespace {
+
+// SCSCL register addresses (from the public datasheet).
+constexpr uint8_t REG_OPERATION_MODE   = 33;  // 0x21 — 0=Position, 1=PWM
+constexpr uint8_t REG_TORQUE_ENABLE    = 40;  // 0x28
+constexpr uint8_t REG_GOAL_POSITION_L  = 42;  // 0x2A — followed by H, time L/H, speed L/H
+constexpr uint8_t REG_GOAL_SPEED_L     = 46;  // 0x2E — also PWM target in PWM mode
+constexpr uint8_t REG_PRESENT_POSITION_L = 56;  // 0x38
+constexpr uint8_t REG_MOVING           = 66;  // 0x42
+
+// Protocol instruction codes.
+constexpr uint8_t INST_READ  = 0x02;
+constexpr uint8_t INST_WRITE = 0x03;
+
+// Hard physical limits enforced inside this driver. The caller is expected
+// to have already clamped to its own application limits, but we re-check
+// here so a bug upstream can't accidentally drive the servo past the
+// register range and physically damage the rig.
+constexpr uint16_t HARD_POS_MAX = 1023;
+constexpr int16_t  HARD_PWM_ABS_MAX = 1023;
+
+// Bus response timeout. 1 Mbps × 8 bytes ≈ 80 µs; 20 ms is plenty.
+constexpr TickType_t RX_TIMEOUT = pdMS_TO_TICKS(20);
+
+uint8_t calc_checksum(const uint8_t* buf, size_t len)
+{
+    // Sum of bytes from ID through last param (i.e. skip the two header
+    // 0xFF bytes), inverted.
+    uint32_t sum = 0;
+    for (size_t i = 2; i < len; i++) sum += buf[i];
+    return static_cast<uint8_t>(~sum & 0xFF);
+}
+
+}  // namespace
+
+void FeetechScs::begin(uart_port_t uart, int baud, int tx_pin, int rx_pin)
+{
+    if (_ready && _uart == uart) return;
+
+    _uart = uart;
+
+    uart_config_t cfg = {};
+    cfg.baud_rate     = baud;
+    cfg.data_bits     = UART_DATA_8_BITS;
+    cfg.parity        = UART_PARITY_DISABLE;
+    cfg.stop_bits     = UART_STOP_BITS_1;
+    cfg.flow_ctrl     = UART_HW_FLOWCTRL_DISABLE;
+    cfg.source_clk    = UART_SCLK_DEFAULT;
+
+    ESP_ERROR_CHECK(uart_param_config(uart, &cfg));
+    ESP_ERROR_CHECK(uart_set_pin(uart, tx_pin, rx_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
+    if (!uart_is_driver_installed(uart)) {
+        ESP_ERROR_CHECK(uart_driver_install(uart, 256, 0, 0, nullptr, 0));
+    }
+
+    _ready = true;
+    ESP_LOGI(TAG, "begin uart=%d baud=%d tx=%d rx=%d", (int)uart, baud, tx_pin, rx_pin);
+}
+
+int FeetechScs::write_reg(uint8_t id, uint8_t addr, const uint8_t* data, uint8_t n)
+{
+    if (!_ready) return -1;
+
+    // 0xFF 0xFF ID LEN INST ADDR PARAMS... CHK
+    // LEN = (ADDR + PARAMS + CHK + INST) -> = n + 3
+    uint8_t buf[16];
+    if (n + 7 > sizeof(buf)) return -1;  // safety bound — we never write more than 6 params
+
+    buf[0] = 0xFF;
+    buf[1] = 0xFF;
+    buf[2] = id;
+    buf[3] = static_cast<uint8_t>(n + 3);
+    buf[4] = INST_WRITE;
+    buf[5] = addr;
+    if (data && n) std::memcpy(&buf[6], data, n);
+    size_t total = 6 + n;
+    buf[total]   = calc_checksum(buf, total);
+    total += 1;
+
+    uart_flush_input(_uart);
+    int written = uart_write_bytes(_uart, reinterpret_cast<const char*>(buf), total);
+    if (written != (int)total) return -1;
+
+    // Local patch (issue #79): wait for TX to drain off the wire before
+    // reading the half-duplex bus, mirroring the upstream SCServo_lib's
+    // SCSerial::wFlushSCS (uart_wait_tx_done with 100ms timeout). Without
+    // this, our own outgoing bytes can clip the incoming ACK packet and
+    // surface as spurious bus errors.
+    if (uart_wait_tx_done(_uart, pdMS_TO_TICKS(100)) != ESP_OK) return -1;
+
+    // Wait for status reply (0xFF 0xFF ID LEN ERR CHK = 6 bytes total) when
+    // not broadcasting. Broadcast (id=0xFE) does not get a reply.
+    if (id == 0xFE) return 0;
+
+    uint8_t reply[6] = {};
+    int got          = uart_read_bytes(_uart, reply, sizeof(reply), RX_TIMEOUT);
+    if (got != (int)sizeof(reply))                  return -1;
+    if (reply[0] != 0xFF || reply[1] != 0xFF)       return -1;
+    if (reply[2] != id)                             return -1;
+    if (reply[3] != 2)                              return -1;
+    uint8_t exp_chk = static_cast<uint8_t>(~(reply[2] + reply[3] + reply[4]) & 0xFF);
+    if (reply[5] != exp_chk)                        return -1;
+    return 0;
+}
+
+int FeetechScs::read_reg(uint8_t id, uint8_t addr, uint8_t n, uint8_t* out)
+{
+    if (!_ready || !out || n == 0) return -1;
+
+    // 0xFF 0xFF ID LEN(=4) INST(=2) ADDR N CHK
+    uint8_t buf[8];
+    buf[0] = 0xFF;
+    buf[1] = 0xFF;
+    buf[2] = id;
+    buf[3] = 4;
+    buf[4] = INST_READ;
+    buf[5] = addr;
+    buf[6] = n;
+    buf[7] = calc_checksum(buf, 7);
+
+    uart_flush_input(_uart);
+    int written = uart_write_bytes(_uart, reinterpret_cast<const char*>(buf), 8);
+    if (written != 8) return -1;
+
+    // Local patch (issue #79): same TX-drain wait as write_reg() — see
+    // the comment there for the rationale.
+    if (uart_wait_tx_done(_uart, pdMS_TO_TICKS(100)) != ESP_OK) return -1;
+
+    // Reply: 0xFF 0xFF ID LEN(=2+n) ERR DATA[n] CHK
+    const size_t reply_len = 6u + n;
+    uint8_t reply[16] = {};
+    if (reply_len > sizeof(reply)) return -1;
+    int got = uart_read_bytes(_uart, reply, reply_len, RX_TIMEOUT);
+    if (got != (int)reply_len)                            return -1;
+    if (reply[0] != 0xFF || reply[1] != 0xFF)             return -1;
+    if (reply[2] != id)                                   return -1;
+    if (reply[3] != static_cast<uint8_t>(n + 2))          return -1;
+
+    uint32_t sum = reply[2] + reply[3] + reply[4];
+    for (uint8_t i = 0; i < n; i++) sum += reply[5 + i];
+    uint8_t exp_chk = static_cast<uint8_t>(~sum & 0xFF);
+    if (reply[reply_len - 1] != exp_chk)                  return -1;
+
+    std::memcpy(out, &reply[5], n);
+    return 0;
+}
+
+int FeetechScs::WritePos(uint8_t id, uint16_t position, uint16_t time_ms, uint16_t speed)
+{
+    // Defensive clamp — protects the mech if any caller forgets to clamp.
+    if (position > HARD_POS_MAX) position = HARD_POS_MAX;
+
+    // SCSCL series stores 16-bit registers BIG-endian over the wire: the
+    // byte at the lower register address (`*_L`) is actually the *high*
+    // byte of the word. (The naming in the datasheet is "L = low address",
+    // not "low byte" — easy to misread.) Sending little-endian made the
+    // servo see a huge value and clamp to the mechanical maximum.
+    uint8_t params[6] = {
+        static_cast<uint8_t>((position >> 8) & 0xFF),
+        static_cast<uint8_t>(position & 0xFF),
+        static_cast<uint8_t>((time_ms >> 8) & 0xFF),
+        static_cast<uint8_t>(time_ms & 0xFF),
+        static_cast<uint8_t>((speed >> 8) & 0xFF),
+        static_cast<uint8_t>(speed & 0xFF),
+    };
+    return write_reg(id, REG_GOAL_POSITION_L, params, 6);
+}
+
+int FeetechScs::ReadPos(uint8_t id)
+{
+    uint8_t b[2];
+    if (read_reg(id, REG_PRESENT_POSITION_L, 2, b) != 0) return -1;
+    // Big-endian: byte at lower address is the high byte (see WritePos comment).
+    return (b[0] << 8) | b[1];
+}
+
+int FeetechScs::ReadMove(uint8_t id)
+{
+    uint8_t b;
+    if (read_reg(id, REG_MOVING, 1, &b) != 0) return -1;
+    return b;
+}
+
+int FeetechScs::EnableTorque(uint8_t id, uint8_t enable)
+{
+    uint8_t v = enable ? 1 : 0;
+    return write_reg(id, REG_TORQUE_ENABLE, &v, 1);
+}
+
+int FeetechScs::ReadToqueEnable(uint8_t id)
+{
+    uint8_t b;
+    if (read_reg(id, REG_TORQUE_ENABLE, 1, &b) != 0) return -1;
+    return b;
+}
+
+int FeetechScs::SwitchMode(uint8_t id, uint8_t mode)
+{
+    uint8_t v = (mode == 0) ? 0 : 1;
+    return write_reg(id, REG_OPERATION_MODE, &v, 1);
+}
+
+int FeetechScs::WritePWM(uint8_t id, int16_t pwm)
+{
+    if (pwm >  HARD_PWM_ABS_MAX) pwm =  HARD_PWM_ABS_MAX;
+    if (pwm < -HARD_PWM_ABS_MAX) pwm = -HARD_PWM_ABS_MAX;
+    // SCS0009 PWM word: low 10 bits = magnitude, bit 10 = direction.
+    uint16_t mag = static_cast<uint16_t>(pwm < 0 ? -pwm : pwm) & 0x03FF;
+    uint16_t v   = mag | (pwm < 0 ? 0x0400 : 0x0000);
+    // Big-endian word — see WritePos for the byte-order rationale.
+    uint8_t params[2] = {
+        static_cast<uint8_t>((v >> 8) & 0xFF),
+        static_cast<uint8_t>(v & 0xFF),
+    };
+    return write_reg(id, REG_GOAL_SPEED_L, params, 2);
+}

--- a/firmware/components/feetech_scs/feetech_scs.h
+++ b/firmware/components/feetech_scs/feetech_scs.h
@@ -1,0 +1,71 @@
+/*
+ * MIT-licensed minimal driver for Feetech SCS0009 / SCSCL serial servos.
+ *
+ * Implements only the seven calls our ScsServo wrapper actually uses, with
+ * the same signatures as the upstream SCServo_lib SCSCL class so the rest
+ * of the firmware doesn't change. Designed as a clean-room reimplementation
+ * from the public protocol spec — does not contain any code derived from
+ * the GPLv3 SCServo_lib.
+ *
+ * Protocol (Dynamixel 1.0-compatible half-duplex UART, 1 Mbps default):
+ *   Packet:  0xFF 0xFF ID LEN INST PARAMS... CHK
+ *   CHK = ~(ID + LEN + INST + Σ PARAMS) & 0xFF
+ *
+ * Register map references (all from the public SCS0009 / SCSCL datasheet):
+ *   0x21 (33)  Operation mode      — 0=Position, 1=PWM
+ *   0x28 (40)  Torque enable       — 0=off, 1=on
+ *   0x2A (42)  Goal position L/H   — u16 (0..1023)
+ *   0x2C (44)  Goal time L/H       — u16 (ms)
+ *   0x2E (46)  Goal speed L/H      — u16 (also used as PWM target in PWM mode,
+ *                                          bit 10 = direction)
+ *   0x38 (56)  Present position L/H — u16
+ *   0x42 (66)  Moving               — u8 (1 = still moving)
+ *
+ * Safety: every WritePos / WritePWM clamps its inputs to physical limits
+ * before sending, so a caller that forgets to clamp can't drive the servo
+ * past 0..1023 or PWM beyond ±1023.
+ */
+#pragma once
+#include <cstdint>
+#include <driver/uart.h>
+
+class FeetechScs {
+public:
+    // One-time UART init. Idempotent — calling it twice on the same port
+    // is a no-op.
+    void begin(uart_port_t uart, int baud, int tx_pin, int rx_pin);
+
+    // ---- Position-mode commands -------------------------------------------
+    // Goal position 0..1023, time 0..65535 ms, speed 0..65535 (0 = max).
+    int WritePos(uint8_t id, uint16_t position, uint16_t time_ms, uint16_t speed);
+
+    // Returns 0..1023 on success, -1 on timeout / checksum error.
+    int ReadPos(uint8_t id);
+
+    // Returns 1 if the servo is still moving, 0 if at rest, -1 on bus error.
+    int ReadMove(uint8_t id);
+
+    // ---- Torque ---------------------------------------------------------
+    int EnableTorque(uint8_t id, uint8_t enable);
+    int ReadToqueEnable(uint8_t id);  // typo preserved for SCSCL API parity
+
+    // ---- PWM / wheel mode ------------------------------------------------
+    // Switch operation mode. 0 = position, 1 = PWM.
+    int SwitchMode(uint8_t id, uint8_t mode);
+
+    // PWM output, signed -1023..1023. Bit 10 of the on-wire value carries
+    // sign per the SCS0009 spec. SwitchMode(id, 1) must be called first.
+    int WritePWM(uint8_t id, int16_t pwm);
+
+private:
+    uart_port_t _uart  = UART_NUM_1;
+    bool        _ready = false;
+
+    // Build & send a WRITE_DATA packet (INST=0x03). data may be nullptr if
+    // n == 0.  Returns 0 on ACK, -1 on bus error.
+    int write_reg(uint8_t id, uint8_t addr, const uint8_t* data, uint8_t n);
+
+    // Build & send a READ_DATA packet (INST=0x02). Reads n bytes into out.
+    // Returns 0 on success, -1 on bus / checksum error.
+    int read_reg(uint8_t id, uint8_t addr, uint8_t n, uint8_t* out);
+};

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -836,6 +836,31 @@ if(CONFIG_BOARD_TYPE_STACKCHAN)
         list(REMOVE_ITEM BOARD_SOURCES ${STACKCHAN_BOARD_DIR}/avatar_images.cc)
         message(STATUS "Using StackChan local avatar override: ${STACKCHAN_LOCAL_AVATAR_CC}")
     endif()
+
+    # Issue #79: when the experimental MIT FeetechScs driver is selected,
+    # exclude the GPL-3.0 SCServo_lib sources from the build so the firmware
+    # ships under MIT only. The default (CONFIG_STACKCHAN_SERVO_SCSCL) keeps
+    # SCServo_lib in place for stability until validation completes.
+    #
+    # The MIT driver lives under firmware/components/feetech_scs/ for clean
+    # license separation. We pull its source/header directly into main's
+    # build rather than registering it as an independent ESP-IDF component:
+    # this project uses MINIMAL_BUILD (top-level CMakeLists.txt) which trims
+    # components not in main's REQUIRES *before* their public include paths
+    # propagate to main, so the component-style integration would silently
+    # fail with `feetech_scs.h: No such file or directory`. Inlining the
+    # source into main avoids the chicken-and-egg dependency.
+    if(CONFIG_STACKCHAN_SERVO_FEETECH)
+        list(REMOVE_ITEM BOARD_SOURCES
+            ${STACKCHAN_BOARD_DIR}/SCS.cc
+            ${STACKCHAN_BOARD_DIR}/SCSCL.cc
+            ${STACKCHAN_BOARD_DIR}/SCSerial.cc)
+        list(APPEND BOARD_SOURCES
+            "${CMAKE_CURRENT_SOURCE_DIR}/../components/feetech_scs/feetech_scs.cpp")
+        list(APPEND INCLUDE_DIRS
+            "${CMAKE_CURRENT_SOURCE_DIR}/../components/feetech_scs")
+        message(STATUS "StackChan: using MIT FeetechScs driver, excluding SCServo_lib sources from build")
+    endif()
 endif()
 list(APPEND SOURCES ${BOARD_SOURCES})
 

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1035,4 +1035,34 @@ menu "TAIJIPAI_S3_CONFIG"
         启动双声道
 endmenu
 
+if BOARD_TYPE_STACKCHAN
+
+choice STACKCHAN_SERVO_DRIVER
+    prompt "StackChan Servo Driver"
+    default STACKCHAN_SERVO_SCSCL
+    help
+        Choose between the original GPL-3.0 SCServo_lib (current default)
+        and the MIT-licensed clean-room reimplementation
+        (necobit/feetech_scs_esp_idf, vendored under
+        firmware/components/feetech_scs/).
+
+        See Issue #79 for the migration roadmap to MIT-only firmware.
+
+    config STACKCHAN_SERVO_SCSCL
+        bool "SCServo_lib (GPL-3.0, current default)"
+        help
+            Use the original SCServo_lib sources shipped under
+            firmware/main/boards/stackchan/. License: GPL-3.0.
+
+    config STACKCHAN_SERVO_FEETECH
+        bool "feetech_scs_esp_idf (MIT, experimental)"
+        help
+            Use the MIT-licensed clean-room driver vendored at
+            firmware/components/feetech_scs/. Currently under validation —
+            firmware behavior is expected to match SCSCL but real-device
+            verification is in progress (#79).
+endchoice
+
+endif # BOARD_TYPE_STACKCHAN
+
 endmenu

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -7,7 +7,26 @@
 #include "i2c_device.h"
 #include "axp2101.h"
 #include "mcp_server.h"
+// Issue #79: servo driver is selectable at build time via Kconfig.
+//   - CONFIG_STACKCHAN_SERVO_SCSCL  (default): GPL-3.0 SCServo_lib
+//   - CONFIG_STACKCHAN_SERVO_FEETECH: MIT clean-room driver vendored at
+//     firmware/components/feetech_scs/.
+// Both drivers share the same begin / WritePos / ReadPos call signatures
+// used by this board, but their WritePos success value differs (see
+// ServoWritePosOk() below). The rest of stackchan.cc treats both drivers
+// uniformly through the ScsBus type alias plus that helper.
+#if CONFIG_STACKCHAN_SERVO_FEETECH
+#include "feetech_scs.h"
+using ScsBus = FeetechScs;
+// FeetechScs::WritePos returns 0 on ACK and -1 on bus error.
+static inline bool ServoWritePosOk(int r) { return r >= 0; }
+#else
 #include "SCSCL.h"
+using ScsBus = SCSCL;
+// SCSCL::WritePos returns 1 on ACK, 0 on ACK timeout, -1 on bus error.
+// Treat ACK timeout as failure to keep the original behaviour intact.
+static inline bool ServoWritePosOk(int r) { return r > 0; }
+#endif
 #include "avatar_images.h"
 
 #include <esp_log.h>
@@ -482,7 +501,7 @@ private:
     EspVideo* camera_;
     esp_timer_handle_t touchpad_timer_;
     PowerSaveTimer* power_save_timer_;
-    SCSCL scs_bus_;
+    ScsBus scs_bus_;
     std::unique_ptr<Py32IoExpander> io_expander_;
 
     // Avatar overlay state. avatar_img_ is created lazily on the active LVGL
@@ -976,7 +995,16 @@ private:
     void InitializeServo() {
         ESP_LOGI(TAG, "Init SCS0009 servo bus (UART%d, baud=%d, tx=%d, rx=%d)",
                  SERVO_UART_NUM, SERVO_BAUDRATE, SERVO_TX_PIN, SERVO_RX_PIN);
+#if CONFIG_STACKCHAN_SERVO_FEETECH
+        // FeetechScs::begin() returns void and uses ESP_ERROR_CHECK internally,
+        // so a UART configuration error aborts the boot rather than reporting
+        // false. If begin() returns to us, init succeeded.
+        scs_bus_.begin(SERVO_UART_NUM, SERVO_BAUDRATE, SERVO_TX_PIN, SERVO_RX_PIN);
+        servo_ok_ = true;
+#else
+        // SCServo_lib SCSCL::begin() returns bool — false if UART setup failed.
         servo_ok_ = scs_bus_.begin(SERVO_UART_NUM, SERVO_BAUDRATE, SERVO_TX_PIN, SERVO_RX_PIN);
+#endif
         // ACK reading is enabled (SCS::Level defaults to 1). genWrite() will
         // wait for the SCS0009's 6-byte ACK packet before returning, which
         // implicitly enforces an inter-frame gap and prevents a follow-up
@@ -1189,7 +1217,7 @@ private:
             if (yaw_local.moving) {
                 int yaw_pos = YawDegToPos(new_yaw_current);
                 int r = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, MOTION_PER_WRITE_TIME_MS, 0);
-                if (r <= 0) {
+                if (!ServoWritePosOk(r)) {
                     ESP_LOGW(TAG, "Motion yaw WritePos failed: r=%d (deg=%d, pos=%d)",
                              r, new_yaw_current, yaw_pos);
                 }
@@ -1198,7 +1226,7 @@ private:
             if (pitch_local.moving) {
                 int pitch_pos = PitchDegToPos(new_pitch_current);
                 int r = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, MOTION_PER_WRITE_TIME_MS, 0);
-                if (r <= 0) {
+                if (!ServoWritePosOk(r)) {
                     ESP_LOGW(TAG, "Motion pitch WritePos failed: r=%d (deg=%d, pos=%d)",
                              r, new_pitch_current, pitch_pos);
                 }
@@ -2076,10 +2104,10 @@ private:
                     xSemaphoreGive(motion_mutex_);
                 }
                 ESP_LOGI(TAG, "set_head_angles: yaw=%d (pos=%d) motion_started=%d, pitch=%d (pos=%d) motion_started=%d, uart=%d, servo_ok=%d",
-                         yaw, yaw_pos, yaw_motion_started, pitch, pitch_pos, pitch_motion_started, (int)scs_bus_.uart_num, servo_ok_);
+                         yaw, yaw_pos, yaw_motion_started, pitch, pitch_pos, pitch_motion_started, (int)SERVO_UART_NUM, servo_ok_);
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddBoolToObject(root, "servo_init_ok", servo_ok_);
-                cJSON_AddNumberToObject(root, "uart_num", (int)scs_bus_.uart_num);
+                cJSON_AddNumberToObject(root, "uart_num", (int)SERVO_UART_NUM);
                 cJSON_AddNumberToObject(root, "yaw_pos", yaw_pos);
                 cJSON_AddNumberToObject(root, "pitch_pos", pitch_pos);
                 cJSON_AddNumberToObject(root, "yaw_motion_started", yaw_motion_started ? 1 : 0);


### PR DESCRIPTION
## Summary

Vendor [necobit/feetech_scs_esp_idf](https://github.com/necobit/feetech_scs_esp_idf) at commit `38a91984` under `firmware/components/feetech_scs/` as a clean-room MIT alternative to the GPL-3.0 `SCServo_lib`. Selecting `CONFIG_STACKCHAN_SERVO_FEETECH=y` produces a fully MIT-licensed firmware binary; the default driver remains `SCServo_lib` until real-device validation is broadened across multiple units.

This PR is the implementation follow-up to the **#79 tracking issue**. The upstream MIT driver was published 2026-05-10 by @necobit explicitly inviting verification, and stackchan-mcp's hardware target (M5Stack CoreS3 + SCS0009 ×2) makes us well-positioned to help validate it early.

## Why

`firmware/main/boards/stackchan/` ships **8 GPL-3.0 files** (`SCS.{cc,h}`, `SCSCL.{cc,h}`, `SCSerial.{cc,h}`, `INST.h`, `SCServo.h`) — the only GPL boundary in the firmware. A clean MIT replacement, if viable, lets the entire firmware ship under a single MIT license, simplifying downstream redistribution and packaging.

## Build / integration

- Add `CONFIG_STACKCHAN_SERVO_DRIVER` Kconfig choice gated on `BOARD_TYPE_STACKCHAN` so other boards do not see the option.
- When `CONFIG_STACKCHAN_SERVO_FEETECH=y`, exclude `SCS.cc` / `SCSCL.cc` / `SCSerial.cc` from `BOARD_SOURCES` so the firmware links against the MIT driver only.
- Pull `feetech_scs.cpp` / `feetech_scs.h` directly into main's `SOURCES` / `INCLUDE_DIRS` rather than declaring it as a `REQUIRES` dependency. The project enables `MINIMAL_BUILD` in the top `CMakeLists`, which trims components not in main's `REQUIRES` *before* their public include path propagates to main; the inline approach sidesteps that dependency-resolution race.

## stackchan.cc

- Select driver header via `#if` and introduce a `ScsBus` type alias so the rest of the file is driver-agnostic.
- Replace `scs_bus_.uart_num` with the `SERVO_UART_NUM` constant since `FeetechScs` does not expose a public uart accessor.
- Bridge `begin()` return-type difference (SCSCL returns `bool`, FeetechScs is `void` with internal `ESP_ERROR_CHECK`) under `#if`.
- Add `ServoWritePosOk()` inline helper used at WritePos call sites: SCSCL succeeds with `r > 0` (1 = ACK ok, 0 = ACK timeout, -1 = bus error; ACK timeout kept as failure to preserve behaviour); FeetechScs succeeds with `r >= 0` (0 = ACK ok, -1 = bus error). Found by codex review.

## Local patches to vendored MIT driver

The vendor copy is **not byte-for-byte identical** to upstream; this PR carries one local patch (planned to be sent back upstream as an Issue/PR after broader validation):

- Insert `uart_wait_tx_done(_uart, 100ms)` between `uart_write_bytes` and `uart_read_bytes` in `write_reg` / `read_reg`, mirroring the upstream `SCServo_lib`'s `SCSerial::wFlushSCS` pattern. Without this, our own outgoing bytes can clip the incoming ACK on a half-duplex bus and surface as spurious bus errors. Documented in `firmware/components/feetech_scs/README.md` "Local modifications". The upstream `LICENSE` file remains verbatim — MIT attribution is preserved. Found by codex adversarial-review (high severity).

## Documentation

- `README.md` / `README.ja.md`: add an experimental note under the License section describing the opt-in MIT-only firmware build path.
- `CHANGELOG.md`: Firmware entry under `[Unreleased]` referencing #79.
- `firmware/components/feetech_scs/README.md`: vendor source attribution with upstream URL, commit pin, license terms, and local patch inventory.

## Validation

### Side-by-side Docker builds (espressif/idf:v5.5.2)

Both drivers on `esp32s3` / `BOARD_TYPE_STACKCHAN`:

- **SCSCL default**: xiaozhi.bin 3,440,352 bytes (matches main pre-PR baseline).
- **FEETECH variant**: xiaozhi.bin 3,437,264 bytes (smaller as expected from removing the GPL sources and adding the smaller MIT driver).

### Real-device test (M5Stack CoreS3 + SCS0009 ×2)

| Test | FEETECH (MIT) | SCSCL default | Equivalent? |
|---|---|---|---|
| Boot + WS connect | ✅ | ✅ | yes |
| MCP tools_count | 19 | 19 | yes |
| `move_head(yaw=15°)` | 14° (within 1°) | 15° (within 1°) | yes |
| `move_head(yaw=-90/+90)` full sweep | -89° / +89° | -89° / +89° | yes |
| `move_head(pitch=+30°)` max-up | +29° | +29° | yes |
| `move_head(pitch=-10°)` (down) | -1° (mechanical end-stop, see #80) | -2° (same) | **driver-equivalent — both hit same hardware limit** |

Hitting the down-direction end-stop happens **identically in both drivers** — the SCSCL baseline and FeetechScs produce the same physical behaviour, confirming this is a hardware/coordinate-mapping constraint, not a driver-side bug. The corresponding hot fix lands separately in #80 / #81.

### Code review

- `codex review` (pass 1, code quality): identified the WritePos return-value mismatch (SCSCL: success=1, FeetechScs: success=0). Fixed by `ServoWritePosOk()` driver-bridge helper.
- `codex adversarial-review` (pass 2, license + design): identified the missing `uart_wait_tx_done` between TX and RX on the half-duplex bus. Fixed via local patch documented in the vendor README.
- `codex adversarial-review` re-pass: **approved** (`ship`) after both fixes integrated.

## Test plan

- [x] Docker build with `CONFIG_STACKCHAN_SERVO_SCSCL` (default): xiaozhi.bin builds to 3,440,352 bytes (matches main).
- [x] Docker build with `CONFIG_STACKCHAN_SERVO_FEETECH=y`: xiaozhi.bin builds to 3,437,264 bytes.
- [x] Real-device test (M5Stack CoreS3 + SCS0009 ×2) confirms FEETECH and SCSCL produce equivalent behaviour across yaw -90..+90, pitch 0..+30 ranges.
- [x] codex review (both passes) approved.
- [x] Personal-config / private-data leak check: clean.
- [ ] Real-device validation on additional units (community help wanted, tracked in #79).

## Out of scope

- Promoting `CONFIG_STACKCHAN_SERVO_FEETECH=y` to default — pending broader community validation across units.
- Deleting the GPL-3.0 SCServo_lib files — same gating, planned for a future PR once the MIT driver matures upstream and validation completes.
- Sending the `uart_wait_tx_done` patch back to upstream as an Issue/PR — planned but separate work.

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)