### PR TITLE
feat(firmware): #76 add TTS state-driven mouth lip-sync animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- **TTS lip-sync (state-driven)**: drive avatar mouth animation while
+  the gateway is speaking. The firmware now reacts to the
+  `tts.start` / `tts.stop` JSON notifications introduced in #75 (Issue
+  #70 PR2) and cycles the mouth shape through `closed → half → open →
+  half` on a fixed 150 ms cadence for the lifetime of each utterance,
+  snapping back to `closed` at stop. Autonomous blink is paused while
+  active (same Phase 2 trade-off as the existing `set_mouth_sequence`
+  task: a blink ending would otherwise restore the full-face image
+  and overwrite the mouth overlay) and restored at stop based on
+  `blink_desired_` so a `set_blink` issued mid-playback is honoured.
+  Coexists with user-issued `set_mouth` / `set_mouth_sequence` calls
+  by yielding the current frame when `mouth_seq_active_` is true; the
+  user-issued sequence wins until it completes, then lip-sync resumes
+  on the next tick. Wired through a new no-op `Board::OnTtsStart` /
+  `OnTtsStop` hook so non-stackchan boards are unaffected. The (B)
+  audio-envelope-driven follow-up proposed in the issue will be
+  tracked separately. Closes #76. Refs #70, #75.
 - **Default servo driver switched to MIT FeetechScs** (Phase A of the
   GPL → MIT firmware migration tracked in #79). The opt-in MIT driver
   added in #82 is now the build default for the canonical build path

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -512,18 +512,22 @@ void Application::InitializeProtocol() {
         });
     });
     
-    protocol_->OnIncomingJson([this, display](const cJSON* root) {
+    protocol_->OnIncomingJson([this, display, &board](const cJSON* root) {
         // Parse JSON data
         auto type = cJSON_GetObjectItem(root, "type");
         if (strcmp(type->valuestring, "tts") == 0) {
             auto state = cJSON_GetObjectItem(root, "state");
             if (strcmp(state->valuestring, "start") == 0) {
-                Schedule([this]() {
+                Schedule([this, &board]() {
                     aborted_ = false;
                     SetDeviceState(kDeviceStateSpeaking);
+                    // Phase 4 audio (Issue #76): drive avatar mouth animation
+                    // for the lifetime of this TTS utterance. Default no-op
+                    // for boards without a mouth display.
+                    board.OnTtsStart();
                 });
             } else if (strcmp(state->valuestring, "stop") == 0) {
-                Schedule([this]() {
+                Schedule([this, &board]() {
                     if (GetDeviceState() == kDeviceStateSpeaking) {
                         if (listening_mode_ == kListeningModeManualStop) {
                             SetDeviceState(kDeviceStateIdle);
@@ -531,6 +535,16 @@ void Application::InitializeProtocol() {
                             SetDeviceState(kDeviceStateListening);
                         }
                     }
+                    // Phase 4 audio (Issue #76): stop the avatar mouth
+                    // animation unconditionally on tts.stop. A wake-word /
+                    // button interrupt can call AbortSpeaking() and move
+                    // the device out of Speaking before the server's
+                    // tts.stop arrives, in which case the previous-state
+                    // guard above is false but the audio playback has
+                    // ended and the mouth animation must still stop.
+                    // OnTtsStop() is idempotent (no-op for boards without
+                    // an avatar / when lip-sync is already stopped).
+                    board.OnTtsStop();
                 });
             } else if (strcmp(state->valuestring, "sentence_start") == 0) {
                 auto text = cJSON_GetObjectItem(root, "text");

--- a/firmware/main/boards/common/board.h
+++ b/firmware/main/boards/common/board.h
@@ -82,6 +82,11 @@ public:
     virtual void SetPowerSaveLevel(PowerSaveLevel level) = 0;
     virtual std::string GetBoardJson() = 0;
     virtual std::string GetDeviceStatusJson() = 0;
+    // Phase 4 audio (Issue #76): TTS playback hooks. Default no-op so non-
+    // stackchan boards are unaffected; boards with an avatar / mouth display
+    // override these to drive lip-sync animation while TTS audio is playing.
+    virtual void OnTtsStart() {}
+    virtual void OnTtsStop() {}
 };
 
 #define DECLARE_BOARD(BOARD_CLASS_NAME) \

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -538,6 +538,27 @@ private:
     // Only meaningful while current_avatar_face_ == "off".
     bool blink_enabled_before_off_ = false;
 
+    // Phase 4 audio (Issue #76): state-driven TTS lip-sync animation.
+    // Driven by the gateway's tts.start / tts.stop notifications (see
+    // Application::OnIncomingJson) via Board::OnTtsStart / OnTtsStop;
+    // cycles the mouth through closed -> half -> open -> half on a fixed
+    // TTS_LIPSYNC_STEP_MS cadence until stopped. Autonomous blink is paused
+    // while active (same Phase 2 trade-off as the mouth-sequence task: a
+    // blink ending would otherwise restore the full-face image and overwrite
+    // the mouth overlay). The user's most recent blink intent is read from
+    // blink_desired_ at stop so a set_blink call issued during playback is
+    // honoured.
+    enum class TtsLipSyncShape : uint8_t {
+        CLOSED = 0,
+        HALF_RISING,   // closed -> open transition
+        OPEN,
+        HALF_FALLING,  // open -> closed transition
+    };
+    static constexpr int TTS_LIPSYNC_STEP_MS = 150;
+    esp_timer_handle_t tts_lipsync_timer_ = nullptr;
+    std::atomic<bool> tts_lipsync_active_{false};
+    TtsLipSyncShape tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
+
     // Phase 7: Si12T head-touch sensing.
     // Polling every TOUCH_POLL_MS samples Output1 (CH1..CH3 -> 3 head zones).
     // Edge detection on the OR of the three zones produces TAP / STROKE
@@ -1740,6 +1761,148 @@ private:
         ESP_LOGI(TAG, "Blink DISABLED");
     }
 
+    // ---- Phase 4 audio (Issue #76): TTS state-driven lip-sync ----------
+    //
+    // While the gateway is playing TTS audio (tts.start..tts.stop), cycle
+    // the mouth shape through CLOSED -> HALF -> OPEN -> HALF on a fixed
+    // TTS_LIPSYNC_STEP_MS cadence. This is the (A) state-driven approach
+    // proposed in Issue #76; the (B) audio-envelope-driven follow-up will
+    // replace this cycle with a per-frame amplitude mapping in a separate
+    // change.
+    //
+    // Concurrency:
+    //   - Single esp_timer self-rearming on ESP_TIMER_TASK.
+    //   - Coexists with the mouth-sequence playback task: when
+    //     mouth_seq_active_ is true (the user issued a set_mouth_sequence
+    //     while we were animating), the lip-sync step yields its frame and
+    //     re-arms; the user-issued sequence wins until it completes, then
+    //     lip-sync resumes naturally on the next tick.
+    //   - Pauses autonomous blink while active (same Phase 2 reasoning as
+    //     the mouth-sequence task: BlinkStepAdvance()'s
+    //     RestoreCurrentFaceLocked() would overwrite the mouth overlay).
+    //     Restores blink at stop based on blink_desired_ so a set_blink
+    //     issued mid-playback is honoured.
+    static void TtsLipSyncStepCb(void* arg) {
+        static_cast<StackChanBoard*>(arg)->TtsLipSyncStepAdvance();
+    }
+
+    void TtsLipSyncStepAdvance() {
+        if (!tts_lipsync_active_.load(std::memory_order_acquire)) {
+            return;
+        }
+        if (display_ == nullptr) {
+            return;
+        }
+        // Yield to an in-flight user-issued mouth sequence; re-arm so we
+        // resume on our cadence as soon as the sequence finishes.
+        if (mouth_seq_active_.load(std::memory_order_acquire)) {
+            esp_timer_start_once(tts_lipsync_timer_,
+                                 (uint64_t)TTS_LIPSYNC_STEP_MS * 1000);
+            return;
+        }
+        const char* shape = nullptr;
+        switch (tts_lipsync_shape_) {
+            case TtsLipSyncShape::CLOSED:
+                shape = "half";
+                tts_lipsync_shape_ = TtsLipSyncShape::HALF_RISING;
+                break;
+            case TtsLipSyncShape::HALF_RISING:
+                shape = "open";
+                tts_lipsync_shape_ = TtsLipSyncShape::OPEN;
+                break;
+            case TtsLipSyncShape::OPEN:
+                shape = "half";
+                tts_lipsync_shape_ = TtsLipSyncShape::HALF_FALLING;
+                break;
+            case TtsLipSyncShape::HALF_FALLING:
+            default:
+                shape = "closed";
+                tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
+                break;
+        }
+        SetMouthShape(shape);
+        if (tts_lipsync_active_.load(std::memory_order_acquire)) {
+            esp_timer_start_once(tts_lipsync_timer_,
+                                 (uint64_t)TTS_LIPSYNC_STEP_MS * 1000);
+        }
+    }
+
+    void EnsureTtsLipSyncTimer() {
+        if (tts_lipsync_timer_ == nullptr) {
+            esp_timer_create_args_t args = {
+                .callback = &StackChanBoard::TtsLipSyncStepCb,
+                .arg = this,
+                .dispatch_method = ESP_TIMER_TASK,
+                .name = "tts_lipsync",
+                .skip_unhandled_events = true,
+            };
+            ESP_ERROR_CHECK(esp_timer_create(&args, &tts_lipsync_timer_));
+        }
+    }
+
+    void StartTtsLipSync() {
+        if (display_ == nullptr) {
+            ESP_LOGD(TAG, "StartTtsLipSync ignored: display_ not ready");
+            return;
+        }
+        EnsureTtsLipSyncTimer();
+        if (tts_lipsync_active_.exchange(true, std::memory_order_acq_rel)) {
+            // Already active (e.g. duplicate tts.start); nothing to do.
+            return;
+        }
+        // Pause autonomous blink so BlinkStepAdvance()'s
+        // RestoreCurrentFaceLocked() does not overwrite the mouth overlay.
+        // blink_desired_ remembers the user's intent for restore at stop.
+        StopBlinkTimer();
+        // Start the cycle from a known resting position so the first audible
+        // frame opens the mouth from closed.
+        tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
+        SetMouthShape("closed");
+        esp_timer_start_once(tts_lipsync_timer_,
+                             (uint64_t)TTS_LIPSYNC_STEP_MS * 1000);
+        ESP_LOGI(TAG, "TTS lip-sync STARTED (cycle=%d ms)",
+                 TTS_LIPSYNC_STEP_MS);
+    }
+
+    void StopTtsLipSync() {
+        if (!tts_lipsync_active_.exchange(false, std::memory_order_acq_rel)) {
+            return;  // already stopped
+        }
+        if (tts_lipsync_timer_ != nullptr) {
+            esp_timer_stop(tts_lipsync_timer_);
+        }
+        // If a user-issued mouth sequence is in flight (we were yielding
+        // our frames to it via the mouth_seq_active_ guard in
+        // TtsLipSyncStepAdvance), let the sequence task own both the
+        // mouth shape and the blink restore at sequence end. Touching
+        // either here would race the sequence:
+        //   - SetMouthShape("closed") would clobber the user's current
+        //     frame mid-sequence;
+        //   - StartBlinkTimer() would let BlinkStepAdvance()'s
+        //     RestoreCurrentFaceLocked() overwrite the mouth overlay
+        //     before the sequence finishes drawing (Phase 2 trade-off).
+        // The sequence task already restores blink from blink_desired_
+        // at its own end (see MouthSequenceTaskLoop), so deferring is
+        // safe and idempotent.
+        if (mouth_seq_active_.load(std::memory_order_acquire)) {
+            ESP_LOGI(TAG,
+                     "TTS lip-sync STOPPED (mouth_seq active; deferring "
+                     "mouth + blink restore to sequence end)");
+            return;
+        }
+        // Snap back to a closed mouth so the device does not freeze on a
+        // half-open frame.
+        if (display_ != nullptr) {
+            SetMouthShape("closed");
+        }
+        // Restore blink based on the user's most recent intent (mirrors the
+        // mouth-sequence playback task's restore semantics).
+        if (blink_desired_.load(std::memory_order_acquire)) {
+            StartBlinkTimer();
+        }
+        ESP_LOGI(TAG, "TTS lip-sync STOPPED");
+    }
+
     // ---- Phase 2: lip-sync sequence playback (Issue #5) ----------------
     //
     // set_mouth_sequence accepts a list of {shape, duration_ms} pairs and
@@ -2702,6 +2865,17 @@ public:
             power_save_timer_->WakeUp();
         }
         WifiBoard::SetPowerSaveLevel(level);
+    }
+
+    // Phase 4 audio (Issue #76): drive avatar mouth animation alongside TTS
+    // playback. The gateway's tts.start / tts.stop notifications reach this
+    // board via Application::OnIncomingJson() -> Board::OnTtsStart/Stop().
+    virtual void OnTtsStart() override {
+        StartTtsLipSync();
+    }
+
+    virtual void OnTtsStop() override {
+        StopTtsLipSync();
     }
 
     virtual Backlight *GetBacklight() override {


### PR DESCRIPTION
## Summary

- Drive avatar mouth animation while the gateway is playing TTS audio.
- Mouth cycles `closed → half → open → half` on a fixed 150 ms cadence
  for the lifetime of each utterance, snaps back to `closed` at end.
- Wired through new no-op `Board::OnTtsStart` / `OnTtsStop` hooks so
  non-stackchan boards are unaffected.

## Why

PR #75 (Issue #70 PR2) added the gateway-side `say()` pipeline. The
`tts.start` / `tts.stop` notifications introduced there bracket the
audio frame stream so the firmware enters / leaves
`kDeviceStateSpeaking`, but they did not drive the avatar's mouth.
During real-device verification of #75 with a 333-frame / ~20-second
utterance, the avatar face was visible but the mouth stayed in its
resting shape throughout playback. This PR closes that binding gap.

This is the **(A) state-driven approach** proposed in #76: firmware-
side periodic mouth-shape rotation while audio is playing, no audio
analysis required. The (B) audio-envelope-driven follow-up
(per-frame amplitude → mouth shape mapping) will be tracked
separately.

## Implementation notes

- Single `esp_timer` self-rearming on `ESP_TIMER_TASK`. Member state is
  the active-flag (atomic), the current shape, and the timer handle.
- **Coexists with the existing mouth-sequence playback task** by
  yielding the current frame when `mouth_seq_active_` is true; the
  user-issued sequence wins until it completes, then lip-sync resumes
  naturally on the next tick.
- **Pauses autonomous blink while active** (same Phase 2 trade-off as
  the mouth-sequence task: `BlinkStepAdvance()`'s
  `RestoreCurrentFaceLocked()` would otherwise overwrite the mouth
  overlay). Restores blink at stop based on `blink_desired_` so a
  `set_blink` call issued mid-playback is honoured.
- **On stop while a user-issued mouth sequence is in flight**, defers
  the mouth and blink restore to the sequence task's end so the
  user's current frame is not clobbered.
- **`OnTtsStop()` runs unconditionally on `tts.stop`** (not gated on
  the Speaking state) so a wake-word / button interrupt that calls
  `AbortSpeaking()` and transitions out of Speaking before the
  server's `tts.stop` arrives still cancels the mouth animation.

## Validation

### codex review (1 pass)

Two follow-up findings, both reflected in the final commit:

- **P1** (`application.cc`): `tts.stop` now stops lip-sync
  unconditionally, separated from the Speaking-state guard, so an
  `AbortSpeaking()` interrupt that transitions the device to
  Listening before `tts.stop` arrives still cancels the mouth
  animation.
- **P2** (`stackchan.cc StopTtsLipSync`): defers the mouth + blink
  restore when `mouth_seq_active_` is true, leaving sequence end to
  own them and avoiding a race where blink would overwrite the
  user's mouth frame mid-sequence.

### Real-device validation

Tested on M5Stack CoreS3 + SCS0009 ×2 with the new firmware build
(`xiaozhi.bin` flashed at `0x20000`), gateway connected via Tailscale
Funnel, `set_blink(true)` enabled, and a running VOICEVOX engine
container:

- **Short utterance** (`say`, 75 frames / 4.5 s): mouth animated
  through `closed → half → open → half` cycle as expected, snapped
  back to `closed` at end of audio.
- **Long utterance** (`say`, 349 frames / 20.94 s): mouth animation
  sustained for the full ~21 s without stalling. Autonomous blink
  stayed paused for the entire utterance (lip-sync owns the mouth
  overlay; the `BlinkStepAdvance()` restore path would otherwise
  overwrite it). Blink resumed within the
  `BLINK_MIN_GAP_MS..BLINK_MAX_GAP_MS` random window (3-6 s) after
  the utterance ended, honouring the `set_blink(true)` intent
  latched in `blink_desired_`.
- Serial monitor showed no TCP receive failures or auth-related
  disconnects during testing.

## Out of scope (follow-up)

The (B) audio-envelope-driven approach proposed in #76 (RMS envelope
per Opus frame → mouth shape) will be tracked in a separate issue; it
is a higher-fidelity replacement for this state machine, not an
addition on top of it.

Closes #76. Refs #70, #75.