### PR TITLE
fix(firmware): #98 two-tier pitch guard (clamp 0..88 + rec 5..85)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -422,22 +422,27 @@ python scripts/avatar_convert/convert_avatars.py
 
 ## ハードウェア安全上の注意
 
-> ⚠️ **Y軸 (pitch) の安全範囲**
+> ⚠️ **Y軸 (pitch) の安全範囲 — 2 層ガード**
+
+Pitch 軸は firmware に組み込まれた 2 つの相補的なガードで保護されており、いずれも `set_head_angles` MCP ツールの description にも反映されています:
+
+| 層 | 範囲 | 強制方法 | 根拠 |
+|---|---|---|---|
+| **Tier 1 — ハードクランプ** | `0..+88°` | 黙ってクランプ + `ESP_LOGW` | 機械的破損の防止。下限 `0°` は M5Stack CoreS3 + SCS0009 ハードウェアで実機検証したエンドストップ (`-1°` 付近) から ~1° のマージンを取った値 (PR #81)。上限 `88°` は Issue #98 の実機 sweep で `pitch=89°` に audible sub-stall（「じーーー」というギア負荷音）が観測されたため、そこから ~1° 内側に取った値。 |
+| **Tier 2 — 推奨動作範囲** | `5..+85°` | 受け付ける + `ESP_LOGI` (ソフトシグナル) | M5Stack 公式が長期信頼性のために推奨している範囲。この外を 1 回叩いてもハード破損には至りませんが、`5..85°` の外で長期間動かし続けるとサーボに負担が蓄積する可能性があります。 |
 
 M5Stack 公式ドキュメントには以下の警告があります:
 
 > The movement angle of the StackChan Y-axis servo (vertical direction) is recommended to be controlled within 5 ~ 85°. Operating at extreme angles may cause **servo stall and permanent damage**.
-> — https://docs.m5stack.com/en/StackChan
+> — https://docs.m5stack.com/en/StackChan ("Motion Angle Notice")
 >
 > (StackChan の Y 軸サーボの可動角度は 5°〜85° の範囲内に制御することを推奨します。極端な角度で動作させると **サーボストール や 永久故障** を引き起こす可能性があります。)
 
-このファームウェアが対象とする M5Stack CoreS3 + SCS0009 ハードウェアでは、**下方向の機械的エンドストップがファームウェア座標系の `pitch=-1°` 付近にある** ことを実機で確認しています（テストユニットで検証）。それより低い値（例: `pitch=-5`、`pitch=-10`）を要求するとサーボのギアが物理的なストッパーに当たり、「カチッ」と音がします。
+`set_head_angles` MCP ツールは pitch を完全に **permissive** な schema range として宣言しています — `int` 型の全範囲 (`std::numeric_limits<int>::min()` から `std::numeric_limits<int>::max()` まで、境界値含む)。Tier 1 の権威ある enforcement は firmware ハンドラ側にあります — schema range を狭めると `McpServer::Property` が十分に極端な out-of-range リクエスト (例: `pitch=200` や `pitch=INT_MIN`) をハンドラ呼び出し前に reject してしまい、ドキュメントに書かれた Tier 1 挙動が到達不能になります（詳しくは #98 を参照）。`0°` 未満のリクエストは `0°` に引き上げられ (`ESP_LOGW`)、`88°` 超のリクエストは `88°` に引き下げられ (`ESP_LOGW`)、`[0, 88]` 内かつ `[5, 85]` 外のリクエストはそのまま受け入れた上で `ESP_LOGI` のソフトシグナルを出力します。過去に `-30..+30°` を target にしていた caller はそのまま動作します（負側は `0°` にクランプされます）。
 
-これを防ぐため、`set_head_angles` MCP ツールは Property 宣言上の範囲は `-30..+30°` のままですが、**handler 側で `pitch` を `0..+30°` に clamp** します。`0°` 未満のリクエストは `0°` に引き上げられます（`ESP_LOGW` 付き）。Property 宣言の数値範囲は後方互換性のためそのまま維持していますが、今後は `0..+30°` を target にしてください。
+X 軸 (yaw、`-90..+90°`) には同等のハードウェア制限はなく — M5Stack 公式が「X 軸には角度制限は不要」と明記しています — 宣言範囲全体を使えます。
 
-X 軸（yaw、`-90..+90°`）には同等のハードウェア制限はなく、宣言範囲全体を使えます。
-
-詳細な背景・検証ノートは [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80) を参照してください。
+下限の経緯は [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80)、2 層ガードへの拡張 (firmware ハードクランプ `30°` → `88°`、M5Stack 推奨 `5..85°` をソフトシグナル層に格上げ) は [#98](https://github.com/kisaragi-mochi/stackchan-mcp/issues/98) を参照してください。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -468,20 +468,25 @@ Do not commit personal PNGs, generated local avatar files, photos, or other user
 
 ## Hardware safety notes
 
-> ⚠️ **Y-axis (pitch) safe range**
+> ⚠️ **Y-axis (pitch) safe range — two-tier guard**
 
-M5Stack's official documentation explicitly warns:
+The pitch axis is guarded by two complementary tiers, both encoded in firmware and surfaced through the `set_head_angles` MCP tool description:
+
+| Tier | Range | Enforcement | Rationale |
+|---|---|---|---|
+| **Tier 1 — Hard clamp** | `0..+88°` | Silent clamp + `ESP_LOGW` | Prevents mechanical damage. Lower bound `0°` leaves ~1° margin above the validated mechanical end-stop on M5Stack CoreS3 + SCS0009 hardware (PR #81). Upper bound `88°` sits ~1° inside the audible sub-stall boundary observed at `pitch=89°` during the Issue #98 on-device sweep ("ji-ji-" gear strain sound). |
+| **Tier 2 — Recommended operating range** | `5..+85°` | Accept + `ESP_LOGI` (soft signal) | The M5Stack-documented sweet spot for long-term servo reliability. Single requests outside this range are not hardware-damaging, but sustained operation outside `5..85°` may stress the servo over time. |
+
+M5Stack's official documentation states:
 
 > The movement angle of the StackChan Y-axis servo (vertical direction) is recommended to be controlled within 5 ~ 85°. Operating at extreme angles may cause **servo stall and permanent damage**.
-> — https://docs.m5stack.com/en/StackChan
+> — https://docs.m5stack.com/en/StackChan ("Motion Angle Notice")
 
-On the M5Stack CoreS3 + SCS0009 hardware that this firmware targets, the **mechanical end-stop on the down direction sits very close to this firmware's pitch coordinate of `-1°`** (validated on a real unit). Driving below that value (e.g. `pitch=-5`, `pitch=-10`) presses the servo gear into the physical stopper and produces an audible click.
+The `set_head_angles` MCP tool declares pitch with a fully permissive schema range — the entire `int` value range, `std::numeric_limits<int>::min()` to `std::numeric_limits<int>::max()`, corner values included; the firmware-side handler is the authoritative Tier 1 enforcement layer. Any narrower schema range would cause `McpServer::Property` to reject sufficiently-extreme out-of-range requests (e.g. `pitch=200` or `pitch=INT_MIN`) before the handler could clamp / log them, leaving the documented Tier 1 behavior unreachable for those callers — see #98. Requests below `0°` are silently raised to `0°` (with `ESP_LOGW`), requests above `88°` are silently lowered to `88°` (with `ESP_LOGW`), and requests inside `[0, 88]` but outside `[5, 85]` are accepted with an `ESP_LOGI` soft signal. Older callers that targeted `-30..+30°` continue to work without modification (the negative half clamps to `0°`).
 
-To prevent that, the `set_head_angles` MCP tool **clamps pitch to `0..+30°`** internally even though the declared property range is `-30..+30°`. Requests below `0°` are silently raised to `0°` (with an `ESP_LOGW`); the original out-of-range numerical bounds are kept on the property declaration only for backward compatibility with older callers — please target `0..+30°` going forward.
+The X-axis (yaw, `-90..+90°`) is not subject to a comparable hardware restriction — M5Stack's documentation explicitly notes "No angle restriction is required for the X-axis" — and remains usable across its full declared range.
 
-The X-axis (yaw, `-90..+90°`) is not subject to a comparable hardware restriction and remains usable across its full declared range.
-
-See [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80) for the engineering background and validation notes.
+See [#80](https://github.com/kisaragi-mochi/stackchan-mcp/issues/80) for the lower-bound engineering background and [#98](https://github.com/kisaragi-mochi/stackchan-mcp/issues/98) for the two-tier upper-bound widening (firmware hard clamp `30°` → `88°`, with the M5Stack-recommended `5..85°` operating range surfaced as a soft-signal tier).
 
 ## Known issues
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -45,6 +45,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include <cJSON.h>
 #include <lvgl.h>
 #include <atomic>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -645,23 +646,58 @@ private:
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
 
-    // Issue #80: pitch hardware-safe range. The mechanical end-stop on the
-    // M5Stack CoreS3 + SCS0009 hardware sits very close to pitch=-1°, and
-    // M5Stack's official docs warn that operating the Y-axis outside the
-    // recommended 5°-85° range may cause servo stall and permanent damage
-    // (https://docs.m5stack.com/en/StackChan). On this firmware's coordinate
-    // system, pitch=0 leaves ~1° margin above the validated end-stop.
+    // Issue #80 / #98: pitch is guarded by two complementary tiers.
     //
-    // Defense-in-depth: we enforce this range at every servo-write boundary
-    //   1. PitchDegToPos() clamps its input (covers motion-task interpolation
-    //      and any future caller that bypasses the MCP layer).
-    //   2. The start-up restore from ReadPos clamps the recovered angle so
-    //      a device booting with the head physically pushed below 0° does
-    //      not carry that negative starting angle into motion interpolation.
-    //   3. The set_head_angles MCP handler additionally clamps the request
-    //      target so the original out-of-range value is logged.
+    // Tier 1 — Hard clamp [SAFE_PITCH_MIN, SAFE_PITCH_MAX]:
+    //   The absolute mechanical safety net. Its only job is to prevent
+    //   physical damage to the servo / gear / chassis. Values are silently
+    //   clamped to this range at every servo-write boundary and an
+    //   ESP_LOGW is emitted when clamping occurs.
+    //   - Lower bound 0°: the mechanical end-stop on the M5Stack CoreS3 +
+    //     SCS0009 hardware sits very close to pitch=-1° (validated on a
+    //     real unit, PR #81). Driving below 0° presses the servo gear into
+    //     the physical stopper and produces an audible click.
+    //   - Upper bound (SAFE_PITCH_MAX): chosen 1° inside the validated
+    //     mechanical upper limit. The M5Stack-documented servo features
+    //     advertise "90-degree movement on the vertical axis", so the
+    //     mechanical upper end-stop is expected near 90°; the precise
+    //     value is established by real-device sweep (Issue #98 validation).
+    //
+    // Tier 2 — Recommended operating range [RECOMMENDED_PITCH_MIN,
+    //          RECOMMENDED_PITCH_MAX]:
+    //   The M5Stack-documented sweet spot for long-term servo reliability
+    //   (https://docs.m5stack.com/en/StackChan, "Motion Angle Notice":
+    //   "The movement angle of the StackChan Y-axis servo (vertical
+    //   direction) is recommended to be controlled within 5 ~ 85°.
+    //   Operating at extreme angles may cause servo stall and permanent
+    //   damage.").
+    //   Values inside the hard clamp but outside this range are accepted
+    //   (they are not hardware-damaging on a single call), and an
+    //   ESP_LOGI is emitted so callers / agents can notice the deviation
+    //   without blocking the motion.
+    //
+    // Defense-in-depth: the hard clamp is enforced at every servo-write
+    // boundary —
+    //   1. PitchDegToPos() clamps its input (covers motion-task
+    //      interpolation and any future caller that bypasses the MCP
+    //      layer).
+    //   2. The start-up restore from ReadPos clamps the recovered angle
+    //      so a device booting with the head physically pushed past the
+    //      safe range does not carry that out-of-range starting angle
+    //      into motion interpolation.
+    //   3. The set_head_angles MCP handler additionally clamps the
+    //      request target so the original out-of-range value is logged.
     static constexpr int SAFE_PITCH_MIN = 0;
-    static constexpr int SAFE_PITCH_MAX = 30;
+    static constexpr int SAFE_PITCH_MAX = 88;  // Issue #98: validated on real hardware
+                                                // (M5Stack CoreS3 + SCS0009 ×2). On-device
+                                                // sweep observed clean motion at pitch=85
+                                                // and pitch=88 reached without end-stop, but
+                                                // pitch=89 exhibited an audible sub-stall
+                                                // ("ji-ji-" gear strain sound). Mirrors PR #81
+                                                // lower-bound rationale: stay 1° inside the
+                                                // observed servo-strain boundary.
+    static constexpr int RECOMMENDED_PITCH_MIN = 5;   // M5Stack official docs
+    static constexpr int RECOMMENDED_PITCH_MAX = 85;  // M5Stack official docs
 
     static int YawDegToPos(int deg) {
         int pos = 460 + deg * 16 / 5;
@@ -2229,31 +2265,60 @@ private:
 
         // Set head angles (yaw, pitch in degrees)
         // SCS0009: 1 step = 0.3125 degrees, so 1 degree = 3.2 steps (= 16/5)
-        // yaw: -90..90 degrees, pitch: -30..30 (declared) but the handler
-        // clamps to a hardware-safe sub-range — see SAFE_PITCH_MIN/MAX below
-        // and Issue #80.
+        // yaw: -90..90 degrees (no hardware restriction). pitch: two-tier
+        // guard — see SAFE_PITCH_MIN/MAX (hard clamp for mechanical safety)
+        // and RECOMMENDED_PITCH_MIN/MAX (M5Stack-documented operating sweet
+        // spot) above, plus Issue #80 / #98.
         mcp_server.AddTool(
             "self.robot.set_head_angles",
-            "Set the head angles of the robot. yaw: horizontal (-90 to 90), pitch: vertical (recommended 0 to 30; the lower half of the -30..0 range may hit the mechanical end-stop on M5Stack CoreS3 + SCS0009 hardware and risks servo stall — see README \"Hardware safety notes\").",
+            "Set the head angles of the robot. yaw: horizontal (-90 to 90). pitch: vertical. M5Stack-recommended operating range is 5 to 85 degrees per https://docs.m5stack.com/en/StackChan (\"Motion Angle Notice\"). The firmware also accepts values up to 88 degrees (the hard clamp guards against the audible sub-stall observed at pitch=89 on real hardware), but values outside 5-85 degrees are not officially endorsed and may stress the servo over time. Requests below 0 degrees or above 88 degrees are silently clamped with an ESP_LOGW. See README \"Hardware safety notes\".",
+            // Pitch schema range is intentionally permissive across the
+            // entire `int` value range (std::numeric_limits<int>::min/max):
+            // the authoritative Tier 1 enforcement lives in the handler
+            // below (silent clamp to [SAFE_PITCH_MIN, SAFE_PITCH_MAX] with
+            // ESP_LOGW). Any narrower range would cause McpServer::Property
+            // to reject sufficiently-extreme requests (e.g. pitch=200 or
+            // pitch=INT_MIN) before the handler can run, leaving the
+            // Tier 1 clamp / log unreachable for those callers and
+            // contradicting the tool-description / README claim that
+            // out-of-range requests are silently clamped with ESP_LOGW —
+            // see Issue #98 (three adversarial-review rounds zeroed in on
+            // this exact contract, including the int-boundary corners) and
+            // PR #81's defense-in-depth requirement that every servo-write
+            // boundary be guarded inside the firmware regardless of
+            // caller behavior.
             PropertyList({Property("yaw", kPropertyTypeInteger, 0, -90, 90),
-                          Property("pitch", kPropertyTypeInteger, 0, -30, 30)}),
+                          Property("pitch", kPropertyTypeInteger, 0,
+                                   std::numeric_limits<int>::min(),
+                                   std::numeric_limits<int>::max())}),
             [this](const PropertyList& properties) -> ReturnValue {
                 int yaw = properties["yaw"].value<int>();
                 int pitch = properties["pitch"].value<int>();
-                // Issue #80: clamp the requested pitch to the hardware-safe
-                // sub-range. PitchDegToPos() clamps again at the servo-write
-                // boundary (defense-in-depth), but doing it here too lets us
-                // log when the original request was out of range. See the
-                // SAFE_PITCH_MIN/MAX comment block above for rationale.
+                // Issue #80 / #98: two-tier pitch guard.
+                //
+                // Tier 1 (hard clamp): silently clamp to [SAFE_PITCH_MIN,
+                // SAFE_PITCH_MAX] and ESP_LOGW. PitchDegToPos() clamps
+                // again at the servo-write boundary (defense-in-depth);
+                // doing it here lets us log the original out-of-range
+                // value. See the SAFE_PITCH_MIN/MAX comment block above.
                 if (pitch < SAFE_PITCH_MIN) {
                     ESP_LOGW(TAG, "set_head_angles: pitch=%d below SAFE_PITCH_MIN=%d, clamping (servo end-stop protection)",
                              pitch, SAFE_PITCH_MIN);
                     pitch = SAFE_PITCH_MIN;
                 }
                 if (pitch > SAFE_PITCH_MAX) {
-                    ESP_LOGW(TAG, "set_head_angles: pitch=%d above SAFE_PITCH_MAX=%d, clamping",
+                    ESP_LOGW(TAG, "set_head_angles: pitch=%d above SAFE_PITCH_MAX=%d, clamping (servo end-stop protection)",
                              pitch, SAFE_PITCH_MAX);
                     pitch = SAFE_PITCH_MAX;
+                }
+                // Tier 2 (recommended-range soft signal): inside the hard
+                // clamp but outside the M5Stack-documented operating
+                // range — accept the value and emit an ESP_LOGI so callers
+                // can notice the deviation without blocking the motion.
+                if (pitch < RECOMMENDED_PITCH_MIN || pitch > RECOMMENDED_PITCH_MAX) {
+                    ESP_LOGI(TAG, "set_head_angles: pitch=%d outside M5Stack-recommended range %d..%d (within hard clamp %d..%d); acceptable but not officially endorsed",
+                             pitch, RECOMMENDED_PITCH_MIN, RECOMMENDED_PITCH_MAX,
+                             SAFE_PITCH_MIN, SAFE_PITCH_MAX);
                 }
                 int yaw_pos = YawDegToPos(yaw);
                 int pitch_pos = PitchDegToPos(pitch);


### PR DESCRIPTION
## Summary

Adopt a two-tier pitch guard in `firmware/main/boards/stackchan/stackchan.cc`, replacing the single hard clamp `0..+30°` that has been the bottleneck for several gesture-oriented features:

- **Tier 1 (hard clamp)** `[SAFE_PITCH_MIN, SAFE_PITCH_MAX] = [0°, 88°]` — silent clamp + `ESP_LOGW`. Same defense-in-depth shape as PR #81 (4 enforcement points: `PitchDegToPos()`, start-up `ReadPos` restore, `set_head_angles` handler input, motion-task interpolation flows through `PitchDegToPos`).
- **Tier 2 (recommended range)** `[RECOMMENDED_PITCH_MIN, RECOMMENDED_PITCH_MAX] = [5°, 85°]` — accept + `ESP_LOGI` soft signal. Sourced verbatim from M5Stack's official documentation ("Motion Angle Notice", https://docs.m5stack.com/en/StackChan).

The MCP `Property("pitch", ...)` schema is declared with the **entire `int` value range** (`std::numeric_limits<int>::min()` to `std::numeric_limits<int>::max()`, corner values included) so that every out-of-range request reaches the firmware-side handler — the firmware is the authoritative Tier 1 enforcement point, with the MCP schema serving only as a type check. The tool description prominently surfaces the M5Stack-recommended `5..85°` range. Callers pinned to the previous `-30..+30°` range continue to work without modification (the negative half clamps to `0°` exactly as before).

`README.md` and `README.ja.md` `"Hardware safety notes"` sections are rewritten as a single two-tier table so the model documented in the firmware is visible at the doc layer too.

Closes #98. Refs #80, #81 (lower-bound clamp — this PR makes the two-tier intent explicit and widens the upper bound).

## Why

`SAFE_PITCH_MAX = 30` was carried over verbatim from the original `Property(-30..+30)` declaration without explicit hardware justification. PR #81 chose `30°` deliberately as a "do not regress" upper bound while focusing on the lower-bound damage path; widening it was always going to be a follow-up.

The current `30°` ceiling blocks several gesture features:

- **#96** `listen()` visual + motion feedback wants a look-up pose around `45°–60°` pitch.
- **#89** named motion templates ("look up curiously", "look at the ceiling") are mostly blocked above `30°`.
- Future affection / acknowledgement glance gestures from #4 / #6 (touch reactions) need the full upward range.

M5Stack's official servo documentation supports widening up to `85°` as the operational sweet spot, with the mechanical upper limit near `90°`. The two-tier model lets the firmware refuse only physically damaging values while documenting the recommended range to callers via the tool description.

## Implementation notes

### Defense-in-depth — all 4 enforcement points carry the new `SAFE_PITCH_MAX`

PR #81 codex adversarial-review surfaced that a single handler-input clamp leaks through motion-task interpolation. The same 4 enforcement points used in #81 are preserved verbatim and all pick up the new bound through `SAFE_PITCH_MAX`:

1. `PitchDegToPos()` (servo-write boundary; covers motion-task interpolation and any future caller bypassing the MCP layer).
2. Start-up `ReadPos` restore (clamps the recovered angle so a device booting outside the safe range does not carry that into interpolation).
3. `set_head_angles` MCP handler input (clamps the requested target and logs the original out-of-range value).
4. Motion-task `WritePos` path — flows through `PitchDegToPos()` from (1), so no separate change needed.

### MCP schema permissiveness — firmware as authoritative Tier 1

The `Property("pitch", ...)` declaration uses `std::numeric_limits<int>::min()` and `std::numeric_limits<int>::max()` (the entire `int` value range, corner values included). A narrower schema range would cause `McpServer::Property` to reject sufficiently-extreme requests (e.g. `pitch=200` or `pitch=INT_MIN`) before they could reach the handler, leaving the documented Tier 1 `ESP_LOGW` / clamp pathway unreachable for those callers and contradicting the tool description / README claim that out-of-range requests are silently clamped. The firmware-side handler is therefore the authoritative Tier 1 enforcement point; the MCP schema only enforces the value's type. This faithfully implements the "every servo-write boundary guarded inside the firmware regardless of caller behavior" model from PR #81.

### Tier 2 soft signal placement

The new `ESP_LOGI` for `[0, 88]`-but-outside-`[5, 85]` fires in the `set_head_angles` handler **after** the hard clamp. This is intentional: the soft signal must reflect the value that will actually be commanded to the servo, not the raw request that may have already violated the hard clamp. As a result, a request like `pitch=89` produces a `ESP_LOGW` (Tier 1, raw value above max) followed by a chained `ESP_LOGI` (Tier 2, the clamped value `88°` is still outside the recommended ceiling `85°`).

## Validation

### Plan

On-device sweep anchored to M5Stack's documented spec (rather than stepping blindly through the full upper range):

- M5Stack official: `5 ~ 85°` recommended; "90-degree movement on the vertical axis" servo feature
- Initial prediction: `SAFE_PITCH_MAX = 89°` (M5Stack ceiling `85°` + 4° margin / servo feature `90°` - 1° margin)

A temporary `SAFE_PITCH_MAX = 95` validation firmware was flashed so the sweep could actually reach the predicted limit. The sweep used 3 calls to bracket the upper boundary, with the call sequence chosen to keep mechanical end-stop hits to at most one.

### Sweep (on-device, M5Stack CoreS3 + SCS0009 ×2)

| # | Call | `pitch_pos` | ReadPos (deg) | Observation | Verdict |
|---|---|---|---|---|---|
| 1 | `move_head(yaw=0, pitch=85)` | `892` | `84°` | Smooth motion, no audible stall, head visibly oriented upward | Clean — M5Stack-recommended ceiling reached |
| 2 | `move_head(yaw=0, pitch=89)` | `904` | `88°` | Motion completed but **audible "ji-ji-" gear strain sound** (sub-stall — the gear pressing against the mechanical end-stop in PWM-correction loops) | **Boundary crossed** |
| 3 | _skipped_ | — | — | — | Trial 2 sub-stall observation already established the boundary; skipping `pitch=90°` avoids an unnecessary deliberate end-stop hit |

### Conclusion

`SAFE_PITCH_MAX = 88°`. Rationale mirrors PR #81's lower-bound rationale: stay 1° inside the observed servo-strain boundary (`pitch=89°` sub-stall), matching the lower-bound's "1° margin above the validated mechanical end-stop at `pitch=-1°`" pattern. The resulting two-tier model:

- Hard clamp `0..+88°` — physical safety net, silent clamp with `ESP_LOGW`
- Recommended range `5..+85°` — M5Stack-documented sweet spot, `ESP_LOGI` soft signal outside

### Post-validation spot checks (on-device)

After re-flashing the final firmware (`SAFE_PITCH_MAX = 88`, fully permissive pitch schema `std::numeric_limits<int>::min()..max()`), two boundary calls verified each tier on real hardware. The schema is intentionally permissive so that the firmware-side handler — not the MCP-layer schema validator — is the authoritative Tier 1 enforcement point.

- **Tier 1 (hard clamp upper)** — `move_head(yaw=0, pitch=89)` is accepted by the schema, reaches the firmware handler, and is silently clamped to `88` with the documented `ESP_LOGW`. Real-device serial log:
  ```
  W StackChanBoard: set_head_angles: pitch=89 above SAFE_PITCH_MAX=88, clamping
                    (servo end-stop protection)
  I StackChanBoard: set_head_angles: pitch=88 outside M5Stack-recommended range 5..85
                    (within hard clamp 0..88); acceptable but not officially endorsed
  I StackChanBoard: set_head_angles: yaw=0 motion_started=0, pitch=88 (pos=901)
                    motion_started=1, uart=1, servo_ok=1
  ```
  The MCP response confirms the clamped value reached the servo path: `pitch_pos = 901 = 620 + 88 × 16/5`, i.e. the position write used the clamped `88°`, not the raw `89°`. The Tier 2 soft signal also chains correctly (the clamped `88°` is itself outside the recommended `5..85°` band, so a second `ESP_LOGI` fires).

  Because the schema is fully permissive across the entire `int` range, the same handler pathway is exercised by any out-of-range value, including the integer corner cases (`pitch=INT_MIN`, `pitch=INT_MAX`) that earlier rounds of adversarial review surfaced.

- **Tier 2 (recommended-range soft signal)** — `move_head(yaw=0, pitch=4)` is accepted (inside the hard clamp `[0, 88]` but below the M5Stack-recommended floor of `5`):
  ```
  I StackChanBoard: set_head_angles: pitch=4 outside M5Stack-recommended range 5..85
                    (within hard clamp 0..88); acceptable but not officially endorsed
  I StackChanBoard: set_head_angles: yaw=0 motion_started=0, pitch=4 motion_started=1,
                    uart=1, servo_ok=1
  ```
  Confirms the `ESP_LOGI` soft signal fires in the documented condition and motion proceeds without rejection.

### Incidental observation (tracked separately)

During the post-Trial-2 motion sequence, a servo bus hang occurred — a variant of Issue #1 (half-duplex SCS0009 collision pattern) — where `ReadPos` returned `-1` while `WritePos` continued to ACK. ESP32 hard-reset did not recover the bus because the SCS0009 power line is gated by the PY32 IO-expander's `VM EN` pin (independent of the ESP32 reset path). A full cold boot via the CoreS3 power button cleared the state. This recovery gap is unrelated to the two-tier guard introduced by this PR; tracked separately as #100 for a firmware-side recovery path.

## Risks

- The new `SAFE_PITCH_MAX` widens the defense-in-depth path: requests in `(30°, 88°]` were silently clamped before this PR and are accepted afterward. The validation sweep gated the final value on real-device confirmation; the chosen bound stays inside the observed sub-stall boundary.
- The MCP property declaration changes from `+30` to a fully permissive `int`-wide schema. This is **backward-compatible** for existing callers (requests `≤ 30°` still work unchanged); clients pinned to the old maximum will simply not exercise the new range.
- The Tier 2 soft signal (description + `ESP_LOGI`) shifts responsibility for "stay inside `5..85°`" to callers / LLM prompts. Acceptable trade-off because (a) Tier 1 still prevents damage and (b) hard-rejecting Tier 2 deviations would surprise agents that hit `pitch=86` once in a while.

## Out of scope

- Yaw (X-axis): M5Stack documentation states "No angle restriction is required for the X-axis". No change to `YawDegToPos` or the declared `-90..+90°` range.
- Lower bound: stays at `SAFE_PITCH_MIN = 0` per PR #81 rationale (mechanical end-stop near `-1°`; `0°` is the natural neutral and tightening to `5°` would force a clamp warning on every `pitch=0` call).
- Coordinate-system origin shift (e.g. re-anchoring `pitch=0` to M5Stack's recommended `5°` floor): would require a breaking change to the existing `move_head(pitch=0) == straight ahead` convention. Tracked in #99.
- Servo bus hang recovery improvements (the firmware-side `VM EN` toggle path that would survive without a manual power-button long-press): Tracked in #100.

## Files

- `firmware/main/boards/stackchan/stackchan.cc` — constants, `set_head_angles` tool description + property declaration + handler logic, doc comments
- `README.md` / `README.ja.md` — "Hardware safety notes" section rewritten as a two-tier table (EN / JP kept in sync)