### PR TITLE
feat(stt): #96 add visual + motion feedback to listen() capture window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Gateway
+
+- `listen()` now accepts optional visual/motion feedback arguments:
+  `motion="face-only"` shows the `thinking` avatar during capture and
+  restores `idle` at the end, while `motion="look-up"` preserves yaw,
+  tilts pitch to `look_up_pitch` (validated to 5..85 degrees), shows
+  `thinking`, and holds the pose on success so the caller's response
+  can continue from the attentive posture. The default
+  `motion="none"` preserves the existing behavior. Refs #96.
+
 ## [0.6.0] - 2026-05-12
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@
 | `set_leds(colors)` | `[[r,g,b], ...]` 配列で先頭 N 個を一括設定（I2C 1 回のバースト送信、アニメーション等向け）。指定外の LED は前の色を保持 | ✅ |
 | `clear_leds` | ベース部の RGB LED 12 個すべて消灯 | ✅ |
 | `say(text, voice?, speaker_id?, reference_audio?)` | gateway 側 TTS でデバイススピーカーから喋らせる。デフォルトエンジンは **VOICEVOX**（別 HTTP サービスとして起動 — [TTS セットアップ](#4-オプション-tts-セットアップ-voicevox) 参照）。`[tts]` extras が必要 | ✅ |
-| `listen(duration_ms?, engine?, language?, model?)` | デバイスマイクから短い発話をキャプチャし、gateway 側 STT で文字起こし。デフォルトエンジンは **faster-whisper**（ローカル動作・MIT — [STT セットアップ](#5-オプション-stt-セットアップ-faster-whisper) 参照）。`[stt-faster-whisper]`（または `[stt-openai]`）extras と、`listen` ワイヤタイプを受け付けるファームウェアが必要 | ✅ |
+| `listen(duration_ms?, engine?, language?, model?, motion?, look_up_pitch?)` | デバイスマイクから短い発話をキャプチャし、gateway 側 STT で文字起こし。デフォルトエンジンは **faster-whisper**（ローカル動作・MIT — [STT セットアップ](#5-オプション-stt-セットアップ-faster-whisper) 参照）。任意の `motion` feedback で、キャプチャ中に `thinking` face を出したり、頭を上向きに傾けたりできます。`[stt-faster-whisper]`（または `[stt-openai]`）extras と、`listen` ワイヤタイプを受け付けるファームウェアが必要 | ✅ |
 
 詳細スキーマは `gateway/README.md` 参照。
 
@@ -384,8 +384,13 @@ gateway がデバイスに `{"type":"listen","state":"start","mode":"manual"}`
 STT エンジンに渡して文字起こし、という流れです。`faster-whisper`
 エンジンの初回呼び出しではモデル（`base` で約 140 MB）が Hugging
 Face キャッシュにダウンロードされ、以降は再利用されます。
-STT フレームワークもエンジン非依存なので、Vosk・whisper.cpp・他の
-クラウドサービス等を `listen` API を変えずに後から追加できます。
+見た目でキャプチャ中であることを示したい場合は、`motion="face-only"`
+でキャプチャ中に `thinking` アバターを表示して終了時に `idle` へ戻すか、
+`motion="look-up"` で yaw を保ったまま pitch を `look_up_pitch`
+（デフォルト 50°、有効範囲 5..85°）へ傾け、`thinking` を表示し、
+成功時はその姿勢を保持できます。STT フレームワークもエンジン非依存なので、
+Vosk・whisper.cpp・他のクラウドサービス等を `listen` API を変えずに
+後から追加できます。
 
 ## アバター画像について
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This repository is a monorepo.
 | `set_leds(colors)` | Batch-set the first N LEDs from a `[[r,g,b], ...]` array in a single I2C burst (use this for animations / multi-color patterns); trailing LEDs keep their previous color | ✅ |
 | `clear_leds` | Turn all 12 base RGB LEDs off | ✅ |
 | `say(text, voice?, speaker_id?, reference_audio?)` | Speak text on the device speaker via gateway-side TTS. Default engine: **VOICEVOX** (runs as a separate HTTP service — see [TTS setup](#optional-tts-setup-voicevox)). Requires the `[tts]` extra. | ✅ |
-| `listen(duration_ms?, engine?, language?, model?)` | Capture a short utterance from the device microphone and transcribe it via gateway-side STT. Default engine: **faster-whisper** (local, MIT) — see [STT setup](#optional-stt-setup-faster-whisper). Requires the `[stt-faster-whisper]` (or `[stt-openai]`) extra and a firmware update with the inbound `listen` wire type. | ✅ |
+| `listen(duration_ms?, engine?, language?, model?, motion?, look_up_pitch?)` | Capture a short utterance from the device microphone and transcribe it via gateway-side STT. Default engine: **faster-whisper** (local, MIT) — see [STT setup](#optional-stt-setup-faster-whisper). Optional `motion` feedback can show the `thinking` face or tilt the head up during capture. Requires the `[stt-faster-whisper]` (or `[stt-openai]`) extra and a firmware update with the inbound `listen` wire type. | ✅ |
 
 See `gateway/README.md` for full schemas.
 
@@ -434,9 +434,13 @@ capture window, then sends `{"type":"listen","state":"stop"}` and
 hands the buffered audio to the registered STT engine. The first call
 to the `faster-whisper` engine downloads the chosen model (~140 MB
 for `base`) into the Hugging Face cache; subsequent calls reuse it.
-The STT framework is engine-agnostic — additional engines (Vosk,
-whisper.cpp, cloud providers) can be added without changing the
-`listen` API.
+For visible capture feedback, pass `motion="face-only"` to show the
+`thinking` avatar during capture and restore `idle` at the end, or
+`motion="look-up"` to preserve yaw, tilt pitch to `look_up_pitch`
+(default 50°, valid 5..85°), show `thinking`, and hold that pose on
+success. The STT framework is engine-agnostic — additional engines
+(Vosk, whisper.cpp, cloud providers) can be added without changing
+the `listen` API.
 
 ## About the avatar images
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -422,6 +422,9 @@ def create_server() -> Server:
                     "minimal firmware change to handle the inbound 'listen' "
                     "wire type (paired with this gateway release). Engine is "
                     "selectable via 'engine' (default 'faster-whisper', local). "
+                    "Optional 'motion' feedback can switch the avatar to "
+                    "'thinking' during capture ('face-only') or tilt the head "
+                    "up while preserving yaw ('look-up'). "
                     "Install the relevant extra "
                     "('pip install stackchan-mcp[stt-faster-whisper]' or "
                     "'stt-openai'); calling this tool before an engine is "
@@ -464,6 +467,29 @@ def create_server() -> Server:
                                 "whisper, 'whisper-1' for OpenAI). Engines "
                                 "fall back to their default when omitted."
                             ),
+                        },
+                        "motion": {
+                            "type": "string",
+                            "enum": ["none", "face-only", "look-up"],
+                            "description": (
+                                "Optional visible feedback during capture. "
+                                "'none' preserves the previous behaviour. "
+                                "'face-only' shows the thinking avatar during "
+                                "capture and restores idle at the end. "
+                                "'look-up' preserves yaw, tilts pitch to "
+                                "look_up_pitch, and holds the pose on success."
+                            ),
+                            "default": "none",
+                        },
+                        "look_up_pitch": {
+                            "type": "number",
+                            "description": (
+                                "Pitch angle for motion='look-up'. Must be "
+                                "between 5 and 85 degrees."
+                            ),
+                            "default": 50.0,
+                            "minimum": 5,
+                            "maximum": 85,
                         },
                     },
                 },

--- a/gateway/stackchan_mcp/stt/orchestrator.py
+++ b/gateway/stackchan_mcp/stt/orchestrator.py
@@ -112,7 +112,7 @@ async def _shield_listen_motion_cleanup(
     saved_angles: tuple[float, float] | None,
     *,
     succeeded: bool,
-) -> None:
+) -> BaseException | None:
     """Wait for motion cleanup to complete even under cancellation.
 
     A bare ``await asyncio.shield(coro())`` protects the inner
@@ -124,6 +124,12 @@ async def _shield_listen_motion_cleanup(
     re-await it under shield through repeated cancellations, then
     surface the cancellation once cleanup has finished so the
     caller still sees ``CancelledError``.
+
+    Non-cancellation cleanup failures are both logged at warning
+    level and returned to the caller, so partial-failure paths
+    (e.g. setup-time motion failure followed by a rollback failure)
+    can chain the cleanup error onto the primary error rather than
+    silently swallow a physical-state mismatch.
     """
     cleanup_task = asyncio.create_task(
         _finish_listen_motion(
@@ -135,6 +141,7 @@ async def _shield_listen_motion_cleanup(
     )
 
     outer_cancelled = False
+    cleanup_error: BaseException | None = None
     while True:
         try:
             await asyncio.shield(cleanup_task)
@@ -142,6 +149,7 @@ async def _shield_listen_motion_cleanup(
             outer_cancelled = True
             continue
         except Exception as exc:
+            cleanup_error = exc
             logger.warning(
                 "best-effort listen motion cleanup failed: %s", exc
             )
@@ -149,6 +157,7 @@ async def _shield_listen_motion_cleanup(
 
     if outer_cancelled:
         raise asyncio.CancelledError()
+    return cleanup_error
 
 
 async def _call_device_tool(
@@ -210,13 +219,20 @@ async def _begin_listen_motion(
     try:
         await _set_head_angles(gateway, yaw=yaw, pitch=look_up_pitch)
         await _set_avatar(gateway, LISTENING_FACE)
-    except Exception:
-        await _shield_listen_motion_cleanup(
+    except Exception as forward_exc:
+        cleanup_error = await _shield_listen_motion_cleanup(
             gateway,
             motion,
             (yaw, pitch),
             succeeded=False,
         )
+        if cleanup_error is not None:
+            # Forward setup failed AND rollback also failed — the
+            # device may still be in the look-up pose. Chain the
+            # cleanup error onto the forward exception so the caller
+            # sees both physical-state concerns instead of just the
+            # forward avatar / motion error.
+            raise forward_exc from cleanup_error
         raise
     return yaw, pitch
 

--- a/gateway/stackchan_mcp/stt/orchestrator.py
+++ b/gateway/stackchan_mcp/stt/orchestrator.py
@@ -156,6 +156,14 @@ async def _shield_listen_motion_cleanup(
         break
 
     if outer_cancelled:
+        if cleanup_error is not None:
+            # The outer task was cancelled WHILE rollback itself
+            # also failed. Chain the cleanup failure via
+            # ``__cause__`` so the caller still gets a programmatic
+            # signal that the device may be off-baseline, instead
+            # of seeing only a fresh ``CancelledError`` and silently
+            # losing the rollback error.
+            raise asyncio.CancelledError() from cleanup_error
         raise asyncio.CancelledError()
     return cleanup_error
 

--- a/gateway/stackchan_mcp/stt/orchestrator.py
+++ b/gateway/stackchan_mcp/stt/orchestrator.py
@@ -237,8 +237,14 @@ async def _finish_listen_motion(
         return
 
     yaw, pitch = saved_angles
-    await _set_head_angles(gateway, yaw=yaw, pitch=pitch)
-    await _set_avatar(gateway, IDLE_FACE)
+    try:
+        await _set_head_angles(gateway, yaw=yaw, pitch=pitch)
+    finally:
+        # Restore the avatar regardless of whether the pitch rollback
+        # succeeded — otherwise a failed ``set_head_angles`` would
+        # leave the device visibly stuck on the ``thinking`` face
+        # even though the listen itself already failed.
+        await _set_avatar(gateway, IDLE_FACE)
 
 
 async def listen_and_transcribe(

--- a/gateway/stackchan_mcp/stt/orchestrator.py
+++ b/gateway/stackchan_mcp/stt/orchestrator.py
@@ -384,6 +384,7 @@ async def listen_and_transcribe(
         connection = gateway.esp32.connection
         session_id = getattr(connection, "session_id", "") if connection else ""
 
+        primary_exc: BaseException | None = None
         try:
             motion_saved_angles = await _begin_listen_motion(
                 gateway, motion, look_up_pitch
@@ -489,13 +490,41 @@ async def listen_and_transcribe(
                     ),
                 }
             succeeded = True
+        except BaseException as exc:
+            # Capture the listen-body failure so the cleanup helper
+            # can chain a rollback failure onto it below if cleanup
+            # also raises. Without this, a rollback failure on top
+            # of an already-failed listen would vanish into a
+            # ``logger.warning`` and the caller would only see the
+            # listen failure with no signal that physical state may
+            # be off-baseline.
+            primary_exc = exc
+            raise
         finally:
-            await _shield_listen_motion_cleanup(
+            cleanup_error = await _shield_listen_motion_cleanup(
                 gateway,
                 motion,
                 motion_saved_angles,
                 succeeded=succeeded,
             )
+            if cleanup_error is not None:
+                if primary_exc is not None:
+                    # Listen body already failed AND rollback also
+                    # failed — chain via ``__cause__`` so the
+                    # caller sees both physical-state concerns. The
+                    # listen failure stays primary (it triggered the
+                    # rollback attempt); the rollback failure is
+                    # exposed via ``__cause__`` for inspection. Any
+                    # pre-existing ``__cause__`` on the listen
+                    # failure (e.g. engine's TimeoutError chained
+                    # to a RuntimeError) is preserved on
+                    # ``__context__`` automatically.
+                    raise primary_exc from cleanup_error
+                # Cleanup itself failed on an otherwise-successful
+                # listen — surface it so the failure doesn't vanish
+                # into a logger.warning while the device may be
+                # off-baseline.
+                raise cleanup_error
 
     logger.info(
         "listen(): engine=%s frames=%d duration_ms=%d text=%r",

--- a/gateway/stackchan_mcp/stt/orchestrator.py
+++ b/gateway/stackchan_mcp/stt/orchestrator.py
@@ -32,9 +32,10 @@ same protocol-v1 gate.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..audio_stream import start_recording, stop_recording
 from .audio_utils import DEVICE_FRAME_DURATION_MS, DEVICE_SAMPLE_RATE, decode_opus_frames
@@ -68,6 +69,151 @@ MAX_DURATION_MS = 30000
 #: the first inbound frame can race the ``kDeviceStateListening``
 #: transition; 50 ms is well above typical scheduling latency.
 LISTEN_START_TRANSITION_DELAY_S = 0.05
+
+LISTENING_FACE = "thinking"
+IDLE_FACE = "idle"
+LISTEN_MOTIONS = {"none", "face-only", "look-up"}
+MIN_LOOK_UP_PITCH = 5.0
+MAX_LOOK_UP_PITCH = 85.0
+
+
+def _validate_motion_args(
+    arguments: dict[str, Any],
+) -> tuple[Literal["none", "face-only", "look-up"], float]:
+    motion = arguments.get("motion", "none")
+    if not isinstance(motion, str) or motion not in LISTEN_MOTIONS:
+        raise ValueError(
+            "'motion' must be one of 'none', 'face-only', or 'look-up'; "
+            f"got {motion!r}"
+        )
+
+    look_up_pitch_raw = arguments.get("look_up_pitch", 50.0)
+    if isinstance(look_up_pitch_raw, bool) or not isinstance(
+        look_up_pitch_raw, int | float
+    ):
+        raise ValueError(
+            "'look_up_pitch' must be a number between 5 and 85; got "
+            + repr(look_up_pitch_raw)
+        )
+
+    look_up_pitch = float(look_up_pitch_raw)
+    if look_up_pitch < MIN_LOOK_UP_PITCH or look_up_pitch > MAX_LOOK_UP_PITCH:
+        raise ValueError(
+            "'look_up_pitch' must be between 5 and 85; got "
+            f"{look_up_pitch_raw!r}"
+        )
+
+    return motion, look_up_pitch
+
+
+async def _shield_listen_motion_cleanup(
+    gateway: "Gateway",
+    motion: Literal["none", "face-only", "look-up"],
+    saved_angles: tuple[float, float] | None,
+    *,
+    succeeded: bool,
+) -> None:
+    try:
+        await asyncio.shield(
+            _finish_listen_motion(
+                gateway,
+                motion,
+                saved_angles,
+                succeeded=succeeded,
+            )
+        )
+    except Exception as exc:
+        logger.warning("best-effort listen motion cleanup failed: %s", exc)
+
+
+async def _call_device_tool(
+    gateway: "Gateway",
+    name: str,
+    arguments: dict[str, Any],
+) -> Any:
+    result, error = await gateway.esp32.call_tool(name, arguments)
+    if error:
+        message = error.get("message", error) if isinstance(error, dict) else error
+        raise RuntimeError(f"Device tool '{name}' failed: {message}")
+    return result
+
+
+def _extract_head_angles(result: Any) -> tuple[float, float]:
+    payload = result
+    if isinstance(result, dict) and "content" in result:
+        content = result.get("content") or []
+        if content:
+            text = content[0].get("text") if isinstance(content[0], dict) else None
+            if isinstance(text, str):
+                payload = json.loads(text)
+
+    if not isinstance(payload, dict):
+        raise RuntimeError("Device tool 'self.robot.get_head_angles' returned no angles")
+
+    yaw = payload.get("yaw")
+    pitch = payload.get("pitch")
+    if not isinstance(yaw, int | float) or not isinstance(pitch, int | float):
+        raise RuntimeError("Device tool 'self.robot.get_head_angles' returned invalid angles")
+    return float(yaw), float(pitch)
+
+
+async def _set_avatar(gateway: "Gateway", face: str) -> None:
+    await _call_device_tool(gateway, "self.display.set_avatar", {"face": face})
+
+
+async def _set_head_angles(gateway: "Gateway", *, yaw: float, pitch: float) -> None:
+    await _call_device_tool(
+        gateway,
+        "self.robot.set_head_angles",
+        {"yaw": yaw, "pitch": pitch},
+    )
+
+
+async def _begin_listen_motion(
+    gateway: "Gateway",
+    motion: Literal["none", "face-only", "look-up"],
+    look_up_pitch: float,
+) -> tuple[float, float] | None:
+    if motion == "none":
+        return None
+    if motion == "face-only":
+        await _set_avatar(gateway, LISTENING_FACE)
+        return None
+
+    result = await _call_device_tool(gateway, "self.robot.get_head_angles", {})
+    yaw, pitch = _extract_head_angles(result)
+    try:
+        await _set_head_angles(gateway, yaw=yaw, pitch=look_up_pitch)
+        await _set_avatar(gateway, LISTENING_FACE)
+    except Exception:
+        await _shield_listen_motion_cleanup(
+            gateway,
+            motion,
+            (yaw, pitch),
+            succeeded=False,
+        )
+        raise
+    return yaw, pitch
+
+
+async def _finish_listen_motion(
+    gateway: "Gateway",
+    motion: Literal["none", "face-only", "look-up"],
+    saved_angles: tuple[float, float] | None,
+    *,
+    succeeded: bool,
+) -> None:
+    if motion == "none":
+        return
+    if motion == "face-only":
+        await _set_avatar(gateway, IDLE_FACE)
+        return
+    if succeeded or saved_angles is None:
+        return
+
+    yaw, pitch = saved_angles
+    await _set_head_angles(gateway, yaw=yaw, pitch=pitch)
+    await _set_avatar(gateway, IDLE_FACE)
 
 
 async def listen_and_transcribe(
@@ -121,6 +267,7 @@ async def listen_and_transcribe(
             f"'duration_ms' must be between {MIN_DURATION_MS} and "
             f"{MAX_DURATION_MS}; got {duration_raw}"
         )
+    motion, look_up_pitch = _validate_motion_args(arguments)
 
     engine_raw = arguments.get("engine", DEFAULT_ENGINE)
     engine_name = (
@@ -183,110 +330,125 @@ async def listen_and_transcribe(
     frame_count = 0
     pcm = b""
     actual_duration_ms = 0
+    motion_saved_angles: tuple[float, float] | None = None
+    succeeded = False
 
     async with lock_ctx:
         connection = gateway.esp32.connection
         session_id = getattr(connection, "session_id", "") if connection else ""
 
-        # Switch the audio_stream module into recording mode BEFORE
-        # sending listen.start so we don't drop the first frame the
-        # device emits the moment it lands in kDeviceStateListening.
-        start_recording(session_id)
-        listen_start_sent = False
         try:
-            try:
-                await gateway.esp32.send_listen_state("start", mode="manual")
-                listen_start_sent = True
-            except ConnectionError as exc:
-                raise RuntimeError(
-                    f"Device disconnected before listen.start: {exc}"
-                ) from exc
-
-            # Wait for the firmware's state machine to land in
-            # kDeviceStateListening before we start counting the
-            # capture window (same rationale as the TTS pipeline's
-            # ``TTS_START_TRANSITION_DELAY_S``).
-            await asyncio.sleep(LISTEN_START_TRANSITION_DELAY_S)
-
-            await asyncio.sleep(duration_ms / 1000.0)
-        finally:
-            # Cancellation-safe listen.stop. If the request is
-            # cancelled mid-capture (or any exception unwinds here)
-            # after listen.start has been delivered, the device is
-            # still in ``kDeviceStateListening`` with the microphone
-            # open — without a best-effort stop the firmware would
-            # stay there until an unrelated user action (button /
-            # wake-word) eventually pulled it back to idle.
-            # ``asyncio.shield`` protects the stop send from the
-            # cancellation that's already propagating through the
-            # outer await, so the device receives the stop even
-            # though the orchestrator coroutine itself is being torn
-            # down. The shielded send still completes synchronously
-            # before this ``finally`` block returns.
-            if listen_start_sent:
-                try:
-                    await asyncio.shield(
-                        gateway.esp32.send_listen_state("stop")
-                    )
-                except (ConnectionError, asyncio.CancelledError):
-                    # Device dropped, or our awaiter was cancelled
-                    # after shield released the send back to us. In
-                    # both cases the partial buffer is still worth
-                    # transcribing, but the operator should know the
-                    # firmware may need a manual nudge.
-                    logger.warning(
-                        "listen.stop did not reach device cleanly "
-                        "(cancellation or disconnect); firmware may "
-                        "stay in listening mode until a button press "
-                        "or wake-word"
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "best-effort listen.stop failed: %s", exc
-                    )
-            frames = stop_recording()
-
-        frame_count = len(frames)
-        if frame_count == 0:
-            # Distinguish "device disconnected with no frames" (likely
-            # protocol mismatch / firmware not yet supporting listen)
-            # from "spoken nothing". The latter is a legitimate empty
-            # transcription and not surfaced as an error.
-            logger.info(
-                "listen(): no Opus frames received during %d ms window",
-                duration_ms,
+            motion_saved_angles = await _begin_listen_motion(
+                gateway, motion, look_up_pitch
             )
 
-        try:
-            pcm = decode_opus_frames(frames)
-        except Exception as exc:
-            raise RuntimeError(f"Opus decode failed: {exc}") from exc
-
-        actual_duration_ms = frame_count * DEVICE_FRAME_DURATION_MS
-
-        if pcm:
+            # Switch the audio_stream module into recording mode BEFORE
+            # sending listen.start so we don't drop the first frame the
+            # device emits the moment it lands in kDeviceStateListening.
+            start_recording(session_id)
+            listen_start_sent = False
             try:
-                result = await engine.transcribe(
-                    pcm,
-                    language=language,
-                    model=model,
+                try:
+                    await gateway.esp32.send_listen_state("start", mode="manual")
+                    listen_start_sent = True
+                except ConnectionError as exc:
+                    raise RuntimeError(
+                        f"Device disconnected before listen.start: {exc}"
+                    ) from exc
+
+                # Wait for the firmware's state machine to land in
+                # kDeviceStateListening before we start counting the
+                # capture window (same rationale as the TTS pipeline's
+                # ``TTS_START_TRANSITION_DELAY_S``).
+                await asyncio.sleep(LISTEN_START_TRANSITION_DELAY_S)
+
+                await asyncio.sleep(duration_ms / 1000.0)
+            finally:
+                # Cancellation-safe listen.stop. If the request is
+                # cancelled mid-capture (or any exception unwinds here)
+                # after listen.start has been delivered, the device is
+                # still in ``kDeviceStateListening`` with the microphone
+                # open — without a best-effort stop the firmware would
+                # stay there until an unrelated user action (button /
+                # wake-word) eventually pulled it back to idle.
+                # ``asyncio.shield`` protects the stop send from the
+                # cancellation that's already propagating through the
+                # outer await, so the device receives the stop even
+                # though the orchestrator coroutine itself is being torn
+                # down. The shielded send still completes synchronously
+                # before this ``finally`` block returns.
+                if listen_start_sent:
+                    try:
+                        await asyncio.shield(
+                            gateway.esp32.send_listen_state("stop")
+                        )
+                    except (ConnectionError, asyncio.CancelledError):
+                        # Device dropped, or our awaiter was cancelled
+                        # after shield released the send back to us. In
+                        # both cases the partial buffer is still worth
+                        # transcribing, but the operator should know the
+                        # firmware may need a manual nudge.
+                        logger.warning(
+                            "listen.stop did not reach device cleanly "
+                            "(cancellation or disconnect); firmware may "
+                            "stay in listening mode until a button press "
+                            "or wake-word"
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "best-effort listen.stop failed: %s", exc
+                        )
+                frames = stop_recording()
+
+            frame_count = len(frames)
+            if frame_count == 0:
+                # Distinguish "device disconnected with no frames" (likely
+                # protocol mismatch / firmware not yet supporting listen)
+                # from "spoken nothing". The latter is a legitimate empty
+                # transcription and not surfaced as an error.
+                logger.info(
+                    "listen(): no Opus frames received during %d ms window",
+                    duration_ms,
                 )
-            except ValueError:
-                raise
+
+            try:
+                pcm = decode_opus_frames(frames)
             except Exception as exc:
-                raise RuntimeError(
-                    f"STT engine '{engine_name}' failed: {exc}"
-                ) from exc
-        else:
-            # Empty capture — return an empty transcription rather
-            # than failing the call. ``language`` falls back to the
-            # caller's hint (or empty string).
-            result = {
-                "text": "",
-                "language": (
-                    language if isinstance(language, str) and language else ""
-                ),
-            }
+                raise RuntimeError(f"Opus decode failed: {exc}") from exc
+
+            actual_duration_ms = frame_count * DEVICE_FRAME_DURATION_MS
+
+            if pcm:
+                try:
+                    result = await engine.transcribe(
+                        pcm,
+                        language=language,
+                        model=model,
+                    )
+                except ValueError:
+                    raise
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"STT engine '{engine_name}' failed: {exc}"
+                    ) from exc
+            else:
+                # Empty capture — return an empty transcription rather
+                # than failing the call. ``language`` falls back to the
+                # caller's hint (or empty string).
+                result = {
+                    "text": "",
+                    "language": (
+                        language if isinstance(language, str) and language else ""
+                    ),
+                }
+            succeeded = True
+        finally:
+            await _shield_listen_motion_cleanup(
+                gateway,
+                motion,
+                motion_saved_angles,
+                succeeded=succeeded,
+            )
 
     logger.info(
         "listen(): engine=%s frames=%d duration_ms=%d text=%r",

--- a/gateway/stackchan_mcp/stt/orchestrator.py
+++ b/gateway/stackchan_mcp/stt/orchestrator.py
@@ -113,17 +113,42 @@ async def _shield_listen_motion_cleanup(
     *,
     succeeded: bool,
 ) -> None:
-    try:
-        await asyncio.shield(
-            _finish_listen_motion(
-                gateway,
-                motion,
-                saved_angles,
-                succeeded=succeeded,
-            )
+    """Wait for motion cleanup to complete even under cancellation.
+
+    A bare ``await asyncio.shield(coro())`` protects the inner
+    coroutine from cancellation, but a cancellation propagating
+    through the awaiter is re-raised immediately — which would
+    release ``listen_lock`` while the device-side cleanup is still
+    in flight, and leave the cleanup as an orphan task whose
+    failure nobody observes. Hold the cleanup task in scope,
+    re-await it under shield through repeated cancellations, then
+    surface the cancellation once cleanup has finished so the
+    caller still sees ``CancelledError``.
+    """
+    cleanup_task = asyncio.create_task(
+        _finish_listen_motion(
+            gateway,
+            motion,
+            saved_angles,
+            succeeded=succeeded,
         )
-    except Exception as exc:
-        logger.warning("best-effort listen motion cleanup failed: %s", exc)
+    )
+
+    outer_cancelled = False
+    while True:
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            outer_cancelled = True
+            continue
+        except Exception as exc:
+            logger.warning(
+                "best-effort listen motion cleanup failed: %s", exc
+            )
+        break
+
+    if outer_cancelled:
+        raise asyncio.CancelledError()
 
 
 async def _call_device_tool(

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -462,6 +462,97 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_listen_motion_look_up_nested_partial_failure_surfaces_rollback_error(
+    fake_decode,
+    fast_sleep,
+):
+    """Nested partial failure during look-up setup must surface BOTH
+    errors to the caller.
+
+    Setup sequence: ``set_head_angles(look_up_pitch)`` succeeds, then
+    ``set_avatar('thinking')`` fails. The orchestrator's setup-failure
+    branch attempts a rollback ``set_head_angles(saved)`` which here
+    is configured to fail as well. Without chaining, the caller only
+    sees the forward avatar error while the device remains in the
+    look-up pose with no signal that physical state was altered.
+    The fix chains the cleanup error onto the forward exception via
+    ``raise ... from`` so the caller can observe both.
+    """
+    engine = _CapturingEngine(text="ok")
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    original_call_tool = esp32.call_tool
+
+    async def double_failure(name, arguments):
+        # Forward set_avatar('thinking') fails — record attempt.
+        if (
+            name == "self.display.set_avatar"
+            and arguments.get("face") == "thinking"
+        ):
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "simulated forward avatar failure"}
+        # Rollback set_head_angles(saved pitch=24.0) fails — record attempt.
+        if (
+            name == "self.robot.set_head_angles"
+            and arguments.get("pitch") == 24.0
+        ):
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "simulated rollback pitch failure"}
+        # Forward set_head_angles(50.0), forward get_head_angles, and
+        # any other tool call uses the normal fake-call path which
+        # records into tool_calls on its own.
+        return await original_call_tool(name, arguments)
+
+    esp32.call_tool = double_failure
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": "look-up"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    # The primary exception is the forward avatar failure.
+    primary = exc_info.value
+    assert "set_avatar" in str(primary) or "avatar" in str(primary), (
+        f"primary error should reference the forward avatar failure; got {primary!r}"
+    )
+
+    # The rollback failure is chained via ``__cause__`` so the caller
+    # can inspect both. Without chaining the rollback failure would
+    # vanish into a logger.warning and the device would be left in
+    # the look-up pose with no programmatic signal.
+    chained = primary.__cause__
+    assert chained is not None, (
+        "rollback failure must be chained onto the forward failure, "
+        "not silently swallowed"
+    )
+    assert "set_head_angles" in str(chained), (
+        f"chained error should reference the rollback head-angles failure; got {chained!r}"
+    )
+
+    # Both the forward attempt and the rollback attempt were actually
+    # made (the fake recorded both).
+    avatars_attempted = [
+        args.get("face")
+        for name, args in esp32.tool_calls
+        if name == "self.display.set_avatar"
+    ]
+    assert "thinking" in avatars_attempted, "forward thinking avatar was attempted"
+    pitches_attempted = [
+        args.get("pitch")
+        for name, args in esp32.tool_calls
+        if name == "self.robot.set_head_angles"
+    ]
+    assert 50.0 in pitches_attempted, "forward look_up pitch was attempted"
+    assert 24.0 in pitches_attempted, "rollback saved pitch was attempted"
+
+
+@pytest.mark.asyncio
 async def test_listen_motion_look_up_partial_rollback_still_restores_avatar(
     fake_decode,
     fast_sleep,

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -361,10 +361,17 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
     must complete before the orchestrator's ``listen_lock`` is
     released; otherwise a follow-up listen() can race with an
     in-flight cleanup and observe a partially-restored device state.
-    Without proper handling of ``asyncio.CancelledError`` inside the
-    cleanup wrapper, ``await asyncio.shield(...)`` re-raises the
-    cancellation immediately and the cleanup runs as an orphan task
-    after the lock is already free.
+
+    The lock-ordering invariant is verified directly: a competing
+    waiter races for ``listen_lock`` while ``listen_and_transcribe``
+    is cancelled, and records cleanup observability at the exact
+    moment it acquires the lock. With proper cancellation handling
+    in ``_shield_listen_motion_cleanup`` the orchestrator only exits
+    its ``async with lock_ctx`` block after cleanup completes, so
+    the waiter sees the cleanup events already set. With a naïve
+    ``except Exception`` wrapper around ``asyncio.shield(...)`` the
+    cleanup runs as an orphan task after the lock is released, and
+    the waiter would acquire the lock with the events still unset.
     """
     engine = _CapturingEngine(text="ok")
     esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
@@ -391,7 +398,7 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
     reg = EngineRegistry()
     reg.register(engine)
 
-    task = asyncio.create_task(
+    listen_task = asyncio.create_task(
         listen_and_transcribe(
             {"duration_ms": 200, "motion": motion},
             gateway=gateway,
@@ -399,24 +406,58 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
         )
     )
 
-    # Let the orchestrator enter the capture window before cancelling.
+    # Let the orchestrator enter the capture window and acquire
+    # listen_lock before launching the waiter / cancelling.
     await asyncio.sleep(0.02)
-    task.cancel()
+
+    waiter_snapshot: dict[str, bool] = {}
+
+    async def waiter() -> None:
+        async with esp32.listen_lock:
+            # Snapshot at the exact moment the lock is acquired —
+            # this is the moment the buggy implementation would let
+            # the waiter through while cleanup is still in flight.
+            waiter_snapshot["idle"] = cleanup_idle_observed.is_set()
+            waiter_snapshot["pitch"] = cleanup_pitch_restored.is_set()
+
+    waiter_task = asyncio.create_task(waiter())
+    # Yield once so the waiter registers its lock request before the
+    # orchestrator releases the lock.
+    await asyncio.sleep(0)
+
+    async def re_cancel() -> None:
+        # Re-cancel while the orchestrator is already inside the
+        # motion-cleanup await. With a naïve
+        # ``try / await asyncio.shield(coro()) / except Exception``
+        # wrapper this second cancellation raises CancelledError at
+        # the cleanup await, propagates past the ``except Exception``,
+        # and orphans the in-flight cleanup before the listen_lock is
+        # released — which is the precise regression this test
+        # protects against. The fixed wrapper holds the cleanup task
+        # in scope and re-awaits it under shield, so cleanup still
+        # completes before the function returns.
+        await asyncio.sleep(0.005)
+        if not listen_task.done():
+            listen_task.cancel()
+
+    re_cancel_task = asyncio.create_task(re_cancel())
+
+    listen_task.cancel()
 
     with pytest.raises(asyncio.CancelledError):
-        await task
+        await listen_task
+    await waiter_task
+    await re_cancel_task
 
-    assert cleanup_idle_observed.is_set(), (
-        "set_avatar('idle') must complete during cleanup under cancellation"
+    assert waiter_snapshot["idle"], (
+        "set_avatar('idle') must complete BEFORE listen_lock is released "
+        "to the competing waiter — orphan cleanup race detected"
     )
     if motion == "look-up":
-        assert cleanup_pitch_restored.is_set(), (
-            "saved pitch must be restored during cleanup under cancellation"
+        assert waiter_snapshot["pitch"], (
+            "saved pitch must be restored BEFORE listen_lock is released "
+            "to the competing waiter"
         )
-    # listen_lock must be free only AFTER cleanup completed — the
-    # orchestrator exits ``async with lock_ctx`` after cleanup
-    # finishes when handled correctly.
-    assert not esp32.listen_lock.locked()
     assert not is_recording()
 
 

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -462,6 +462,69 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_listen_motion_look_up_partial_rollback_still_restores_avatar(
+    fake_decode,
+    fast_sleep,
+):
+    """If the pitch rollback fails during look-up cleanup, the avatar
+    restore must still run.
+
+    Otherwise a failed rollback (e.g. servo bus dropped, device
+    error) would leave the device visibly stuck on the ``thinking``
+    face even though the listen itself already failed.
+    """
+    engine = _RaisingEngine(TimeoutError("model timed out"))
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    original_call_tool = esp32.call_tool
+    avatar_idle_observed = asyncio.Event()
+
+    async def selective_rollback_failure(name, arguments):
+        # Fail only on the rollback set_head_angles call (saved
+        # pitch=24.0); the forward set_head_angles for look-up uses
+        # pitch=50.0 and stays on the original fake path. Record the
+        # failing call into tool_calls explicitly so the assertion
+        # below can verify the rollback was actually attempted.
+        if (
+            name == "self.robot.set_head_angles"
+            and arguments.get("pitch") == 24.0
+        ):
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "simulated rollback failure"}
+        result_pair = await original_call_tool(name, arguments)
+        if name == "self.display.set_avatar" and arguments.get("face") == "idle":
+            avatar_idle_observed.set()
+        return result_pair
+
+    esp32.call_tool = selective_rollback_failure
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError):
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": "look-up"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    # The rollback ``set_head_angles`` was actually attempted (and
+    # rejected by the fake).
+    assert any(
+        name == "self.robot.set_head_angles" and args.get("pitch") == 24.0
+        for name, args in esp32.tool_calls
+    ), "pitch rollback should be attempted before the avatar restore"
+
+    # The avatar restore must run regardless of the pitch failure —
+    # this is the user-visible UX contract: failed listen leaves the
+    # device on the idle face, never stuck on the listening face.
+    assert avatar_idle_observed.is_set(), (
+        "set_avatar('idle') must run even when the pitch rollback raises"
+    )
+
+
+@pytest.mark.asyncio
 async def test_pipeline_returns_empty_text_on_no_frames(fake_decode, monkeypatch):
     """An empty capture (no frames) returns text='' rather than erroring.
 

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -60,8 +60,11 @@ class _FakeESP32:
             session_id="session-test",
         )
         self.listen_states: list[tuple[str, str | None]] = []
+        self.tool_calls: list[tuple[str, dict[str, Any]]] = []
         self.events: list[tuple[str, Any]] = []
         self.listen_lock = asyncio.Lock()
+        self.head_yaw = 12.0
+        self.head_pitch = 24.0
         self._frames_to_inject = list(frames_to_inject or [])
         self._injection_delay_s = injection_delay_s
 
@@ -86,6 +89,21 @@ class _FakeESP32:
         for frame in self._frames_to_inject:
             await handle_audio_frame(frame, "session-test")
 
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any], None]:
+        self.tool_calls.append((name, dict(arguments)))
+        self.events.append(("tool", name))
+        if name == "self.robot.get_head_angles":
+            return {"yaw": self.head_yaw, "pitch": self.head_pitch}, None
+        if name == "self.robot.set_head_angles":
+            self.head_yaw = float(arguments["yaw"])
+            self.head_pitch = float(arguments["pitch"])
+            return {"ok": True}, None
+        if name == "self.display.set_avatar":
+            return {"ok": True}, None
+        raise AssertionError(f"unexpected tool call: {name}")
+
 
 class _FakeGateway:
     def __init__(self, esp32: _FakeESP32) -> None:
@@ -106,6 +124,17 @@ def fake_decode(monkeypatch):
 
     monkeypatch.setattr(orchestrator, "decode_opus_frames", fake)
     return fake
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch):
+    real_sleep = asyncio.sleep
+
+    async def fast(delay):
+        await real_sleep(0)
+
+    monkeypatch.setattr(orchestrator.asyncio, "sleep", fast)
+    return fast
 
 
 @pytest.fixture(autouse=True)
@@ -167,6 +196,156 @@ async def test_pipeline_drives_listen_state_and_returns_text(fake_decode, monkey
     assert opts["language"] == "ja"
 
     # Recording slot was closed cleanly.
+    assert not is_recording()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("motion", "expected_tool_calls"),
+    [
+        ("none", []),
+        (
+            "face-only",
+            [
+                ("self.display.set_avatar", {"face": "thinking"}),
+                ("self.display.set_avatar", {"face": "idle"}),
+            ],
+        ),
+        (
+            "look-up",
+            [
+                ("self.robot.get_head_angles", {}),
+                ("self.robot.set_head_angles", {"yaw": 12.0, "pitch": 50.0}),
+                ("self.display.set_avatar", {"face": "thinking"}),
+            ],
+        ),
+    ],
+)
+async def test_listen_motion_success_paths(
+    fake_decode,
+    fast_sleep,
+    motion,
+    expected_tool_calls,
+):
+    """Each motion mode preserves its success cleanup/hold contract."""
+    engine = _CapturingEngine(text="ok")
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await listen_and_transcribe(
+        {"duration_ms": 500, "motion": motion},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert result["text"] == "ok"
+    assert [s[0] for s in esp32.listen_states] == ["start", "stop"]
+    assert esp32.tool_calls == expected_tool_calls
+    if motion == "look-up":
+        assert esp32.head_pitch == 50.0
+    else:
+        assert esp32.head_pitch == 24.0
+    assert not is_recording()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("motion", "expected_tool_calls"),
+    [
+        ("none", []),
+        (
+            "face-only",
+            [
+                ("self.display.set_avatar", {"face": "thinking"}),
+                ("self.display.set_avatar", {"face": "idle"}),
+            ],
+        ),
+        (
+            "look-up",
+            [
+                ("self.robot.get_head_angles", {}),
+                ("self.robot.set_head_angles", {"yaw": 12.0, "pitch": 50.0}),
+                ("self.display.set_avatar", {"face": "thinking"}),
+                ("self.robot.set_head_angles", {"yaw": 12.0, "pitch": 24.0}),
+                ("self.display.set_avatar", {"face": "idle"}),
+            ],
+        ),
+    ],
+)
+async def test_listen_motion_failure_paths(
+    fake_decode,
+    fast_sleep,
+    motion,
+    expected_tool_calls,
+):
+    """Failures clean up avatar state and roll back look-up pitch."""
+    engine = _RaisingEngine(TimeoutError("model timed out"))
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": motion},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    assert [s[0] for s in esp32.listen_states] == ["start", "stop"]
+    assert esp32.tool_calls == expected_tool_calls
+    assert esp32.head_pitch == 24.0
+    assert not is_recording()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("motion", ["none", "face-only", "look-up"])
+async def test_listen_motion_validation_error_paths(motion):
+    """look_up_pitch is validated before any device-side call."""
+    engine = _CapturingEngine()
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(ValueError, match="look_up_pitch"):
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": motion, "look_up_pitch": 4.0},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    assert esp32.listen_states == []
+    assert esp32.tool_calls == []
+    assert engine.calls == []
+    assert not is_recording()
+
+
+@pytest.mark.asyncio
+async def test_listen_motion_rejects_unknown_mode():
+    """Unknown motion values fail before any device-side call."""
+    engine = _CapturingEngine()
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(ValueError, match="motion"):
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": "nod"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    assert esp32.listen_states == []
+    assert esp32.tool_calls == []
+    assert engine.calls == []
     assert not is_recording()
 
 

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -462,6 +462,90 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_listen_motion_look_up_re_cancel_during_cleanup_chains_rollback_failure(
+    fake_decode,
+):
+    """Cancellation re-arriving during the motion-cleanup await
+    combined with a rollback failure must still surface the
+    rollback error.
+
+    The first cancel propagates through the capture sleep and lands
+    the orchestrator in the motion-cleanup await. A second
+    ``listen_task.cancel()`` from a sibling task fires while
+    ``_shield_listen_motion_cleanup`` is waiting on the slow
+    rollback ``set_head_angles``, exercising the cancellation
+    branch of the wrapper. Without explicit chaining the wrapper
+    would raise a fresh ``CancelledError`` and discard the
+    ``cleanup_error``, hiding the physical-state mismatch from the
+    caller. The fix chains via ``raise CancelledError() from
+    cleanup_error`` so the caller can inspect both.
+    """
+    engine = _CapturingEngine(text="ok")
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    original_call_tool = esp32.call_tool
+
+    async def slow_failing_rollback(name, arguments):
+        # Slow the rollback so the re-cancel lands while the
+        # cleanup_task is still in flight.
+        if (
+            name == "self.robot.set_head_angles"
+            and arguments.get("pitch") == 24.0
+        ):
+            await asyncio.sleep(0.03)
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "simulated rollback pitch failure"}
+        return await original_call_tool(name, arguments)
+
+    esp32.call_tool = slow_failing_rollback
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    listen_task = asyncio.create_task(
+        listen_and_transcribe(
+            {"duration_ms": 200, "motion": "look-up"},
+            gateway=gateway,
+            registry=reg,
+        )
+    )
+
+    # Let the orchestrator enter the capture window.
+    await asyncio.sleep(0.02)
+
+    async def re_cancel() -> None:
+        # Re-cancel after the first cancel has propagated past the
+        # capture sleep and the orchestrator is inside
+        # ``_shield_listen_motion_cleanup``'s shield-await loop.
+        await asyncio.sleep(0.005)
+        if not listen_task.done():
+            listen_task.cancel()
+
+    re_cancel_task = asyncio.create_task(re_cancel())
+    listen_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await listen_task
+    await re_cancel_task
+
+    # Cleanup failure must be chained onto the cancellation —
+    # otherwise the cancellation branch silently swallows the
+    # rollback failure and the caller has no programmatic signal
+    # about a potentially off-baseline pose.
+    primary = exc_info.value
+    chained = primary.__cause__
+    assert chained is not None, (
+        "rollback failure must be chained onto the cancellation even "
+        "when _shield_listen_motion_cleanup raises a fresh CancelledError"
+    )
+    assert "set_head_angles" in str(chained), (
+        f"chained error should reference the rollback head-angles failure; "
+        f"got {chained!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_listen_motion_look_up_engine_failure_with_rollback_failure_chains(
     fake_decode,
     fast_sleep,

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -350,6 +350,77 @@ async def test_listen_motion_rejects_unknown_mode():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("motion", ["face-only", "look-up"])
+async def test_listen_motion_cleanup_completes_under_cancellation(
+    fake_decode,
+    motion,
+):
+    """Cancellation during capture must not bypass motion cleanup.
+
+    The avatar / head rollback driven by ``_finish_listen_motion``
+    must complete before the orchestrator's ``listen_lock`` is
+    released; otherwise a follow-up listen() can race with an
+    in-flight cleanup and observe a partially-restored device state.
+    Without proper handling of ``asyncio.CancelledError`` inside the
+    cleanup wrapper, ``await asyncio.shield(...)`` re-raises the
+    cancellation immediately and the cleanup runs as an orphan task
+    after the lock is already free.
+    """
+    engine = _CapturingEngine(text="ok")
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    cleanup_idle_observed = asyncio.Event()
+    cleanup_pitch_restored = asyncio.Event()
+    original_call_tool = esp32.call_tool
+
+    async def slow_cleanup(name, arguments):
+        result_pair = await original_call_tool(name, arguments)
+        # Add a small delay specifically on the cleanup-path calls
+        # so we can observe whether the orchestrator waits for them.
+        if name == "self.display.set_avatar" and arguments.get("face") == "idle":
+            await asyncio.sleep(0.02)
+            cleanup_idle_observed.set()
+        if name == "self.robot.set_head_angles" and arguments.get("pitch") == 24.0:
+            await asyncio.sleep(0.02)
+            cleanup_pitch_restored.set()
+        return result_pair
+
+    esp32.call_tool = slow_cleanup
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    task = asyncio.create_task(
+        listen_and_transcribe(
+            {"duration_ms": 200, "motion": motion},
+            gateway=gateway,
+            registry=reg,
+        )
+    )
+
+    # Let the orchestrator enter the capture window before cancelling.
+    await asyncio.sleep(0.02)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_idle_observed.is_set(), (
+        "set_avatar('idle') must complete during cleanup under cancellation"
+    )
+    if motion == "look-up":
+        assert cleanup_pitch_restored.is_set(), (
+            "saved pitch must be restored during cleanup under cancellation"
+        )
+    # listen_lock must be free only AFTER cleanup completed — the
+    # orchestrator exits ``async with lock_ctx`` after cleanup
+    # finishes when handled correctly.
+    assert not esp32.listen_lock.locked()
+    assert not is_recording()
+
+
+@pytest.mark.asyncio
 async def test_pipeline_returns_empty_text_on_no_frames(fake_decode, monkeypatch):
     """An empty capture (no frames) returns text='' rather than erroring.
 

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -546,6 +546,104 @@ async def test_listen_motion_look_up_re_cancel_during_cleanup_chains_rollback_fa
 
 
 @pytest.mark.asyncio
+async def test_listen_motion_look_up_double_cleanup_failure_preserves_both_errors(
+    fake_decode,
+    fast_sleep,
+):
+    """Both pitch-rollback and avatar-restore failures must remain
+    inspectable to the caller.
+
+    In ``_finish_listen_motion`` the pitch rollback runs in a ``try``
+    and the avatar restore in the matching ``finally`` so the avatar
+    always runs. When both raise, the avatar failure overrides as
+    the primary cleanup error (Python finally semantics) and the
+    pitch failure is preserved on ``__context__`` via automatic
+    exception-context tracking. The outer ``finally`` then chains
+    the avatar failure onto the listen failure via ``__cause__``,
+    so the caller can navigate the chain as
+
+        primary  ⟶ __cause__ (avatar)  ⟶ __context__ (pitch)
+
+    and see both physical-state concerns without losing either.
+    """
+    engine = _RaisingEngine(TimeoutError("engine fail"))
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    original_call_tool = esp32.call_tool
+
+    async def double_cleanup_failure(name, arguments):
+        # Rollback set_head_angles(saved pitch=24.0) fails.
+        if (
+            name == "self.robot.set_head_angles"
+            and arguments.get("pitch") == 24.0
+        ):
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "rollback pitch failure"}
+        # Cleanup-path set_avatar('idle') also fails.
+        if (
+            name == "self.display.set_avatar"
+            and arguments.get("face") == "idle"
+        ):
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "rollback avatar failure"}
+        return await original_call_tool(name, arguments)
+
+    esp32.call_tool = double_cleanup_failure
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": "look-up"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    primary = exc_info.value
+    assert "engine" in str(primary).lower(), (
+        f"primary should reference the engine failure; got {primary!r}"
+    )
+
+    # The avatar-restore failure became the cleanup primary (it
+    # overrode the pitch failure via the try/finally raise sequence
+    # in _finish_listen_motion) and is chained via __cause__.
+    chained = primary.__cause__
+    assert chained is not None, "cleanup chain must reach the caller"
+    assert "set_avatar" in str(chained), (
+        f"primary cleanup error should be the avatar restore failure; "
+        f"got {chained!r}"
+    )
+
+    # The pitch failure is preserved on the avatar failure's
+    # __context__ via Python's automatic exception-context tracking,
+    # so the caller can navigate to it programmatically.
+    pitch_failure = chained.__context__
+    assert pitch_failure is not None, (
+        "pitch rollback failure must remain inspectable via "
+        "__cause__.__context__"
+    )
+    assert "set_head_angles" in str(pitch_failure), (
+        f"pitch failure should appear on __context__; got {pitch_failure!r}"
+    )
+
+    # Both cleanup attempts were made on the device.
+    pitches = [
+        args.get("pitch")
+        for name, args in esp32.tool_calls
+        if name == "self.robot.set_head_angles"
+    ]
+    faces = [
+        args.get("face")
+        for name, args in esp32.tool_calls
+        if name == "self.display.set_avatar"
+    ]
+    assert 24.0 in pitches, "pitch rollback was attempted"
+    assert "idle" in faces, "idle avatar restore was attempted"
+
+
+@pytest.mark.asyncio
 async def test_listen_motion_look_up_engine_failure_with_rollback_failure_chains(
     fake_decode,
     fast_sleep,

--- a/gateway/tests/test_stt_orchestrator.py
+++ b/gateway/tests/test_stt_orchestrator.py
@@ -462,6 +462,88 @@ async def test_listen_motion_cleanup_completes_under_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_listen_motion_look_up_engine_failure_with_rollback_failure_chains(
+    fake_decode,
+    fast_sleep,
+):
+    """When the STT engine fails mid-capture AND the rollback also
+    fails for motion='look-up', the caller must see both errors.
+
+    The engine failure is the primary cause (it triggered the
+    rollback attempt). The rollback failure is chained via
+    ``__cause__`` from the outer listen() finally so the caller
+    can detect that physical state may be off-baseline even though
+    the original primary cause references the engine timeout.
+    Without this chaining the rollback failure would vanish into
+    ``logger.warning`` and the caller would only see the engine
+    error with no signal about the device pose.
+    """
+    engine = _RaisingEngine(TimeoutError("model timed out"))
+    esp32 = _FakeESP32(frames_to_inject=[b"opus_a"])
+    gateway = _FakeGateway(esp32)
+
+    original_call_tool = esp32.call_tool
+
+    async def rollback_only_failure(name, arguments):
+        # Forward set_head_angles uses pitch=50.0 (look_up_pitch),
+        # forward set_avatar uses face='thinking'. Both stay on the
+        # original fake path. Only the rollback set_head_angles
+        # (saved pitch=24.0) fails here.
+        if (
+            name == "self.robot.set_head_angles"
+            and arguments.get("pitch") == 24.0
+        ):
+            esp32.tool_calls.append((name, dict(arguments)))
+            return {}, {"message": "simulated rollback pitch failure"}
+        return await original_call_tool(name, arguments)
+
+    esp32.call_tool = rollback_only_failure
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await listen_and_transcribe(
+            {"duration_ms": 500, "motion": "look-up"},
+            gateway=gateway,
+            registry=reg,
+        )
+
+    # The engine failure is wrapped into a RuntimeError stating
+    # which engine failed; it remains the primary exception so the
+    # caller's first signal is still "what triggered the failure".
+    primary = exc_info.value
+    assert "STT engine" in str(primary) or "engine" in str(primary).lower(), (
+        f"primary error should reference the engine failure; got {primary!r}"
+    )
+
+    # The rollback failure is chained via ``__cause__`` so the
+    # caller can inspect it programmatically without it disappearing
+    # into a logger.warning. (The engine's original TimeoutError is
+    # still reachable through ``__context__`` thanks to Python's
+    # automatic exception-context tracking.)
+    chained = primary.__cause__
+    assert chained is not None, (
+        "rollback failure must be chained onto the listen failure, "
+        "not silently swallowed"
+    )
+    assert "set_head_angles" in str(chained), (
+        f"chained error should reference the rollback head-angles failure; "
+        f"got {chained!r}"
+    )
+
+    # Sanity: forward motion ran (pitch=50, thinking) and rollback
+    # was attempted (pitch=24 — that's the call we made fail).
+    pitches_attempted = [
+        args.get("pitch")
+        for name, args in esp32.tool_calls
+        if name == "self.robot.set_head_angles"
+    ]
+    assert 50.0 in pitches_attempted
+    assert 24.0 in pitches_attempted
+
+
+@pytest.mark.asyncio
 async def test_listen_motion_look_up_nested_partial_failure_surfaces_rollback_error(
     fake_decode,
     fast_sleep,


### PR DESCRIPTION
## Summary

Add optional visual + motion feedback to the gateway-side `listen()` MCP tool so the device can signal the active capture window without the caller juggling separate `set_avatar` / `move_head` calls.

A new `motion` parameter selects one of three behaviours during the capture window:

- `motion="none"` (default) — unchanged from PR #93; no avatar or pose change.
- `motion="face-only"` — the avatar switches to `thinking` for the duration of the capture window and returns to `idle` at the end. The head holds its current pose.
- `motion="look-up"` — yaw is preserved, pitch is tilted up to `look_up_pitch` (default `50°`, clamped to the M5Stack-recommended `5..85` range), the avatar shows `thinking` during the capture, and the pose is held on success so the device visibly "stays attentive" until the next caller-driven motion. On failure / cancellation the original pose and avatar are restored as a best-effort cleanup.

The schema gains two new optional parameters (`motion`, `look_up_pitch`); existing callers that omit them see byte-identical behaviour to PR #93.

Touched (gateway-only, no firmware changes in this PR):

- `gateway/stackchan_mcp/stt/orchestrator.py` — listen() motion lifecycle (`_begin_listen_motion` / `_finish_listen_motion` / `_shield_listen_motion_cleanup`), asyncio cancellation safety, structured error chaining for nested cleanup failures
- `gateway/stackchan_mcp/stdio_server.py` — `listen` tool schema extended with `motion` / `look_up_pitch`
- `gateway/tests/test_stt_orchestrator.py` — 7 new regression tests covering motion happy paths, cancellation, and cleanup-failure chains
- `CHANGELOG.md` — entry under `[Unreleased]`
- `README.md` / `README.ja.md` — short note on the new motion options

## Test plan

### Code-level

- [x] gateway: `uv run pytest tests/test_stt_orchestrator.py` — all 18 tests pass (11 existing + 7 new)
- [x] gateway: full suite — passes apart from one pre-existing `libopus` env-only failure unrelated to this change
- [x] Codex adversarial review across R1–R8: 6 cleanup-chain bugs found and fixed in R1–R7, R8 returned "approve / no material findings"

### Hardware

**Real-device verification completed on 2026-05-14** (M5Stack CoreS3 + SCS0009 ×2, ESP-IDF v5.5.2 firmware build of this branch, gateway reached via Tailscale Funnel). Force-mode-enabled re-flash via `python ./scripts/release.py stackchan` + `esptool write_flash 0x20000 build/xiaozhi.bin` succeeded; NVS preserved, WebSocket reconnected on first boot.

- [x] Device boots without crash — confirmed across multiple reboots during the verification session.
- [x] Existing MCP tools still work where affected: gateway-only change; backward compatibility re-confirmed by `motion="none"` default plus the existing 11 `listen()` tests passing unchanged.
- [x] Existing touch/servo behavior still works where affected: no firmware change in this PR.
- [x] New behavior verified on real hardware:
  - `listen(duration_ms=5000, motion="face-only")` — avatar switched to `thinking` for the capture window and restored to `idle` at the end; head held position (post-call `get_head_angles` returned the same `yaw=0, pitch=0` as before the call). STT capture completed in `5220 ms` with `87` Opus frames received.
  - `listen(duration_ms=5000, motion="look-up", look_up_pitch=50)` — yaw was preserved, pitch tilted up to the recommended target (post-call `get_head_angles` returned `pitch=49°`, within rounding of the requested `50°`), avatar showed `thinking` during the capture, and the pose was held after the capture window closed (the documented success-hold behaviour). STT capture completed in `5040 ms` with `84` Opus frames received.
  - `look_up_pitch` tuning: default `50` was judged as "looking up at the speaker" on this hardware. The full `45 / 50 / 55 / 60` sweep was not executed in this session and remains scoped under #108.
  - Motion pacing verified through the firmware-side `StackChanBoard` serial log — pitch advanced through the incremental smoothing steps (`deg=11 → 17 → 21 → 25 → ... → 50`) rather than jerking to the target in one frame, matching the `set_head_angles` interpolation contract.
- [x] Real-device verification was in scope and is now complete.

#### Side discovery — separate firmware bug, not introduced by this PR

During the look-up motion testing the SCS0009 servo bus hang state tracked in #100 was reproduced and analysed. The hang is firmware-side and not introduced by this PR; the `listen()` motion logic itself completed correctly in every observed case (avatar state machine transitioned `idle → listening → idle`, `set_head_angles` was dispatched, success-hold was applied as designed). The bus-hang appears in the *following* motion when the starting pose is below the M5Stack-recommended `5°` floor:

- Sequence 1: `listen(motion="look-up")` → pose held at `pitch=49°` → `move_head(yaw=0, pitch=0)` to restore "neutral" → firmware log shows 10 consecutive `Motion pitch WritePos failed: r=-1` lines spanning `deg=50 → 47 → 44 → ... → 15`, followed by `get_head_angles` returning the `{"yaw":-144, "pitch":-194}` failure sentinel, only recoverable by a CoreS3 power-button long-press.
- Sequence 2 (clean reboot, no `listen()` involved): `get_head_angles` returns `{"yaw":0, "pitch":0}` → `move_head(yaw=0, pitch=5)` (smallest possible motion into the recommended floor) → same `-144 / -194` sentinel result. Firmware emits its `pitch=0 outside M5Stack-recommended range 5..85 (within hard clamp 0..88); acceptable but not officially endorsed` `ESP_LOGI` from PR #101 along the way.

The differential between the two paths shifts the suspected trigger from "incremental smoothing across the recommended floor during reversal" to "any first motion that starts from below the M5Stack-recommended `5°` floor." Captured evidence and full firmware-side logs are filed in comments on #99 and #100. The gateway-side mitigation — refusing `move_head` requests with `pitch` outside `5..85` at the MCP boundary — has been opened as #111 (Closes #109); the firmware-side coordinate / boot-default question is tracked in #99 and #100 directly.

## Breaking changes

None. The default `motion="none"` preserves the previous `listen()` behaviour exactly — same wire format, same return shape, same error mapping. Existing callers see zero behavioural change.

## Related issues

- Closes #96.
- Refs #93 (`listen()` pipeline), #101 (pitch safety range).
- Side discovery filed against #99 / #100; gateway-side mitigation in #111 (Closes #109).
- Real-device re-flash workflow and any post-merge `look_up_pitch` tuning continuations remain scoped under #108.
