### PR TITLE
chore(firmware): #79 promote MIT FeetechScs to default servo driver (Phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,57 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- **Default servo driver switched to MIT FeetechScs** (Phase A of the
+  GPL → MIT firmware migration tracked in #79). The opt-in MIT driver
+  added in #82 is now the build default for the canonical build path
+  (`firmware/scripts/release.py stackchan`), which now appends
+  `CONFIG_STACKCHAN_SERVO_FEETECH=y` to the per-board `sdkconfig` so
+  the selection is enforced regardless of any pre-existing
+  `firmware/sdkconfig` left in the workspace. Builds produced this way
+  exclude the GPL-3.0 SCServo_lib sources from the linked binary —
+  i.e. the firmware binary is MIT-licensed end-to-end. Equivalence
+  with SCSCL was validated on M5Stack CoreS3 + SCS0009 x2 in #82.
+
+  **Migration note for users with an existing `firmware/sdkconfig`:**
+  ESP-IDF persists Kconfig choices into `firmware/sdkconfig`, and a
+  Kconfig `default` change does not retroactively rewrite that file.
+  This release works around that by enforcing the choice at the
+  `release.py` layer (`sdkconfig_append`); rebuilding via
+  `release.py stackchan` produces an MIT default binary even on a
+  workspace that previously selected SCSCL. If you build by directly
+  invoking `idf.py` instead and have an existing `sdkconfig`, you may
+  need to run `idf.py menuconfig` (or delete `firmware/sdkconfig`) to
+  pick up the new default.
+
+  **Opting back into the GPL fallback:** the GPL-3.0 SCServo_lib
+  sources remain in-tree. To build against them, add
+  `CONFIG_STACKCHAN_SERVO_SCSCL=y` to `firmware/sdkconfig.defaults.local`
+  (which `release.py` merges in *after* `sdkconfig_append`, so it wins
+  over the FEETECH default).
+
+  Phase B (removal of the SCServo_lib sources, fully MIT-only
+  firmware) is gated on a multi-week observation period in #79 closing
+  without regressions. Please open an issue referencing #79 if you
+  observe any regression after rebuilding so the migration can be held
+  or rolled back. Refs #79.
+- `firmware/scripts/release.py` no longer **skips** the build when
+  `releases/v{PROJECT_VER}_{board}.zip` already exists. `PROJECT_VER`
+  is pinned to the upstream xiaozhi-esp32 firmware version
+  (currently `2.2.6`) and is not bumped per stackchan-mcp change, so
+  the previous skip behaviour silently let an old artifact survive a
+  rebuild invocation — including across license-sensitive
+  configuration changes such as the FEETECH/SCSCL servo driver swap
+  above. Existing `releases/v2.2.6_<board>.zip` files are now
+  automatically replaced by a fresh build (`zip_bin` already unlinks
+  before writing). Manual `rm -rf firmware/releases/v2.2.6_*.zip`
+  before invoking `release.py` is no longer required. Refs #79.
 - Add opt-in MIT-licensed servo driver alternative
   (`firmware/components/feetech_scs/`, vendored from
   [necobit/feetech_scs_esp_idf](https://github.com/necobit/feetech_scs_esp_idf)
   at commit `38a91984`). Build with Kconfig
   `CONFIG_STACKCHAN_SERVO_FEETECH=y` to exclude the GPL-3.0 SCServo_lib
-  sources and produce a fully MIT-licensed firmware binary. The default
-  keeps the existing GPL-3.0 SCServo_lib driver for stability until
-  real-device validation completes. Refs #79.
+  sources and produce a fully MIT-licensed firmware binary. (Promoted
+  to default in the entry above.) Refs #79.
 - **Hardware safety**: clamp `set_head_angles` pitch parameter to a
   hardware-safe sub-range (`0..+30°`) to prevent driving the SCS0009 servo
   into its mechanical end-stop. M5Stack docs explicitly warn that operating

--- a/README.ja.md
+++ b/README.ja.md
@@ -382,26 +382,36 @@ X 軸（yaw、`-90..+90°`）には同等のハードウェア制限はなく、
 
 ## ライセンス
 
-このリポジトリはデュアルライセンス構成です。
+正規の firmware ビルドパス (`firmware/scripts/release.py stackchan`) は **end-to-end で MIT ライセンス** のバイナリを生成します。GPL-3.0 の SCServo_lib ソースは [#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79) の移行期間中、opt-in fallback としてリポジトリに残しています。
 
 | 範囲 | ライセンス |
 |---|---|
-| 全体 (`gateway/`, トップレベル, `firmware/` の大部分) | **MIT License** (`LICENSE` 参照) |
-| `firmware/main/boards/stackchan/` 内の **SCServo_lib 由来ファイル** (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) | **GNU GPL-3.0** (`firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt` 参照) |
+| `gateway/`、トップレベル、**正規ビルド** の `firmware/` 全体 (`release.py stackchan` が `CONFIG_STACKCHAN_SERVO_FEETECH=y` を append し、MIT の [`feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf) ドライバ (`firmware/components/feetech_scs/` 配下に vendor 取り込み) をリンク) | **MIT License** (`LICENSE` 参照) |
+| `firmware/main/boards/stackchan/` 内の **SCServo_lib 由来ファイル** (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) — `CONFIG_STACKCHAN_SERVO_SCSCL=y` (例: `sdkconfig.defaults.local` 経由) を選択した場合のみリンクされます | **GNU GPL-3.0** (`firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt` 参照) |
 
-これは Feetech の SCServo SDK が GPL-3.0 で配布されているための制約です。SCServo_lib を静的リンクする **firmware バイナリ全体は実質 GPL-3.0** として配布されることになります。
+`gateway/` は独立した Python プロセスで、ESP32 とはネットワーク経由 (WebSocket) でしか通信しないため、firmware 側のドライバ選択に関わらず **MIT License** のまま利用・派生できます。
 
-一方、`gateway/` は独立した Python プロセスで、ESP32 とはネットワーク経由 (WebSocket) でしか通信しないため、**MIT License** のまま利用・派生できます。
+> **既存の `firmware/sdkconfig` を持っている `idf.py` 直叩きユーザーへの注意:**
+> ESP-IDF は Kconfig の選択を `firmware/sdkconfig` に永続化します。
+> Kconfig の `default` 変更はそのファイルを遡及的に書き換えません。
+> 正規ビルドパスは `release.py` レイヤーで (`sdkconfig_append` 経由で)
+> MIT ドライバを強制するため、`release.py stackchan` 経由の再ビルドは
+> 確実に MIT デフォルトのバイナリを生成します。
+> `release.py` を経由せず `idf.py` を直接叩く場合で、過去に SCSCL を
+> 選択した workspace では、新しい default を反映するために
+> `idf.py menuconfig` の実行 (または `firmware/sdkconfig` の削除) が
+> 必要になることがあります。
 
-> **MIT 単一ライセンス firmware ビルドのオプション (experimental, [#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79) 以降):**
-> SCServo_lib のクリーンルーム MIT 代替実装
-> ([`necobit/feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf)、
-> `firmware/components/feetech_scs/` 配下に vendor 取り込み) を opt-in
-> として Kconfig で選べます。`CONFIG_STACKCHAN_SERVO_FEETECH=y` でビルド
-> すると GPL-3.0 の SCServo_lib ソースがビルドから除外され、MIT 単一
-> ライセンスの firmware バイナリが生成されます。デフォルトは
-> `SCServo_lib` のまま (実機検証完了まで)、状況は #79 でトラッキング
-> しています。
+> **GPL-3.0 fallback ビルド (opt-in):**
+> 元の SCServo_lib ソースは、#79 の移行が観察期間中である間の安全網
+> として、引き続きリポジトリに同梱されています。
+> ビルドに使うには `firmware/sdkconfig.defaults.local` に
+> `CONFIG_STACKCHAN_SERVO_SCSCL=y` を追加してください。
+> `release.py` は `sdkconfig_append` の **後に** これをマージするため、
+> FEETECH デフォルトを上書きできます。その構成では firmware バイナリが
+> GPL-3.0 ソースを静的リンクするため、**実質 GPL-3.0** として配布される
+> ことになります。観察期間が回帰なしで終了したら、GPL ファイルは
+> 削除予定です (#79 の Phase B)。
 
 ### upstream
 

--- a/README.md
+++ b/README.md
@@ -430,25 +430,36 @@ See [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80) for the eng
 
 ## License
 
-This repository is dual-licensed.
+The canonical firmware build path (`firmware/scripts/release.py stackchan`) produces an **MIT-licensed end-to-end** binary. The GPL-3.0 SCServo_lib sources remain in the tree as an opt-in fallback during the migration tracked in [#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79).
 
 | Scope | License |
 |---|---|
-| All (`gateway/`, top-level, most of `firmware/`) | **MIT License** (see `LICENSE`) |
-| **SCServo_lib-derived files** under `firmware/main/boards/stackchan/` (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) | **GNU GPL-3.0** (see `firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt`) |
+| `gateway/`, top-level, all of `firmware/` in the **canonical build** (`release.py stackchan` appends `CONFIG_STACKCHAN_SERVO_FEETECH=y` and links the MIT [`feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf) driver vendored under `firmware/components/feetech_scs/`) | **MIT License** (see `LICENSE`) |
+| **SCServo_lib-derived files** under `firmware/main/boards/stackchan/` (SCS.{cc,h}, SCSCL.{cc,h}, SCSerial.{cc,h}, INST.h, SCServo.h) — only linked when `CONFIG_STACKCHAN_SERVO_SCSCL=y` is selected (e.g. via `sdkconfig.defaults.local`) | **GNU GPL-3.0** (see `firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt`) |
 
-This split exists because Feetech's SCServo SDK is distributed under GPL-3.0. The **firmware binary as a whole**, which statically links SCServo_lib, is therefore **effectively distributed under GPL-3.0**.
+The `gateway/` runs as an independent Python process and only talks to the ESP32 over the network (WebSocket), so it stays usable and derivable under the **MIT License** regardless of which servo driver the firmware-side build selects.
 
-The `gateway/` runs as an independent Python process and only talks to the ESP32 over the network (WebSocket), so it stays usable and derivable under the **MIT License**.
+> **Note for direct `idf.py` users with a pre-existing `firmware/sdkconfig`:**
+> ESP-IDF persists Kconfig choices into `firmware/sdkconfig`, and a
+> change to the Kconfig `default` does not retroactively rewrite that
+> file. The canonical build path enforces the MIT driver at the
+> `release.py` layer (via `sdkconfig_append`), so rebuilding via
+> `release.py stackchan` reliably produces the MIT default binary.
+> If you bypass `release.py` and call `idf.py` directly on a workspace
+> that previously selected SCSCL, you may need to run `idf.py menuconfig`
+> (or delete `firmware/sdkconfig`) to pick up the new default.
 
-> **Optional MIT-only firmware build (experimental, since [#79](https://github.com/kisaragi-mochi/stackchan-mcp/issues/79)):**
-> A clean-room MIT alternative to SCServo_lib
-> ([`necobit/feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf),
-> vendored under `firmware/components/feetech_scs/`) is available as an
-> opt-in via Kconfig. Building with `CONFIG_STACKCHAN_SERVO_FEETECH=y`
-> excludes the GPL-3.0 SCServo_lib sources, producing a fully
-> MIT-licensed firmware binary. The default remains `SCServo_lib` until
-> real-device validation completes; track #79 for status.
+> **GPL-3.0 fallback build (opt-in):**
+> The original SCServo_lib sources are still shipped in the repository
+> as a safety net while the migration tracked in #79 is in its
+> observation period. To build against them, add
+> `CONFIG_STACKCHAN_SERVO_SCSCL=y` to `firmware/sdkconfig.defaults.local`;
+> `release.py` merges this in **after** `sdkconfig_append`, so it
+> overrides the FEETECH default. In that configuration the firmware
+> binary statically links the GPL-3.0 sources and is therefore
+> **effectively distributed under GPL-3.0**. Once the observation
+> period closes without regressions the GPL files are scheduled for
+> removal (Phase B of #79).
 
 ### upstream
 

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1039,28 +1039,38 @@ if BOARD_TYPE_STACKCHAN
 
 choice STACKCHAN_SERVO_DRIVER
     prompt "StackChan Servo Driver"
-    default STACKCHAN_SERVO_SCSCL
+    default STACKCHAN_SERVO_FEETECH
     help
-        Choose between the original GPL-3.0 SCServo_lib (current default)
-        and the MIT-licensed clean-room reimplementation
+        Choose between the MIT-licensed clean-room reimplementation
         (necobit/feetech_scs_esp_idf, vendored under
-        firmware/components/feetech_scs/).
+        firmware/components/feetech_scs/, current default) and the
+        original GPL-3.0 SCServo_lib (kept in-tree as a fallback).
 
-        See Issue #79 for the migration roadmap to MIT-only firmware.
-
-    config STACKCHAN_SERVO_SCSCL
-        bool "SCServo_lib (GPL-3.0, current default)"
-        help
-            Use the original SCServo_lib sources shipped under
-            firmware/main/boards/stackchan/. License: GPL-3.0.
+        Phase A of the migration roadmap toward MIT-only firmware
+        tracked in #79. The opt-in MIT driver added in #82 was promoted
+        to default after single-unit equivalence validation on
+        M5Stack CoreS3 + SCS0009 x2. The GPL-3.0 sources remain
+        selectable via CONFIG_STACKCHAN_SERVO_SCSCL=y while the
+        observation period in #79 stays open; once that period closes
+        without regressions, the SCServo_lib sources are scheduled for
+        removal in Phase B.
 
     config STACKCHAN_SERVO_FEETECH
-        bool "feetech_scs_esp_idf (MIT, experimental)"
+        bool "feetech_scs_esp_idf (MIT, default)"
         help
             Use the MIT-licensed clean-room driver vendored at
-            firmware/components/feetech_scs/. Currently under validation —
-            firmware behavior is expected to match SCSCL but real-device
-            verification is in progress (#79).
+            firmware/components/feetech_scs/. Equivalence with SCSCL
+            confirmed on M5Stack CoreS3 + SCS0009 x2 in #82; broader
+            real-device validation continues under #79.
+
+    config STACKCHAN_SERVO_SCSCL
+        bool "SCServo_lib (GPL-3.0, fallback)"
+        help
+            Use the original SCServo_lib sources shipped under
+            firmware/main/boards/stackchan/. License: GPL-3.0. Kept in
+            the tree as an opt-in fallback in case a regression is
+            discovered with the MIT driver during the #79 observation
+            period. Scheduled for removal in Phase B of the migration.
 endchoice
 
 endif # BOARD_TYPE_STACKCHAN

--- a/firmware/main/boards/stackchan/config.json
+++ b/firmware/main/boards/stackchan/config.json
@@ -7,7 +7,8 @@
                 "CONFIG_SPIRAM_MODE_QUAD=y",
                 "CONFIG_CAMERA_GC0308=y",
                 "CONFIG_CAMERA_GC0308_AUTO_DETECT_DVP_INTERFACE_SENSOR=y",
-                "CONFIG_CAMERA_GC0308_DVP_YUV422_320X240_20FPS=y"
+                "CONFIG_CAMERA_GC0308_DVP_YUV422_320X240_20FPS=y",
+                "CONFIG_STACKCHAN_SERVO_FEETECH=y"
             ]
         }
     ]

--- a/firmware/scripts/release.py
+++ b/firmware/scripts/release.py
@@ -379,8 +379,20 @@ def release(board_type: str, config_filename: str = "config.json", *, filter_nam
         final_name = f"{manufacturer}-{name}" if manufacturer else name
         output_path = Path("releases") / f"v{project_version}_{final_name}.zip"
         if output_path.exists():
-            print(f"Skipping {final_name} because {output_path} already exists")
-            continue
+            # Do NOT skip when an artifact already exists. Skipping silently
+            # reused stale binaries even when the source-side configuration
+            # had license-sensitive changes (e.g. the FEETECH/SCSCL servo
+            # driver swap tracked in #79). PROJECT_VER is pinned to the
+            # upstream xiaozhi-esp32 firmware version (currently 2.2.6) and
+            # is not bumped per stackchan-mcp change, so skipping by zip
+            # name would let an old GPL-linked artifact survive a rebuild
+            # invocation. zip_bin() unlinks the existing file before
+            # writing, so a plain rebuild is safe.
+            print(
+                f"[INFO] Existing {output_path} will be replaced by a "
+                f"fresh build. Configuration source: config.json "
+                f"sdkconfig_append + sdkconfig.defaults.local overrides."
+            )
 
         # Process sdkconfig_append
         build_sdkconfig_append = build.get("sdkconfig_append", [])


### PR DESCRIPTION
## Summary

Phase A of the GPL → MIT firmware migration tracked in **#79**. The opt-in MIT [`feetech_scs_esp_idf`](https://github.com/necobit/feetech_scs_esp_idf) driver added in **#82** is now the build default for the canonical build path (`firmware/scripts/release.py stackchan`). The GPL-3.0 SCServo_lib sources remain in-tree as an opt-in fallback during the observation period defined on the tracking issue.

The result: a stock `release.py stackchan` build now produces a firmware binary that is **MIT-licensed end-to-end**.

## Why

`firmware/main/boards/stackchan/` ships **8 GPL-3.0 files** derived from the upstream Feetech `SCServo_lib` — the only GPL boundary inside the firmware. Promoting the MIT clean-room driver to default is the first step toward removing those files entirely (Phase B), which would let the firmware ship under a single MIT license and simplify downstream redistribution and packaging.

The opt-in driver added in #82 was equivalence-validated against SCSCL on M5Stack CoreS3 + SCS0009 ×2 (yaw -90..+90°, pitch 0..+30°, end-stop behaviour). The default flip is staged through Phase A first to give the migration an explicit observation window before the GPL files are deleted.

## Changes

### Firmware build configuration

- `firmware/main/Kconfig.projbuild`: flip `STACKCHAN_SERVO_DRIVER` choice default from `STACKCHAN_SERVO_SCSCL` to `STACKCHAN_SERVO_FEETECH`. Help text reframed to "default" / "fallback" instead of "current default" / "experimental".
- `firmware/main/boards/stackchan/config.json`: append `CONFIG_STACKCHAN_SERVO_FEETECH=y` to `sdkconfig_append`. ESP-IDF persists Kconfig choices into `firmware/sdkconfig`, and a Kconfig `default` change does **not** retroactively rewrite that file. Enforcing the choice at the `release.py` layer ensures the canonical build path produces an MIT default binary even on workspaces with a pre-existing `sdkconfig`.

### `firmware/scripts/release.py`

- Drop the existing-zip skip in the per-build loop. `PROJECT_VER` is pinned to the upstream xiaozhi-esp32 firmware version (currently `2.2.6`) and is not bumped per stackchan-mcp change, so the previous skip behaviour silently let an old GPL-linked artifact survive a rebuild invocation across license-sensitive configuration changes (e.g. this PR's FEETECH/SCSCL swap). `zip_bin()` already unlinks the existing file before writing, so a plain rebuild is safe; manual `rm -rf firmware/releases/v2.2.6_*.zip` before invoking `release.py` is no longer required.

### Documentation

- `README.md` / `README.ja.md`: rewrite the License section. Scope the MIT-binary claim to the canonical `release.py stackchan` path; document the `idf.py`-direct edge case (a pre-existing `sdkconfig` may need `idf.py menuconfig` or deletion to pick up the new default); document the GPL fallback path via `firmware/sdkconfig.defaults.local` + `CONFIG_STACKCHAN_SERVO_SCSCL=y` (release.py merges local overrides **after** `sdkconfig_append`, so the fallback selection wins).
- `CHANGELOG.md`: Firmware entries describing both the default-driver switch and the `release.py` skip change.

## Opt-in fallback (GPL)

The GPL-3.0 SCServo_lib sources remain in-tree. To build against them:

```
# firmware/sdkconfig.defaults.local
CONFIG_STACKCHAN_SERVO_SCSCL=y
```

Then re-run `firmware/scripts/release.py stackchan`. `release.py` merges local overrides after `sdkconfig_append`, so this selection wins over the FEETECH default.

## Phase B (out of scope here)

Phase B — deletion of `firmware/main/boards/stackchan/SCS.{cc,h}`, `SCSCL.{cc,h}`, `SCSerial.{cc,h}`, `INST.h`, `SCServo.h`, `SCServo_lib_LICENSE.txt`, plus the Kconfig choice; resulting in fully MIT-only firmware — is gated on a multi-week observation period closing without regressions. Trigger conditions and reporting workflow are documented on **#79**.

## Validation

### Side-by-side Docker build (espressif/idf:v5.5.2, esp32s3, BOARD_TYPE_STACKCHAN)

| Scenario | Result |
|---|---|
| Fresh `release.py stackchan` build | `xiaozhi.bin` 0x3474A0 bytes, `sdkconfig_append` summary contains `CONFIG_STACKCHAN_SERVO_FEETECH=y` |
| Re-run `release.py stackchan` with pre-existing `releases/v2.2.6_stackchan.zip` | `[INFO] Existing releases/v2.2.6_stackchan.zip will be replaced by a fresh build` emitted; build re-ran instead of skipping; zip mtime updated; FEETECH=y still appended |

### Real-device equivalence

Equivalence between SCSCL and FeetechScs on M5Stack CoreS3 + SCS0009 ×2 (yaw -90..+90° full sweep, pitch 0..+30°, end-stop behaviour) was validated in **#82**. This PR is a default-flip + build-path enforcement change with no servo-side code logic change, so the #82 validation continues to apply.

### Code review

- `codex adversarial-review` pass 1: no-ship — flagged that Kconfig `default` does not retroactively rewrite a persisted `sdkconfig`. Fixed by adding `CONFIG_STACKCHAN_SERVO_FEETECH=y` to `config.json`'s `sdkconfig_append`.
- `codex adversarial-review` pass 2: no-ship — flagged that `release.py` skipped when `releases/v{PROJECT_VER}_{board}.zip` already existed, allowing a stale GPL-linked artifact to survive a rebuild call. Fixed by removing the skip.
- `codex adversarial-review` pass 3: **approved**. "The canonical `release.py stackchan` path now rebuilds instead of preserving stale release zips, appends the FEETECH config for StackChan, and the CMake path excludes GPL SCServo sources when FEETECH is selected. EN/JP README license guidance is materially aligned, and the CHANGELOG bullets are publishable."

### Personal-config / leak check

`git diff main..HEAD --stat` confirms only `CHANGELOG.md`, `README.ja.md`, `README.md`, `firmware/main/Kconfig.projbuild`, `firmware/main/boards/stackchan/config.json`, `firmware/scripts/release.py`. No `firmware/sdkconfig.defaults`, no `firmware/sdkconfig.defaults.local`, no `gateway/.env`.

## Test plan

- [x] Docker build with default `release.py stackchan` produces FEETECH-linked `xiaozhi.bin` (verified via `sdkconfig_append` summary)
- [x] Docker re-build with pre-existing `releases/v2.2.6_stackchan.zip` does not skip
- [x] codex adversarial-review (3 passes, last one approved)
- [x] Personal-config / private-data leak check: clean
- [ ] Real-device re-validation on the maintainer's M5Stack CoreS3 + SCS0009 ×2 unit after merge — equivalence already covered in #82, this is a sanity flash to confirm the canonical-build path works end-to-end with the new defaults
- [ ] Open #79 follow-up comment documenting the Phase B observation period and reporting workflow

Refs #79
Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)