### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-12
+
 ### Added
 
 - Phase 4 STT — gateway-side `listen(duration_ms?, engine?, language?,
@@ -38,6 +40,20 @@ change is called out under a `Firmware` subsection of the release entry.
   paired firmware update — see the Firmware section below. Refs #91.
 
 ### Firmware
+
+> The firmware changes below were released through the dedicated firmware
+> release stream as `firmware-v1.0.0` (2026-05-10), `firmware-v1.1.0`
+> (2026-05-10), `firmware-v1.2.0` (2026-05-11), and `firmware-v1.3.0`
+> (paired with this gateway release — contains the server-driven
+> listening trigger that the new `listen()` MCP tool depends on).
+> Prebuilt binaries (`merged-binary.bin` / `xiaozhi.bin` /
+> `v*_stackchan.zip`) for each tag are attached to the corresponding
+> GitHub release:
+> https://github.com/kisaragi-mochi/stackchan-mcp/releases.
+> PyPI users running pre-v1.3.0 firmware can still upgrade to
+> `stackchan-mcp` 0.6.0 — only the new `listen()` MCP tool requires the
+> paired firmware update; the existing `say()` and other tools continue
+> to work against older firmware.
 
 - **Server-driven listening trigger** (paired with the new
   `listen()` MCP tool above, Issue #91). The firmware's
@@ -389,7 +405,8 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.6.0
 [0.5.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.5.0
 [0.4.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.4.0
 [0.3.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.3.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -467,7 +467,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2009,7 +2009,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bump the gateway version from 0.5.0 to 0.6.0 and promote the `[Unreleased]` CHANGELOG entries to a `[0.6.0] - 2026-05-12` section.

## Why

v0.6.0 carries the new gateway-side `listen()` STT MCP tool (#93, closes #91) — the symmetric inbound half of Phase 4. It is paired with a coordinated firmware change (server-driven `listen` wire type) that ships separately as `firmware-v1.3.0` after this PR lands.

## Changes

- `gateway/pyproject.toml`: bump `version` to `0.6.0`.
- `gateway/uv.lock`: regenerated to track the new gateway version (`uv lock`, two-line diff: own version + an `exceptiongroup` marker re-resolution that `uv` produced as part of the relock).
- `CHANGELOG.md`:
  - Promote `[Unreleased]` to `[0.6.0] - 2026-05-12` and leave a fresh empty `[Unreleased]` section above it.
  - Update the compare-link footer (`[Unreleased]` now compares against `v0.6.0`; new `[0.6.0]` tag link added).
  - The Firmware subsection gains a blockquote note clarifying that the firmware changes accumulated since v0.5.0 are released through the dedicated `firmware-vX.Y.Z` stream (`firmware-v1.0.0` .. `firmware-v1.3.0`) and pointing PyPI users to the matching GitHub releases for prebuilt binaries. Pre-`firmware-v1.3.0` firmware remains compatible with PyPI 0.6.0 — only the new `listen()` MCP tool requires the paired firmware update.

## Validation

- `uv sync --frozen` in `gateway/` agrees with the new lock (`pyproject.toml` and `uv.lock` both at 0.6.0).
- Codex review: one round on this branch; one P1 finding (`uv.lock` out of sync) addressed in this PR.

## Release plan after merge

1. Tag `v0.6.0` on the merge commit → `publish.yml` Trusted Publishing publishes the wheel + sdist to PyPI.
2. Tag `firmware-v1.3.0` on the same commit → `firmware-release.yml` builds the canonical ESP-IDF firmware and attaches `merged-binary.bin` / `xiaozhi.bin` / `v2.2.6_stackchan.zip` to the GitHub release. Release notes need manual augmentation to call out the new server-driven `listen` wire and compatibility with the v0.6.0 gateway.
3. GitHub Release page for `v0.6.0` created from the CHANGELOG `[0.6.0]` section.

Refs #91, #93.
