### PR TITLE
feat(firmware,gateway): #85 envelope-driven TTS lip-sync with state-cycle fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,25 +15,55 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Gateway
+
+- **TTS audio amplitude envelope sidecar (Issue #85)**: the
+  orchestrator now emits one
+  `{"type":"tts","state":"envelope","frame_id":N,"rms":...}` JSON
+  message per Opus audio frame, carrying the per-frame RMS amplitude
+  (normalised to `[0.0, 1.0]`) computed from the same PCM that fed
+  the encoder. Firmware on the StackChan board (see Firmware section)
+  consumes this to drive amplitude-based mouth-shape selection during
+  lip-sync; older firmware ignores the message and falls back to the
+  fixed lip-sync cycle introduced in the previous release. Each
+  envelope is awaited inline before the matching audio frame so the
+  WebSocket write order is guaranteed at the connection layer (a new
+  per-connection `_send_lock` on `ESP32Connection` serialises every
+  underlying `websockets.send()`). To keep that ordering from
+  inflating the 60 ms audio pacing budget, the envelope path uses a
+  bounded `lock_acquire_timeout=30 ms` — if another sender already
+  holds the send lock past that window, the envelope is dropped
+  silently and the audio frame proceeds on schedule, with the
+  firmware fallback cycle covering the missed update. The bound is
+  applied at the *lock acquire* layer rather than around `ws.send()`
+  itself because the `websockets` library documents cancelling an
+  in-flight send as unsafe. Refs #76, #84.
+
 ### Firmware
 
-- **TTS lip-sync (state-driven)**: drive avatar mouth animation while
-  the gateway is speaking. The firmware now reacts to the
-  `tts.start` / `tts.stop` JSON notifications introduced in #75 (Issue
-  #70 PR2) and cycles the mouth shape through `closed → half → open →
-  half` on a fixed 150 ms cadence for the lifetime of each utterance,
-  snapping back to `closed` at stop. Autonomous blink is paused while
-  active (same Phase 2 trade-off as the existing `set_mouth_sequence`
-  task: a blink ending would otherwise restore the full-face image
-  and overwrite the mouth overlay) and restored at stop based on
-  `blink_desired_` so a `set_blink` issued mid-playback is honoured.
-  Coexists with user-issued `set_mouth` / `set_mouth_sequence` calls
-  by yielding the current frame when `mouth_seq_active_` is true; the
-  user-issued sequence wins until it completes, then lip-sync resumes
-  on the next tick. Wired through a new no-op `Board::OnTtsStart` /
-  `OnTtsStop` hook so non-stackchan boards are unaffected. The (B)
-  audio-envelope-driven follow-up proposed in the issue will be
-  tracked separately. Closes #76. Refs #70, #75.
+- **TTS lip-sync now envelope-driven (Issue #85), with the previous
+  state cycle as fallback**: the `closed → half → open → half`
+  rotation introduced for the (A) state-driven path in the previous
+  release is replaced — at the per-step shape selection layer only —
+  by amplitude-based mouth shape selection that reads the per-frame
+  RMS envelope sent by the gateway as
+  `{"type":"tts","state":"envelope","frame_id":N,"rms":...}`. The
+  step cadence is reduced from 150 ms to **60 ms** so the firmware
+  samples envelopes at the same rate the gateway emits them
+  (`audio_utils.DEVICE_FRAME_DURATION_MS`); plosive / onset peaks
+  that would otherwise be overwritten between consecutive 150 ms
+  steps now reach `SetMouthShape()`. When the gateway has not sent
+  an envelope within the last 200 ms (older release, network gap,
+  or a non-envelope-capable engine), the step callback falls back
+  to the fixed cycle so the mouth still moves with no protocol
+  regression. The start/stop, blink-yield, mouth-sequence-yield, and
+  `Board::OnTtsStart` / `OnTtsStop` machinery from the previous
+  release is unchanged; a new no-op `Board::OnTtsEnvelope(frame_id,
+  rms)` hook is added for non-avatar boards. Default amplitude
+  thresholds are `0.05` (low → closed) and `0.15` (high → open),
+  tuned against VOICEVOX (Zundamon) at the device's default volume;
+  re-tune in firmware (and re-flash) when adding engines with a
+  different dynamic range. Closes #85. Refs #76, #84.
 - **Default servo driver switched to MIT FeetechScs** (Phase A of the
   GPL → MIT firmware migration tracked in #79). The opt-in MIT driver
   added in #82 is now the build default for the canonical build path

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -546,6 +546,22 @@ void Application::InitializeProtocol() {
                     // an avatar / when lip-sync is already stopped).
                     board.OnTtsStop();
                 });
+            } else if (strcmp(state->valuestring, "envelope") == 0) {
+                // Phase 4 audio (Issue #85): per-frame audio amplitude
+                // envelope. Drives amplitude-based mouth-shape selection
+                // on boards with an avatar; default no-op elsewhere.
+                // OnTtsEnvelope is intentionally lock-free (atomic stores
+                // only on the avatar board) so it is safe to invoke
+                // directly from the WebSocket task without Schedule().
+                // Avoids loading the main task queue at the per-audio-
+                // frame cadence (~16 Hz for 60 ms Opus frames).
+                auto frame_id = cJSON_GetObjectItem(root, "frame_id");
+                auto rms = cJSON_GetObjectItem(root, "rms");
+                if (cJSON_IsNumber(frame_id) && cJSON_IsNumber(rms)) {
+                    board.OnTtsEnvelope(
+                        static_cast<uint32_t>(frame_id->valueint),
+                        static_cast<float>(rms->valuedouble));
+                }
             } else if (strcmp(state->valuestring, "sentence_start") == 0) {
                 auto text = cJSON_GetObjectItem(root, "text");
                 if (cJSON_IsString(text)) {

--- a/firmware/main/boards/common/board.h
+++ b/firmware/main/boards/common/board.h
@@ -87,6 +87,19 @@ public:
     // override these to drive lip-sync animation while TTS audio is playing.
     virtual void OnTtsStart() {}
     virtual void OnTtsStop() {}
+
+    // Phase 4 audio (Issue #85): per-frame audio envelope hook. The gateway
+    // computes the RMS of each PCM frame before Opus encoding and sends a
+    // {"type":"tts","state":"envelope","frame_id":N,"rms":...} message
+    // immediately before each audio frame. Boards with an avatar override
+    // this to drive amplitude-based mouth shape selection. ``rms`` is
+    // normalised to the [0.0, 1.0] range (signed 16-bit sample magnitude
+    // divided by 32768). Default no-op so non-avatar boards and older
+    // gateways (which do not emit the message) both work unchanged.
+    virtual void OnTtsEnvelope(uint32_t frame_id, float rms) {
+        (void)frame_id;
+        (void)rms;
+    }
 };
 
 #define DECLARE_BOARD(BOARD_CLASS_NAME) \

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -45,6 +45,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include <cJSON.h>
 #include <lvgl.h>
 #include <atomic>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -554,10 +555,49 @@ private:
         OPEN,
         HALF_FALLING,  // open -> closed transition
     };
-    static constexpr int TTS_LIPSYNC_STEP_MS = 150;
+    // Step cadence when an envelope is fresh: aligned with the
+    // gateway's 60 ms Opus frame period
+    // (see audio_utils.DEVICE_FRAME_DURATION_MS) so each per-frame
+    // envelope reaches SetMouthShape() instead of being overwritten by
+    // the next frame between samples. Plosive / onset peaks survive
+    // the firmware-side per-frame map at this rate.
+    static constexpr int TTS_LIPSYNC_STEP_MS = 60;
+    // Fallback step cadence when no envelope has arrived recently.
+    // Pinned to the previous (pre-Issue-#85) value so an older gateway
+    // (no envelope channel), or a network gap mid-utterance, sees the
+    // same CLOSED -> HALF -> OPEN -> HALF cycle period it always did
+    // (~600 ms) rather than the busier 240 ms loop that 60 ms timing
+    // would produce. The single esp_timer is re-armed on each step
+    // with the appropriate delay based on envelope freshness.
+    static constexpr int TTS_LIPSYNC_FALLBACK_STEP_MS = 150;
     esp_timer_handle_t tts_lipsync_timer_ = nullptr;
     std::atomic<bool> tts_lipsync_active_{false};
     TtsLipSyncShape tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
+
+    // Phase 4 audio (Issue #85): per-frame audio amplitude envelope from
+    // the gateway. When fresh (within TTS_LIPSYNC_ENVELOPE_FRESHNESS_MS),
+    // the step callback maps RMS to a discrete mouth shape; otherwise it
+    // walks the fixed CLOSED -> HALF -> OPEN -> HALF cycle so older
+    // gateways (which do not emit {"type":"tts","state":"envelope"})
+    // still produce mouth movement during TTS playback.
+    //
+    // Both fields are written from the WebSocket task (see
+    // Application::OnIncomingJson) and read from the esp_timer task
+    // (TtsLipSyncStepAdvance), so they must be std::atomic.
+    std::atomic<float> tts_lipsync_envelope_rms_{0.0f};
+    std::atomic<uint64_t> tts_lipsync_envelope_at_us_{0};
+    // Threshold pair tuned against VOICEVOX (Zundamon) at the device's
+    // default volume; quieter engines may sit perpetually below the low
+    // threshold and stay closed. Re-tune (and re-flash) as additional
+    // engines (Irodori, etc.) come online.
+    static constexpr float TTS_LIPSYNC_RMS_LOW = 0.05f;
+    static constexpr float TTS_LIPSYNC_RMS_HIGH = 0.15f;
+    // How fresh an envelope value must be to drive the mouth. If we have
+    // not seen a {tts.envelope} message within this window, we assume
+    // the gateway is not emitting them (or there is a network gap) and
+    // fall back to the fixed cycle. Slightly larger than a few audio
+    // frames so a single dropped envelope does not flicker the mode.
+    static constexpr int TTS_LIPSYNC_ENVELOPE_FRESHNESS_MS = 200;
 
     // Phase 7: Si12T head-touch sensing.
     // Polling every TOUCH_POLL_MS samples Output1 (CH1..CH3 -> 3 head zones).
@@ -1801,29 +1841,76 @@ private:
             return;
         }
         const char* shape = nullptr;
-        switch (tts_lipsync_shape_) {
-            case TtsLipSyncShape::CLOSED:
-                shape = "half";
-                tts_lipsync_shape_ = TtsLipSyncShape::HALF_RISING;
-                break;
-            case TtsLipSyncShape::HALF_RISING:
+        const uint64_t now_us = esp_timer_get_time();
+        const uint64_t env_at = tts_lipsync_envelope_at_us_.load(
+            std::memory_order_acquire);
+        const uint64_t freshness_us =
+            (uint64_t)TTS_LIPSYNC_ENVELOPE_FRESHNESS_MS * 1000;
+        const bool envelope_fresh =
+            (env_at != 0) && (now_us - env_at < freshness_us);
+
+        if (envelope_fresh) {
+            // Envelope-driven (Issue #85): amplitude maps to a discrete
+            // mouth shape. Keep tts_lipsync_shape_ coherent with the
+            // displayed shape so a transition back to the cycle
+            // fallback (envelope drops out mid-utterance) starts from
+            // a sensible position rather than wherever the cycle was
+            // left off before envelopes arrived.
+            const float rms = tts_lipsync_envelope_rms_.load(
+                std::memory_order_acquire);
+            if (rms >= TTS_LIPSYNC_RMS_HIGH) {
                 shape = "open";
                 tts_lipsync_shape_ = TtsLipSyncShape::OPEN;
-                break;
-            case TtsLipSyncShape::OPEN:
+            } else if (rms >= TTS_LIPSYNC_RMS_LOW) {
                 shape = "half";
-                tts_lipsync_shape_ = TtsLipSyncShape::HALF_FALLING;
-                break;
-            case TtsLipSyncShape::HALF_FALLING:
-            default:
+                // Mark as RISING so a subsequent fallback step that
+                // reads HALF_RISING advances correctly to OPEN rather
+                // than HALF_FALLING.
+                tts_lipsync_shape_ = TtsLipSyncShape::HALF_RISING;
+            } else {
                 shape = "closed";
                 tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
-                break;
+            }
+        } else {
+            // Fallback: gateway has not sent an envelope (older
+            // release, or network gap mid-utterance). Walk the fixed
+            // CLOSED -> HALF -> OPEN -> HALF cycle so the user still
+            // sees mouth movement.
+            switch (tts_lipsync_shape_) {
+                case TtsLipSyncShape::CLOSED:
+                    shape = "half";
+                    tts_lipsync_shape_ = TtsLipSyncShape::HALF_RISING;
+                    break;
+                case TtsLipSyncShape::HALF_RISING:
+                    shape = "open";
+                    tts_lipsync_shape_ = TtsLipSyncShape::OPEN;
+                    break;
+                case TtsLipSyncShape::OPEN:
+                    shape = "half";
+                    tts_lipsync_shape_ = TtsLipSyncShape::HALF_FALLING;
+                    break;
+                case TtsLipSyncShape::HALF_FALLING:
+                default:
+                    shape = "closed";
+                    tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
+                    break;
+            }
         }
         SetMouthShape(shape);
         if (tts_lipsync_active_.load(std::memory_order_acquire)) {
+            // Re-arm cadence depends on whether the most recent step
+            // ran the envelope-driven path or the fallback. Doing the
+            // selection here (not at start time) keeps the cadence in
+            // sync as the source flips mid-utterance — e.g. an older
+            // gateway begins a session in fallback mode and stays
+            // there, while a hybrid gateway can fall briefly into
+            // fallback during a network gap and then return to 60 ms
+            // sampling once envelopes resume.
+            const int next_delay_ms = envelope_fresh
+                ? TTS_LIPSYNC_STEP_MS
+                : TTS_LIPSYNC_FALLBACK_STEP_MS;
             esp_timer_start_once(tts_lipsync_timer_,
-                                 (uint64_t)TTS_LIPSYNC_STEP_MS * 1000);
+                                 (uint64_t)next_delay_ms * 1000);
         }
     }
 
@@ -1854,14 +1941,31 @@ private:
         // RestoreCurrentFaceLocked() does not overwrite the mouth overlay.
         // blink_desired_ remembers the user's intent for restore at stop.
         StopBlinkTimer();
+        // Issue #85: discard any envelope value left over from a
+        // previous utterance so the first step of this utterance does
+        // not consult a stale RMS reading from minutes ago. The next
+        // tts.envelope message from the gateway re-arms envelope-
+        // driven mode; until then we run the fixed cycle.
+        tts_lipsync_envelope_at_us_.store(0, std::memory_order_release);
+        tts_lipsync_envelope_rms_.store(0.0f, std::memory_order_release);
         // Start the cycle from a known resting position so the first audible
         // frame opens the mouth from closed.
         tts_lipsync_shape_ = TtsLipSyncShape::CLOSED;
         SetMouthShape("closed");
-        esp_timer_start_once(tts_lipsync_timer_,
-                             (uint64_t)TTS_LIPSYNC_STEP_MS * 1000);
-        ESP_LOGI(TAG, "TTS lip-sync STARTED (cycle=%d ms)",
-                 TTS_LIPSYNC_STEP_MS);
+        // Initial step delay matches the cadence the next step would
+        // pick (envelope_fresh is false at start, since we just zeroed
+        // the envelope timestamp), so an older gateway with no
+        // envelope channel sees a uniform fallback cadence from the
+        // very first step rather than a 60 ms outlier followed by
+        // 150 ms intervals. A new envelope arriving before the first
+        // step fires will be picked up at that step and the next
+        // re-arm switches to the 60 ms cadence.
+        esp_timer_start_once(
+            tts_lipsync_timer_,
+            (uint64_t)TTS_LIPSYNC_FALLBACK_STEP_MS * 1000);
+        ESP_LOGI(TAG,
+                 "TTS lip-sync STARTED (envelope=%d ms, fallback=%d ms)",
+                 TTS_LIPSYNC_STEP_MS, TTS_LIPSYNC_FALLBACK_STEP_MS);
     }
 
     void StopTtsLipSync() {
@@ -1871,6 +1975,13 @@ private:
         if (tts_lipsync_timer_ != nullptr) {
             esp_timer_stop(tts_lipsync_timer_);
         }
+        // Issue #85: clear the envelope freshness timestamp so an
+        // overdue envelope arriving after stop does not influence the
+        // next utterance's first step. The RMS value itself is harmless
+        // to leave behind because it is only read when env_at_us_ is
+        // non-zero, but we reset both for symmetry with StartTtsLipSync.
+        tts_lipsync_envelope_at_us_.store(0, std::memory_order_release);
+        tts_lipsync_envelope_rms_.store(0.0f, std::memory_order_release);
         // If a user-issued mouth sequence is in flight (we were yielding
         // our frames to it via the mouth_seq_active_ guard in
         // TtsLipSyncStepAdvance), let the sequence task own both the
@@ -2876,6 +2987,30 @@ public:
 
     virtual void OnTtsStop() override {
         StopTtsLipSync();
+    }
+
+    // Phase 4 audio (Issue #85): per-frame audio amplitude envelope from
+    // the gateway. Cheap atomic stores; safe to call directly from the
+    // WebSocket task without going through Application::Schedule(). The
+    // step callback (TtsLipSyncStepAdvance) reads the latest RMS and
+    // freshness timestamp on its own cadence, so frame_id is currently
+    // informational only.
+    virtual void OnTtsEnvelope(uint32_t frame_id, float rms) override {
+        (void)frame_id;
+        // Defensive clamp: malformed envelopes (NaN, infinity, out-of-
+        // range) are ignored or pinned to [0, 1] so the threshold
+        // comparisons stay well-defined.
+        if (!std::isfinite(rms)) {
+            return;
+        }
+        if (rms < 0.0f) {
+            rms = 0.0f;
+        } else if (rms > 1.0f) {
+            rms = 1.0f;
+        }
+        tts_lipsync_envelope_rms_.store(rms, std::memory_order_release);
+        tts_lipsync_envelope_at_us_.store(esp_timer_get_time(),
+                                          std::memory_order_release);
     }
 
     virtual Backlight *GetBacklight() override {

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -44,6 +44,29 @@ class ESP32Connection:
         # payload). v2/v3 add a BinaryProtocol header that this gateway
         # does not yet wrap — see Issue follow-up to #70.
         self.protocol_version: int = 1
+        # Per-connection send lock (Issue #85). Serialises every
+        # underlying ``websockets.send()`` so a ``send_tts_envelope``
+        # cannot race a ``send_audio_frame`` on the same socket — the
+        # firmware needs envelope[N] to land before audio[N] for the
+        # per-frame mouth shape map to track the right frame, and
+        # ``websockets`` does not internally serialise concurrent send
+        # calls. Held only across the actual ``await self._ws.send()``,
+        # so contention windows are short.
+        #
+        # NOTE: this is a non-reentrant ``asyncio.Lock``. Callers must
+        # not invoke another send on the same connection while already
+        # inside a locked send (e.g. from a websocket-side callback,
+        # an instrumentation wrapper, or any future hook that fires
+        # mid-write) — the second acquire would await the lock the
+        # outer send still holds and wedge the connection. The current
+        # callers are linear (``send_audio_frame`` /
+        # ``send_tts_state`` / ``send_tts_envelope`` /
+        # ``send_mcp_request``), none of which dispatch back into
+        # another send, so this is safe today; if a future change
+        # introduces a re-entrant send path, switch this to an
+        # owner-tracking lock or refactor the egress to a single
+        # writer queue first.
+        self._send_lock = asyncio.Lock()
 
     @property
     def connected(self) -> bool:
@@ -161,17 +184,27 @@ class ESP32Connection:
         errors leak as raw tracebacks into the MCP transport, breaking
         the say() tool's clean error JSON contract on mid-stream
         disconnect.
+
+        Acquires :attr:`_send_lock` for the duration of the
+        ``ws.send()`` call so concurrent senders on the same
+        connection (e.g. an envelope and an audio frame from the TTS
+        orchestrator, see Issue #85) are serialised in the order they
+        arrive at this method rather than racing inside the
+        ``websockets`` library.
         """
-        try:
-            await self._ws.send(payload)
-        except (
-            websockets.exceptions.ConnectionClosed,
-            OSError,
-        ) as exc:
-            # Mark the connection dead so subsequent calls fail fast
-            # rather than each one re-discovering the broken socket.
-            self.disconnect()
-            raise ConnectionError(f"WebSocket send failed: {exc}") from exc
+        async with self._send_lock:
+            try:
+                await self._ws.send(payload)
+            except (
+                websockets.exceptions.ConnectionClosed,
+                OSError,
+            ) as exc:
+                # Mark the connection dead so subsequent calls fail fast
+                # rather than each one re-discovering the broken socket.
+                self.disconnect()
+                raise ConnectionError(
+                    f"WebSocket send failed: {exc}"
+                ) from exc
 
     async def send_audio_frame(self, opus_frame: bytes) -> None:
         """Send a single Opus frame to the ESP32 as a WebSocket binary frame.
@@ -205,6 +238,96 @@ class ESP32Connection:
             "state": state,
         }
         await self._ws_send(json.dumps(message))
+
+    async def send_tts_envelope(
+        self,
+        frame_id: int,
+        rms: float,
+        *,
+        lock_acquire_timeout: float | None = None,
+    ) -> bool:
+        """Send a per-frame audio amplitude envelope (Issue #85).
+
+        The device's :func:`Application::OnIncomingJson` reads
+        ``{"type":"tts","state":"envelope","frame_id":N,"rms":...}``
+        and forwards the value to ``Board::OnTtsEnvelope``, which on
+        the StackChan board drives amplitude-based mouth shape
+        selection. Older firmware (before #85) ignores the message
+        because the ``"envelope"`` state branch falls through the
+        ``OnIncomingJson`` switch as an unknown TTS state. New firmware
+        falls back to a fixed lip-sync cycle if envelopes stop
+        arriving for more than 200 ms, so a single dropped envelope is
+        non-fatal.
+
+        Args:
+            frame_id: Sequence number of the audio frame this envelope
+                corresponds to (orchestrator-assigned, starts at 0).
+            rms: RMS amplitude of the PCM frame, normalised to
+                ``[0.0, 1.0]``.
+            lock_acquire_timeout: If set, give up after this many
+                seconds when waiting for :attr:`_send_lock` rather
+                than blocking indefinitely. Used by the TTS
+                orchestrator to bound how long an envelope can hold
+                up the next audio frame's 60 ms pacing budget — if
+                the lock is held that long by another sender, the
+                envelope is silently dropped instead of cancelling
+                the in-flight ``websockets.send()`` (which the library
+                documents as unsafe).
+
+        Returns:
+            ``True`` if the envelope was actually pushed to the
+            socket, ``False`` if it was dropped due to lock
+            contention timeout. Callers may treat ``False`` as a
+            best-effort skip (firmware will fall back to its fixed
+            lip-sync cycle).
+        """
+        if not self._connected:
+            raise ConnectionError("ESP32 not connected")
+
+        if lock_acquire_timeout is not None:
+            # Wait for the send lock up to the budgeted window. The
+            # acquire() coroutine is safe to cancel (no half-written
+            # bytes hit the wire), unlike cancelling a ws.send() that
+            # has already started.
+            try:
+                await asyncio.wait_for(
+                    self._send_lock.acquire(),
+                    timeout=lock_acquire_timeout,
+                )
+            except asyncio.TimeoutError:
+                return False
+            try:
+                message = {
+                    "session_id": self.session_id,
+                    "type": "tts",
+                    "state": "envelope",
+                    "frame_id": int(frame_id),
+                    "rms": float(rms),
+                }
+                try:
+                    await self._ws.send(json.dumps(message))
+                except (
+                    websockets.exceptions.ConnectionClosed,
+                    OSError,
+                ) as exc:
+                    self.disconnect()
+                    raise ConnectionError(
+                        f"WebSocket send failed: {exc}"
+                    ) from exc
+            finally:
+                self._send_lock.release()
+            return True
+
+        # Unbounded path: delegate to the standard locked sender.
+        message = {
+            "session_id": self.session_id,
+            "type": "tts",
+            "state": "envelope",
+            "frame_id": int(frame_id),
+            "rms": float(rms),
+        }
+        await self._ws_send(json.dumps(message))
+        return True
 
     def disconnect(self) -> None:
         """Mark connection as disconnected."""
@@ -450,6 +573,28 @@ class ESP32Manager:
         if not self._connection or not self._connection.connected:
             raise ConnectionError("No ESP32 device connected")
         await self._connection.send_tts_state(state)
+
+    async def send_tts_envelope(
+        self,
+        frame_id: int,
+        rms: float,
+        *,
+        lock_acquire_timeout: float | None = None,
+    ) -> bool:
+        """Send a per-frame audio amplitude envelope to the device.
+
+        See :meth:`ESP32Connection.send_tts_envelope` for the protocol
+        rationale (Issue #85), the lock-acquire timeout semantics, and
+        the meaning of the ``True`` / ``False`` return value. The
+        orchestrator emits one envelope per Opus audio frame
+        immediately before the corresponding binary frame so the
+        firmware's mouth shape can update in step with playback.
+        """
+        if not self._connection or not self._connection.connected:
+            raise ConnectionError("No ESP32 device connected")
+        return await self._connection.send_tts_envelope(
+            frame_id, rms, lock_acquire_timeout=lock_acquire_timeout
+        )
 
     def get_status(self) -> dict[str, Any]:
         """Get current connection status."""

--- a/gateway/stackchan_mcp/tts/audio_utils.py
+++ b/gateway/stackchan_mcp/tts/audio_utils.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import array
 import io
 import logging
+import math
 import wave
 from typing import Iterator
 
@@ -124,6 +125,43 @@ def resample_pcm16_linear(pcm: bytes, src_rate: int, dst_rate: int) -> bytes:
         # Round toward zero is fine for 16-bit speech.
         out.append(int(a + (b - a) * frac))
     return out.tobytes()
+
+
+def compute_pcm_frame_rms(pcm_frame: bytes) -> float:
+    """Compute the RMS amplitude of a single PCM16 mono frame.
+
+    The result is normalised against the signed 16-bit full-scale value
+    (32768) so it sits in ``[0.0, 1.0]`` regardless of frame length and
+    matches the firmware-side threshold scale (Issue #85). An empty
+    frame yields ``0.0`` rather than raising so a stray short tail
+    chunk from upstream slicing does not crash the envelope path.
+
+    Args:
+        pcm_frame: Raw signed 16-bit little-endian mono PCM bytes for a
+            single frame. Length should be a multiple of 2; an odd
+            trailing byte (which would not appear in production but
+            could in tests) is silently dropped to keep the helper
+            forgiving.
+
+    Returns:
+        RMS amplitude normalised to ``[0.0, 1.0]``. ``0.0`` for silence
+        or empty input; near ``1.0`` for a full-scale square wave.
+    """
+    # Drop a trailing odd byte rather than raising; an unaligned chunk
+    # is a caller bug, but a noisy one breaks the entire TTS pipeline
+    # over a single sample boundary.
+    aligned_len = (len(pcm_frame) // 2) * 2
+    if aligned_len == 0:
+        return 0.0
+    samples = array.array("h")
+    samples.frombytes(pcm_frame[:aligned_len])
+    if not samples:
+        return 0.0
+    # Sum of squares stays inside Python's arbitrary-precision int, so
+    # there's no overflow risk even for the longest plausible frame.
+    sum_sq = sum(s * s for s in samples)
+    rms = math.sqrt(sum_sq / len(samples))
+    return rms / 32768.0
 
 
 def chunk_pcm_into_frames(

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any
 from .audio_utils import (
     DEVICE_FRAME_DURATION_MS,
     DEVICE_SAMPLE_RATE,
+    chunk_pcm_into_frames,
+    compute_pcm_frame_rms,
     encode_opus_frames,
 )
 from .base import EngineRegistry, get_registry
@@ -46,6 +48,21 @@ logger = logging.getLogger(__name__)
 #: VOICEVOX is the canonical default (Issue #70); the concrete engine
 #: ships in PR2 of that Issue.
 DEFAULT_VOICE = "voicevox"
+
+
+#: Maximum time the orchestrator will wait for the connection's send
+#: lock when pushing an envelope. Past this, the envelope is silently
+#: dropped (firmware falls back to its fixed lip-sync cycle, see
+#: Issue #85). Bounded waits live at the *lock acquire* layer rather
+#: than around ``ws.send()`` itself: the ``websockets`` library
+#: explicitly documents cancelling an in-flight ``send()`` as unsafe
+#: (it can leave the socket in a state that breaks the next message),
+#: while an unstarted ``acquire()`` is safe to cancel cleanly. 30 ms
+#: leaves enough headroom over the typical sub-millisecond JSON write
+#: that a transient lock-contention spike does not cascade into audio
+#: underrun, while keeping the worst-case slip well below the 60 ms
+#: per-frame audio pacing budget.
+TTS_ENVELOPE_SEND_TIMEOUT_S = 0.030
 
 
 async def synthesize_and_send(
@@ -181,6 +198,31 @@ async def synthesize_and_send(
     except Exception as exc:
         raise RuntimeError(f"Opus encoding failed: {exc}") from exc
 
+    # Issue #85: precompute the per-frame audio amplitude envelope from
+    # the same PCM that fed the Opus encoder. The two iterators
+    # (chunk_pcm_into_frames, encode_opus_frames) walk the PCM in
+    # lockstep with the same samples_per_frame, so envelopes[i]
+    # corresponds to opus_frames[i] by construction. Older firmware
+    # ignores the envelope message; newer firmware drives mouth shape
+    # selection from it (or falls back to a fixed cycle if envelopes
+    # stop arriving for ~200 ms). Computing the list up front keeps
+    # the per-frame loop branch-free.
+    pcm_chunks = list(chunk_pcm_into_frames(pcm))
+    envelopes = [compute_pcm_frame_rms(chunk) for chunk in pcm_chunks]
+    if len(envelopes) != len(opus_frames):
+        # Defensive guard: the two helpers share samples_per_frame so
+        # this should be impossible, but a future refactor of either
+        # one shouldn't silently corrupt envelope/audio alignment.
+        # Fall back to no-envelope mode rather than misaligning shapes
+        # against the wrong audio frame.
+        logger.warning(
+            "TTS envelope/opus length mismatch (envelopes=%d frames=%d); "
+            "skipping envelope channel for this utterance",
+            len(envelopes),
+            len(opus_frames),
+        )
+        envelopes = [None] * len(opus_frames)
+
     # Bracket the binary audio frames in TTS start/stop notifications.
     # The device firmware (Application::OnIncomingAudio) only accepts
     # binary audio frames while in kDeviceStateSpeaking, which is
@@ -230,10 +272,40 @@ async def synthesize_and_send(
 
         try:
             next_send_time = loop.time()
-            for frame in opus_frames:
+            for frame_id, (frame, envelope) in enumerate(
+                zip(opus_frames, envelopes)
+            ):
                 now = loop.time()
                 if now < next_send_time:
                     await asyncio.sleep(next_send_time - now)
+                # Issue #85: push the envelope first so the firmware's
+                # mouth-shape update lands at-or-before the audio
+                # frame's playback. Envelope delivery is awaited
+                # inline (not via ``create_task``) so the WebSocket
+                # send order is guaranteed by the connection's
+                # ``_send_lock`` — firmware needs envelope[N] to land
+                # before audio[N] for the per-frame mouth shape map
+                # to track the right frame. Pacing is bounded at the
+                # *lock acquire* layer (``lock_acquire_timeout``):
+                # if another sender is already mid-write when this
+                # envelope is ready, we give up after 30 ms rather
+                # than cancelling the in-flight ``ws.send()`` (which
+                # the ``websockets`` library documents as unsafe).
+                # ``send_tts_envelope`` returns ``False`` on the
+                # timeout path; the firmware fallback cycle covers
+                # the dropped frame, so a False return is invisible
+                # to the user.
+                if envelope is not None:
+                    try:
+                        await gateway.esp32.send_tts_envelope(
+                            frame_id,
+                            envelope,
+                            lock_acquire_timeout=TTS_ENVELOPE_SEND_TIMEOUT_S,
+                        )
+                    except ConnectionError:
+                        # Re-raised authoritatively by the audio frame
+                        # send below; nothing useful to log here.
+                        pass
                 try:
                     await gateway.esp32.send_audio_frame(frame)
                 except ConnectionError as exc:

--- a/gateway/tests/test_audio_utils.py
+++ b/gateway/tests/test_audio_utils.py
@@ -12,6 +12,7 @@ from stackchan_mcp.tts.audio_utils import (
     DEVICE_SAMPLE_RATE,
     SAMPLES_PER_FRAME,
     chunk_pcm_into_frames,
+    compute_pcm_frame_rms,
     encode_opus_frames,
     resample_pcm16_linear,
     wav_to_pcm16_mono,
@@ -220,3 +221,61 @@ def test_encode_opus_frames_produces_frames_when_libopus_available():
     assert len(frames) == 1
     assert isinstance(frames[0], bytes)
     assert len(frames[0]) > 0
+
+
+# ---------------------------------------------------------------------------
+# RMS amplitude (Issue #85 — TTS lip-sync envelope)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_pcm_frame_rms_silence_returns_zero():
+    """A frame of all zeros has RMS exactly 0."""
+    silence = b"\x00\x00" * 960
+    assert compute_pcm_frame_rms(silence) == 0.0
+
+
+def test_compute_pcm_frame_rms_empty_returns_zero():
+    """An empty buffer yields 0 rather than raising on division-by-zero."""
+    assert compute_pcm_frame_rms(b"") == 0.0
+
+
+def test_compute_pcm_frame_rms_full_scale_square_wave_near_one():
+    """A full-scale ±32767 square wave hits the top of the [0,1] range."""
+    n = 960
+    samples = array.array(
+        "h", [32767 if i % 2 == 0 else -32767 for i in range(n)]
+    )
+    rms = compute_pcm_frame_rms(samples.tobytes())
+    # Theoretical RMS of a full-scale square wave is exactly 32767/32768
+    # (one tick below 1.0 because 32767 is the positive peak of signed
+    # 16-bit, but the divisor is 32768 to keep the result strictly in
+    # [0, 1] for symmetric ±32768 inputs the encoder may produce).
+    assert rms == pytest.approx(32767 / 32768, rel=1e-4)
+    assert 0.0 <= rms <= 1.0
+
+
+def test_compute_pcm_frame_rms_known_amplitude():
+    """A square wave at amplitude A yields RMS A/32768 within float error."""
+    n = 480  # short frame, doesn't have to match SAMPLES_PER_FRAME
+    samples = array.array(
+        "h", [10000 if i % 2 == 0 else -10000 for i in range(n)]
+    )
+    rms = compute_pcm_frame_rms(samples.tobytes())
+    assert rms == pytest.approx(10000 / 32768, rel=1e-4)
+
+
+def test_compute_pcm_frame_rms_drops_odd_trailing_byte():
+    """An unaligned trailing byte is dropped instead of raising.
+
+    Production callers always feed aligned PCM (chunk_pcm_into_frames
+    zero-pads), but a forgiving helper avoids hard-crashing the entire
+    TTS pipeline on a one-byte slicing bug upstream.
+    """
+    n = 480
+    samples = array.array("h", [5000] * n)
+    aligned = samples.tobytes()
+    # Append a stray byte; helper should ignore it and produce the
+    # same RMS as the aligned input.
+    rms_aligned = compute_pcm_frame_rms(aligned)
+    rms_unaligned = compute_pcm_frame_rms(aligned + b"\xff")
+    assert rms_aligned == pytest.approx(rms_unaligned, rel=1e-9)

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -314,6 +314,100 @@ async def test_manager_send_tts_state_no_device():
         await mgr.send_tts_state("start")
 
 
+# ---------------------------------------------------------------------------
+# send_tts_envelope (Issue #85 — per-frame audio amplitude envelope)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_send_tts_envelope_sends_json():
+    """ESP32Connection.send_tts_envelope writes the expected JSON payload.
+
+    The firmware reads ``frame_id`` and ``rms`` out of this message
+    and feeds them to ``Board::OnTtsEnvelope``; both keys must be
+    present and typed as numbers (``frame_id`` int, ``rms`` float)
+    or the firmware-side ``cJSON_IsNumber`` guard drops the message.
+    """
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-env")  # type: ignore[arg-type]
+
+    sent_ok = await conn.send_tts_envelope(7, 0.123)
+
+    assert sent_ok is True
+    assert len(ws.sent) == 1
+    payload = json.loads(ws.sent[0])
+    assert payload == {
+        "session_id": "session-env",
+        "type": "tts",
+        "state": "envelope",
+        "frame_id": 7,
+        "rms": 0.123,
+    }
+
+
+@pytest.mark.asyncio
+async def test_connection_send_tts_envelope_returns_false_on_lock_timeout():
+    """When the send lock can't be acquired in time, envelope is dropped silently.
+
+    Issue #85: the orchestrator passes ``lock_acquire_timeout`` to
+    bound how long the per-frame envelope can hold up the next
+    audio frame's pacing budget. When another sender holds the
+    connection's send lock past that window, ``send_tts_envelope``
+    must return ``False`` without ever calling ``ws.send()`` —
+    cancelling an in-flight ``ws.send()`` is documented as unsafe
+    by the ``websockets`` library, so the bound has to live at the
+    *acquire* layer rather than around the send itself.
+    """
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-env")  # type: ignore[arg-type]
+
+    # Hold the send lock from another task so the envelope's
+    # acquire times out cleanly.
+    holder_release = asyncio.Event()
+
+    async def lock_holder():
+        async with conn._send_lock:
+            await holder_release.wait()
+
+    holder_task = asyncio.create_task(lock_holder())
+    # Yield once so the holder grabs the lock before we try.
+    await asyncio.sleep(0)
+
+    try:
+        sent_ok = await conn.send_tts_envelope(
+            0, 0.5, lock_acquire_timeout=0.005
+        )
+        assert sent_ok is False
+        # Nothing was written to the socket — the JSON payload was
+        # not even rendered, let alone enqueued.
+        assert ws.sent == []
+    finally:
+        holder_release.set()
+        await holder_task
+
+
+@pytest.mark.asyncio
+async def test_connection_send_tts_envelope_raises_after_disconnect():
+    """A disconnected connection refuses to send envelope notifications."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-env")  # type: ignore[arg-type]
+
+    conn.disconnect()
+
+    with pytest.raises(ConnectionError):
+        await conn.send_tts_envelope(0, 0.0)
+    assert ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_manager_send_tts_envelope_no_device():
+    """ESP32Manager.send_tts_envelope raises when no device is attached."""
+    mgr = ESP32Manager()
+
+    with pytest.raises(ConnectionError):
+        await mgr.send_tts_envelope(0, 0.0)
+
+
 class _FailingWebSocket:
     """WebSocket that raises a websockets-specific error on send()."""
 

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import array
 import asyncio
 from typing import Any
 
@@ -32,9 +33,16 @@ class _FakeESP32:
         self.device_connected = connected
         self.frames: list[bytes] = []
         self.tts_states: list[str] = []
-        # Records the relative order in which audio frames and TTS state
-        # notifications were dispatched, so tests can assert that
-        # ``start`` precedes any frame and ``stop`` trails them.
+        # Issue #85: per-frame envelopes recorded as (frame_id, rms)
+        # tuples. The orchestrator emits one envelope before each
+        # audio frame so the firmware can drive amplitude-based mouth
+        # shapes; tests can assert the count and ordering.
+        self.envelopes: list[tuple[int, float]] = []
+        # Records the relative order in which audio frames, envelopes,
+        # and TTS state notifications were dispatched, so tests can
+        # assert that ``start`` precedes any frame and ``stop`` trails
+        # them, and that each envelope precedes its corresponding
+        # audio frame.
         self.events: list[tuple[str, object]] = []
         # Mirror the production manager's per-device TTS lock so the
         # orchestrator's ``async with gateway.esp32.tts_lock`` works the
@@ -49,6 +57,20 @@ class _FakeESP32:
     async def send_tts_state(self, state: str) -> None:
         self.tts_states.append(state)
         self.events.append(("tts_state", state))
+
+    async def send_tts_envelope(
+        self,
+        frame_id: int,
+        rms: float,
+        *,
+        lock_acquire_timeout: float | None = None,
+    ) -> bool:
+        # ``lock_acquire_timeout`` is honoured implicitly: this fake
+        # never blocks, so acquire-timeout never fires.
+        del lock_acquire_timeout
+        self.envelopes.append((frame_id, rms))
+        self.events.append(("envelope", (frame_id, rms)))
+        return True
 
 
 class _FakeGateway:
@@ -117,9 +139,21 @@ async def test_pipeline_synthesises_encodes_and_pushes(fake_encode):
     assert esp32.tts_states == ["start", "stop"]
     assert esp32.events[0] == ("tts_state", "start")
     assert esp32.events[-1] == ("tts_state", "stop")
-    # All frames sit between start and stop.
+    # Issue #85: each envelope is awaited inline before its
+    # corresponding audio frame so the WebSocket write order is
+    # guaranteed (firmware needs envelope[N] to land before audio
+    # frame[N] for the per-frame mouth shape map to track the right
+    # frame). The middle slice should therefore be a strict
+    # ``envelope, frame`` interleave.
     middle = esp32.events[1:-1]
-    assert all(kind == "frame" for kind, _ in middle)
+    assert len(esp32.envelopes) == len(esp32.frames)
+    pair_kinds = [kind for kind, _ in middle]
+    assert pair_kinds == ["envelope", "frame"] * len(esp32.frames), (
+        f"expected strict envelope-then-frame interleave, got {pair_kinds}"
+    )
+    # frame_id sequence is contiguous starting from 0.
+    sent_frame_ids = [fid for fid, _ in esp32.envelopes]
+    assert sent_frame_ids == list(range(len(esp32.frames)))
 
 
 @pytest.mark.asyncio
@@ -398,6 +432,7 @@ async def test_pipeline_translates_mid_stream_disconnect(fake_encode):
         def __init__(self) -> None:
             self.frames: list[bytes] = []
             self.tts_states: list[str] = []
+            self.envelopes: list[tuple[int, float]] = []
             self.tts_lock = asyncio.Lock()
 
         async def send_audio_frame(self, frame: bytes) -> None:
@@ -410,6 +445,19 @@ async def test_pipeline_translates_mid_stream_disconnect(fake_encode):
             # caller still tries to send it after the failure, simulate
             # a benign no-op rather than raising again.
             self.tts_states.append(state)
+
+        async def send_tts_envelope(
+            self,
+            frame_id: int,
+            rms: float,
+            *,
+            lock_acquire_timeout: float | None = None,
+        ) -> bool:
+            del lock_acquire_timeout
+            # Envelope delivery is best-effort; record but don't fail
+            # so we exercise the same disconnect path on send_audio_frame.
+            self.envelopes.append((frame_id, rms))
+            return True
 
     pcm = b"\x01\x00" * 1440  # 1.5 frames worth
     engine = _PCMEngine(pcm)
@@ -524,6 +572,18 @@ async def test_pipeline_disconnect_before_tts_start(fake_encode):
         async def send_audio_frame(self, frame: bytes) -> None:
             raise AssertionError("frame should not be attempted after start failure")
 
+        async def send_tts_envelope(
+            self,
+            frame_id: int,
+            rms: float,
+            *,
+            lock_acquire_timeout: float | None = None,
+        ) -> bool:
+            del lock_acquire_timeout
+            raise AssertionError(
+                "envelope should not be attempted after start failure"
+            )
+
     pcm = b"\x01\x00" * 960
     engine = _PCMEngine(pcm)
     esp32 = FailingESP32()
@@ -539,3 +599,319 @@ async def test_pipeline_disconnect_before_tts_start(fake_encode):
             registry=reg,
         )
     assert esp32.tts_states == ["start"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #85 — per-frame audio amplitude envelope channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_envelope_with_real_rms(fake_encode):
+    """Envelopes carry the actual RMS of each PCM frame, not a placeholder.
+
+    Builds two frames with very different amplitudes (silence vs. a
+    near-full-scale square wave) so the test can assert that the
+    second frame's envelope is much larger than the first. This guards
+    against an implementation that always sends ``0.0`` (e.g. a stub
+    that records the call shape but never wires up
+    :func:`compute_pcm_frame_rms`).
+    """
+    samples_per_frame = (
+        DEVICE_SAMPLE_RATE * DEVICE_FRAME_DURATION_MS // 1000
+    )
+    # Frame 0: pure silence -> RMS = 0
+    silence = b"\x00\x00" * samples_per_frame
+    # Frame 1: alternating ±10000 (near full-scale) -> RMS ≈ 10000/32768
+    loud_samples = array.array(
+        "h", [10000 if i % 2 == 0 else -10000 for i in range(samples_per_frame)]
+    )
+    loud = loud_samples.tobytes()
+    pcm = silence + loud
+
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    await synthesize_and_send(
+        {"text": "envelope-check"}, gateway=gateway, registry=reg
+    )
+
+    assert len(esp32.envelopes) == 2
+    frame_id_0, rms_0 = esp32.envelopes[0]
+    frame_id_1, rms_1 = esp32.envelopes[1]
+    assert frame_id_0 == 0
+    assert frame_id_1 == 1
+    assert rms_0 == 0.0
+    # Loud frame's RMS should be roughly 10000/32768 ≈ 0.305.
+    assert rms_1 == pytest.approx(10000 / 32768, rel=0.01)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_envelope_send_failure_is_nonfatal(fake_encode):
+    """A ConnectionError on send_tts_envelope must not abort the utterance.
+
+    Envelope delivery is best-effort: the firmware falls back to a
+    fixed mouth cycle when envelopes stop arriving, so a transient
+    failure on the envelope channel is invisible to the user. The
+    audio frames must still be pushed and the stop notification
+    must still fire so the device leaves ``kDeviceStateSpeaking``.
+    """
+
+    class EnvelopeFailingESP32:
+        device_connected = True
+
+        def __init__(self) -> None:
+            self.frames: list[bytes] = []
+            self.tts_states: list[str] = []
+            self.envelope_attempts = 0
+            self.tts_lock = asyncio.Lock()
+
+        async def send_audio_frame(self, frame: bytes) -> None:
+            self.frames.append(frame)
+
+        async def send_tts_state(self, state: str) -> None:
+            self.tts_states.append(state)
+
+        async def send_tts_envelope(
+            self,
+            frame_id: int,
+            rms: float,
+            *,
+            lock_acquire_timeout: float | None = None,
+        ) -> bool:
+            del lock_acquire_timeout
+            self.envelope_attempts += 1
+            raise ConnectionError("envelope channel down")
+
+    pcm = b"\x01\x00" * 1440  # 1.5 -> 2 frames
+    engine = _PCMEngine(pcm)
+    esp32 = EnvelopeFailingESP32()
+    gateway = _FakeGateway(esp32)  # type: ignore[arg-type]
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "hello"}, gateway=gateway, registry=reg
+    )
+
+    assert result["frame_count"] == 2
+    assert len(esp32.frames) == 2
+    assert esp32.tts_states == ["start", "stop"]
+    # Every frame still attempted an envelope before its audio.
+    assert esp32.envelope_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_pipeline_envelope_length_mismatch_skips_envelope_channel(
+    fake_encode, monkeypatch
+):
+    """Defensive guard: opus/envelope length mismatch falls back gracefully.
+
+    The two helpers (:func:`chunk_pcm_into_frames` and
+    :func:`encode_opus_frames`) share ``samples_per_frame`` so a
+    mismatch should be impossible in production, but a future refactor
+    of either one shouldn't silently misalign envelopes against the
+    wrong audio frame. The orchestrator detects the mismatch and skips
+    the envelope channel for that utterance instead of corrupting
+    lip-sync; this test pins that contract.
+    """
+    import stackchan_mcp.tts.orchestrator as orchestrator
+
+    real_chunk = orchestrator.chunk_pcm_into_frames
+
+    def short_chunks(pcm, **kwargs):
+        # Drop the first chunk so envelopes is one shorter than
+        # opus_frames (which the fake_encode fixture sizes correctly).
+        chunks = list(real_chunk(pcm, **kwargs))
+        return iter(chunks[1:])
+
+    monkeypatch.setattr(orchestrator, "chunk_pcm_into_frames", short_chunks)
+
+    pcm = b"\x01\x00" * 1440  # -> 2 opus frames, but only 1 envelope chunk
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "hello"}, gateway=gateway, registry=reg
+    )
+
+    # Audio still pushed in full.
+    assert result["frame_count"] == 2
+    assert len(esp32.frames) == 2
+    # Envelope channel skipped entirely for this utterance.
+    assert esp32.envelopes == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_envelope_lock_contention_skipped_silently(fake_encode):
+    """Envelope drops cleanly when the connection's send lock is busy.
+
+    Regression for the codex findings on Issue #85: an unbounded
+    inline ``await send_tts_envelope`` would chain into the audio
+    frame's pacing sleep math, so a slow envelope (e.g. WiFi
+    backpressure or another sender holding the connection's send
+    lock) could push every iteration past the 60 ms audio pacing
+    budget. The orchestrator now passes ``lock_acquire_timeout=
+    TTS_ENVELOPE_SEND_TIMEOUT_S`` to ``send_tts_envelope``, which
+    silently returns ``False`` on the timeout path instead of
+    raising or cancelling an in-flight ``ws.send()`` (the
+    ``websockets`` library documents that cancellation as unsafe).
+    The firmware's freshness check then falls back to its fixed
+    lip-sync cycle, hiding the dropped envelope from the user.
+    """
+
+    class LockBusyESP32:
+        device_connected = True
+
+        def __init__(self) -> None:
+            self.frames: list[bytes] = []
+            self.tts_states: list[str] = []
+            self.envelopes: list[tuple[int, float]] = []
+            self.envelope_attempts = 0
+            self.tts_lock = asyncio.Lock()
+            self._loop = asyncio.get_event_loop()
+            self._prev_frame_at: float | None = None
+            self.frame_intervals_ms: list[float] = []
+
+        async def send_audio_frame(self, frame: bytes) -> None:
+            now = self._loop.time()
+            if self._prev_frame_at is not None:
+                self.frame_intervals_ms.append(
+                    (now - self._prev_frame_at) * 1000.0
+                )
+            self._prev_frame_at = now
+            self.frames.append(frame)
+
+        async def send_tts_state(self, state: str) -> None:
+            self.tts_states.append(state)
+
+        async def send_tts_envelope(
+            self,
+            frame_id: int,
+            rms: float,
+            *,
+            lock_acquire_timeout: float | None = None,
+        ) -> bool:
+            self.envelope_attempts += 1
+            # Simulate the ``lock_acquire_timeout`` path inside
+            # ``ESP32Connection.send_tts_envelope``: the lock could
+            # not be acquired in time, so the envelope is dropped
+            # without ever touching the wire. ``False`` tells the
+            # caller "skipped, firmware fallback covers it".
+            if lock_acquire_timeout is not None:
+                await asyncio.sleep(lock_acquire_timeout)
+                return False
+            self.envelopes.append((frame_id, rms))
+            return True
+
+    pcm = b"\x01\x00" * (960 * 5)  # 5 frames @ 60 ms
+    engine = _PCMEngine(pcm)
+    esp32 = LockBusyESP32()
+    gateway = _FakeGateway(esp32)  # type: ignore[arg-type]
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "hello"}, gateway=gateway, registry=reg
+    )
+
+    assert result["frame_count"] == 5
+    # Each frame attempted an envelope but every one was skipped.
+    assert esp32.envelope_attempts == 5
+    assert esp32.envelopes == []
+    # Audio pacing must stay within budget despite the lock-acquire
+    # timeout eating ~30 ms per frame. Worst case per frame is the
+    # lock timeout (30 ms) + the 60 ms pacing target; allow 25 ms
+    # slack for event-loop scheduling jitter on a busy CI runner.
+    from stackchan_mcp.tts.orchestrator import TTS_ENVELOPE_SEND_TIMEOUT_S
+
+    assert len(esp32.frame_intervals_ms) == 4
+    budget_ms = (TTS_ENVELOPE_SEND_TIMEOUT_S * 1000) + 60 + 25
+    for interval in esp32.frame_intervals_ms:
+        assert interval < budget_ms, (
+            f"audio pacing slipped to {interval:.1f} ms "
+            f"(budget {budget_ms:.0f} ms); envelope skip path may "
+            f"have regressed"
+        )
+    # Stop still fires after all frames.
+    assert esp32.tts_states[-1] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_envelope_precedes_audio_per_frame(fake_encode):
+    """Each envelope reaches the wire before its corresponding audio frame.
+
+    The firmware's per-frame mouth shape map (Issue #85) only works
+    if envelope[N] arrives at-or-before audio[N] — otherwise the
+    mouth update for frame N races the audio playback or lands one
+    frame late, eroding the per-frame sync the protocol promises.
+    The orchestrator awaits ``send_tts_envelope`` inline (with a
+    small timeout cap to bound pacing slip) precisely so this
+    ordering is guaranteed at the WebSocket write layer; this test
+    pins it for a 3-frame utterance with the envelope deliberately
+    delayed slightly to make any reordering observable.
+    """
+
+    class OrderedESP32:
+        device_connected = True
+
+        def __init__(self) -> None:
+            self.events: list[str] = []
+            self.tts_lock = asyncio.Lock()
+
+        async def send_audio_frame(self, frame: bytes) -> None:
+            self.events.append("frame")
+
+        async def send_tts_state(self, state: str) -> None:
+            self.events.append(f"state:{state}")
+
+        async def send_tts_envelope(
+            self,
+            frame_id: int,
+            rms: float,
+            *,
+            lock_acquire_timeout: float | None = None,
+        ) -> bool:
+            del lock_acquire_timeout
+            # Tiny artificial delay so any reordering bug surfaces
+            # rather than being masked by both sends completing
+            # synchronously. Stays well under the orchestrator's
+            # envelope timeout so the send completes normally.
+            await asyncio.sleep(0.001)
+            self.events.append(f"envelope:{frame_id}")
+            return True
+
+    pcm = b"\x01\x00" * (960 * 3)
+    engine = _PCMEngine(pcm)
+    esp32 = OrderedESP32()
+    gateway = _FakeGateway(esp32)  # type: ignore[arg-type]
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    await synthesize_and_send(
+        {"text": "hello"}, gateway=gateway, registry=reg
+    )
+
+    # Expected event sequence — strict envelope-then-frame interleave
+    # bracketed by the start/stop notifications.
+    assert esp32.events == [
+        "state:start",
+        "envelope:0",
+        "frame",
+        "envelope:1",
+        "frame",
+        "envelope:2",
+        "frame",
+        "state:stop",
+    ]

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -305,6 +305,19 @@ async def test_say_returns_error_json_when_device_disconnects_mid_stream(
         async def send_tts_state(self, state):  # noqa: ARG002 - test stub
             return None
 
+        async def send_tts_envelope(  # noqa: ARG002
+            self,
+            frame_id,
+            rms,
+            *,
+            lock_acquire_timeout=None,
+        ):
+            # Issue #85: orchestrator emits one envelope per audio
+            # frame; the disconnect path is on send_audio_frame, not
+            # here, so a no-op is sufficient for this test. Returning
+            # True matches the real method's "envelope sent" signal.
+            return True
+
     class FakeGateway:
         esp32 = FailingESP32()
 


### PR DESCRIPTION
## Status

**On hold.** Initial implementation pushes an envelope sidecar per Opus frame. On-device testing on the Tailscale-WSS deployment path showed the per-frame `ws.send()` pair (envelope JSON + Opus binary) consumes more than the 60 ms pacing budget, producing audible audio underruns. Sub-sampling the envelope cadence (tested at N=3, N=5, N=10) only stops the underruns at cadences that exceed the firmware's 200 ms `ENVELOPE_FRESH_WINDOW_US`, at which point the envelope-driven mouth path becomes unreachable while the audio risk remains.

The state-driven fallback merged in #84 already drives a usable mouth animation, so this PR stays open as a placeholder pending a wire-format redesign that avoids the two-send-per-frame contention.

Likely paths forward:
- Embed the envelope into the same WebSocket binary frame as the Opus payload (single send per audio frame, no JSON parse cost on device).
- Move the envelope onto a separate side-channel that does not contend with the audio frame send lock.

Closes #85 (when one of the redesign paths is in scope).