### PR TITLE
docs(changelog): fix Unreleased link and add v0.5.0 tag link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,7 +352,8 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.5.0
 [0.4.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.4.0
 [0.3.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.3.0
 [0.2.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.2.0


### PR DESCRIPTION
## Summary

The v0.5.0 release PR (#78) promoted the `Unreleased` section to a
released `[0.5.0]` entry but did not update the link reference table
at the bottom of `CHANGELOG.md`. This PR backfills the two missing
link-maintenance steps so the rendered changelog matches the
"Per-release steps" instructions in `CONTRIBUTING.md`.

## Why

- `[Unreleased]` previously linked to `v0.4.0...HEAD`. The rendered
  "Unreleased" link therefore mixed in everything already shipped in
  `v0.5.0` alongside the genuinely-unreleased Firmware entries
  currently sitting on main.
- `[0.5.0]` was the first release entry without a tag link in the
  reference table, so the inline `[0.5.0]` header rendered as a
  dangling reference (`[0.4.0]` / `[0.3.0]` / `[0.2.0]` / `[0.1.0]`
  all resolve correctly).

After this PR, the `[Unreleased]` link compares the next-release diff
(`v0.5.0...HEAD`) and `[0.5.0]` resolves to the published tag, in
line with the `CONTRIBUTING.md` rule that a new `[Unreleased]` should
compare the new tag to `HEAD` and a new `[X.Y.Z]` link should point
at the release tag.

## Validation

- Visual inspection of the link reference table at the bottom of
  `CHANGELOG.md`.
- Pure docs change: no gateway / firmware behaviour impact, no
  pytest / ruff impact.

Refs #78