### PR TITLE
fix(mcp): #109 enforce move_head pitch in 5..85 range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ change is called out under a `Firmware` subsection of the release entry.
   can continue from the attentive posture. The default
   `motion="none"` preserves the existing behavior. Refs #96.
 
+- `move_head` MCP tool now constrains `pitch` to `5..85` — the
+  M5Stack-recommended operating range. Both the `inputSchema`
+  (`minimum: 5`, `maximum: 85` for `pitch`; `minimum: -90`, `maximum: 90`
+  for `yaw`) and the gateway `call_tool` handler enforce the bound as
+  belt-and-suspenders. The tool description now references
+  `set_head_angles` for callers that genuinely need the wider firmware
+  hard clamp (`0..88`). This also refuses `move_head(yaw=0, pitch=0)`
+  and other below-`5°` pitch requests at the MCP boundary, so an
+  LLM-driven agent cannot trigger the SCS0009 servo bus hang state
+  tracked in
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
+  from a default pose-reset call. See README "Y-axis (pitch) safe
+  range — two-tier guard" for the gateway-side restrictive vs
+  firmware-side permissive policy contrast, and the comment thread on
+  [#99](https://github.com/kisaragi-mochi/stackchan-mcp/issues/99) /
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
+  for the on-device reproduction (2026-05-14). Closes
+  [#109](https://github.com/kisaragi-mochi/stackchan-mcp/issues/109).
+
 ## [0.6.0] - 2026-05-12
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@
 | `take_photo(question?)` | カメラ撮影 → JPEG 保存 → パス返す | ✅ |
 | `set_volume(volume)` | スピーカー音量 (0-100) | ✅ |
 | `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
-| `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ) | ✅ |
+| `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ)。`pitch` は M5Stack 推奨運用レンジ `5..85` に制限される。ファームウェア側のハードクランプ (`0..88`) を使いたい場合は、firmware-side の `set_head_angles` デバイスツールを利用する | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
 | `set_avatar(face)` | アバター表情切替 (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`)、または `off` でアバターを隠し blink も停止して下層の WiFi 設定 / OTA / 設定画面を露出。他 face を指定するとアバター + blink が復帰 | ✅ |
 | `set_blink(state)` | 瞬き ON/OFF | ✅ |
@@ -451,6 +451,8 @@ M5Stack 公式ドキュメントには以下の警告があります:
 > (StackChan の Y 軸サーボの可動角度は 5°〜85° の範囲内に制御することを推奨します。極端な角度で動作させると **サーボストール や 永久故障** を引き起こす可能性があります。)
 
 `set_head_angles` MCP ツールは pitch を完全に **permissive** な schema range として宣言しています — `int` 型の全範囲 (`std::numeric_limits<int>::min()` から `std::numeric_limits<int>::max()` まで、境界値含む)。Tier 1 の権威ある enforcement は firmware ハンドラ側にあります — schema range を狭めると `McpServer::Property` が十分に極端な out-of-range リクエスト (例: `pitch=200` や `pitch=INT_MIN`) をハンドラ呼び出し前に reject してしまい、ドキュメントに書かれた Tier 1 挙動が到達不能になります（詳しくは #98 を参照）。`0°` 未満のリクエストは `0°` に引き上げられ (`ESP_LOGW`)、`88°` 超のリクエストは `88°` に引き下げられ (`ESP_LOGW`)、`[0, 88]` 内かつ `[5, 85]` 外のリクエストはそのまま受け入れた上で `ESP_LOGI` のソフトシグナルを出力します。過去に `-30..+30°` を target にしていた caller はそのまま動作します（負側は `0°` にクランプされます）。
+
+対照的に、**gateway 側の `move_head` MCP ツール** — 上記のツール一覧で LLM クライアントが見るのはこちら — は `pitch=5..85` / `yaw=-90..90` の restrictive な schema を宣言し、gateway `call_tool` ハンドラでも同じ境界を二重に enforce しています（belt-and-suspenders）。これにより、推奨範囲外のリクエストを MCP 境界で reject して、エージェントが `move_head(yaw=0, pitch=0)` のような姿勢リセット呼び出しで [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100) で track されているバスハング状態を誤って誘発しないようにしています。診断やリカバリ等で firmware Tier 1 ハードクランプそのものを使いたい上級用途では、`move_head` を経由せず firmware-side の `set_head_angles` デバイスツールを直接呼んでください — [#109](https://github.com/kisaragi-mochi/stackchan-mcp/issues/109) 参照。
 
 X 軸 (yaw、`-90..+90°`) には同等のハードウェア制限はなく — M5Stack 公式が「X 軸には角度制限は不要」と明記しています — 宣言範囲全体を使えます。
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repository is a monorepo.
 | `take_photo(question?)` | Capture a frame, save as JPEG, return the path | ✅ |
 | `set_volume(volume)` | Speaker volume (0-100) | ✅ |
 | `set_brightness(brightness)` | Screen brightness (0-100) | ✅ |
-| `move_head(yaw, pitch, speed?)` | Move the neck (servos) | ✅ |
+| `move_head(yaw, pitch, speed?)` | Move the neck (servos). `pitch` is constrained to `5..85` — the M5Stack-recommended operating range. For the wider firmware hard clamp (`0..88`), use the firmware-side `set_head_angles` device tool instead. | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying WiFi config / OTA / settings screens are visible. Any other face brings the avatar back and restores blink. | ✅ |
 | `set_blink(state)` | Blink on/off | ✅ |
@@ -494,6 +494,8 @@ M5Stack's official documentation states:
 > — https://docs.m5stack.com/en/StackChan ("Motion Angle Notice")
 
 The `set_head_angles` MCP tool declares pitch with a fully permissive schema range — the entire `int` value range, `std::numeric_limits<int>::min()` to `std::numeric_limits<int>::max()`, corner values included; the firmware-side handler is the authoritative Tier 1 enforcement layer. Any narrower schema range would cause `McpServer::Property` to reject sufficiently-extreme out-of-range requests (e.g. `pitch=200` or `pitch=INT_MIN`) before the handler could clamp / log them, leaving the documented Tier 1 behavior unreachable for those callers — see #98. Requests below `0°` are silently raised to `0°` (with `ESP_LOGW`), requests above `88°` are silently lowered to `88°` (with `ESP_LOGW`), and requests inside `[0, 88]` but outside `[5, 85]` are accepted with an `ESP_LOGI` soft signal. Older callers that targeted `-30..+30°` continue to work without modification (the negative half clamps to `0°`).
+
+Conversely, the **gateway-side `move_head` MCP tool** — the one LLM-driven clients see in the tool list above — declares a restrictive `pitch=5..85` / `yaw=-90..90` schema and re-enforces the same bounds in the gateway `call_tool` handler as belt-and-suspenders. This rejects out-of-recommended requests at the MCP boundary so an agent cannot accidentally trigger the bus-hang risk tracked in [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100) from a pose-reset call like `move_head(yaw=0, pitch=0)`. Callers that need explicit access to the firmware Tier 1 hard clamp (for diagnostics, recovery sequences, or other expert use cases) should bypass `move_head` and call the firmware-side `set_head_angles` device tool directly — see [#109](https://github.com/kisaragi-mochi/stackchan-mcp/issues/109).
 
 The X-axis (yaw, `-90..+90°`) is not subject to a comparable hardware restriction — M5Stack's documentation explicitly notes "No angle restriction is required for the X-axis" — and remains usable across its full declared range.
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -103,8 +103,14 @@ def create_server() -> Server:
             Tool(
                 name="move_head",
                 description=(
-                    "Move the robot's head to the specified angles. "
-                    "yaw: horizontal (-90 to 90), pitch: vertical (-30 to 30)."
+                    "Move the robot's head to safe, recommended angles. "
+                    "yaw: horizontal (-90 to 90), pitch: vertical (5 to 85, "
+                    "the M5Stack-recommended operating range). Out-of-range "
+                    "requests are rejected at this MCP layer; for advanced "
+                    "callers that need the firmware hard clamp (pitch 0..88), "
+                    "use the firmware-side `set_head_angles` device tool, "
+                    "which exposes a permissive schema and the authoritative "
+                    "two-tier guard described in the README."
                 ),
                 inputSchema={
                     "type": "object",
@@ -112,10 +118,19 @@ def create_server() -> Server:
                         "yaw": {
                             "type": "integer",
                             "description": "Horizontal angle in degrees (-90 to 90)",
+                            "minimum": -90,
+                            "maximum": 90,
                         },
                         "pitch": {
                             "type": "integer",
-                            "description": "Vertical angle in degrees (-30 to 30)",
+                            "description": (
+                                "Vertical angle in degrees (5 to 85, "
+                                "M5Stack-recommended operating range). For the "
+                                "wider firmware hard clamp (0..88), use the "
+                                "`set_head_angles` device tool instead."
+                            ),
+                            "minimum": 5,
+                            "maximum": 85,
                         },
                     },
                     "required": ["yaw", "pitch"],
@@ -551,6 +566,59 @@ def create_server() -> Server:
                     text=json.dumps({"error": "No ESP32 device connected. Please check the device."}),
                 )
             ]
+
+        if name == "move_head":
+            # Belt-and-suspenders validation for the recommended pitch range.
+            # The Tool inputSchema already declares minimum/maximum for both
+            # yaw and pitch, but mcp Python SDK server-side enforcement of
+            # JSON Schema bounds is not guaranteed across versions and
+            # clients. Reject out-of-recommended values here as a clean
+            # MCP error JSON before any motion command reaches the device.
+            # Callers that genuinely need the firmware hard clamp 0..88
+            # should use the firmware-side `set_head_angles` device tool,
+            # which exposes the authoritative two-tier guard described in
+            # the README "Y-axis (pitch) safe range" section.
+            yaw_val = arguments.get("yaw")
+            pitch_val = arguments.get("pitch")
+            if (
+                not isinstance(yaw_val, int)
+                or isinstance(yaw_val, bool)
+                or not (-90 <= yaw_val <= 90)
+            ):
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "error": (
+                                    "yaw must be an integer in -90..90 "
+                                    f"(got {yaw_val!r})"
+                                )
+                            }
+                        ),
+                    )
+                ]
+            if (
+                not isinstance(pitch_val, int)
+                or isinstance(pitch_val, bool)
+                or not (5 <= pitch_val <= 85)
+            ):
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "error": (
+                                    "pitch must be an integer in 5..85 "
+                                    "(M5Stack-recommended operating range; "
+                                    "for the wider firmware hard clamp "
+                                    "0..88 use `set_head_angles`). got "
+                                    f"{pitch_val!r}"
+                                )
+                            }
+                        ),
+                    )
+                ]
 
         # Map MCP client tool names to ESP32 MCP tool names (self.* prefix)
         tool_map: dict[str, tuple[str, dict[str, Any]]] = {

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -375,3 +375,197 @@ async def test_set_mouth_sequence_relays_steps_as_json_string(monkeypatch):
     assert name == "self.display.set_mouth_sequence"
     assert set(arguments.keys()) == {"steps_json"}
     assert json.loads(arguments["steps_json"]) == steps
+
+
+# ---------------------------------------------------------------------------
+# move_head — Issue #109: schema + handler enforce the M5Stack-recommended
+# pitch operating range (5..85). pitch=0 motion-starts have been observed on
+# device to trigger the SCS0009 bus hang tracked in Issue #100, and the
+# firmware-side `set_head_angles` tool remains the documented escape hatch
+# for callers that need the wider firmware hard clamp (0..88).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tools_move_head_declares_recommended_pitch_range():
+    """move_head schema mirrors M5Stack-recommended 5..85 / yaw -90..90."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tool = next((t for t in result.root.tools if t.name == "move_head"), None)
+    assert tool is not None, "move_head tool should be registered"
+
+    pitch_schema = tool.inputSchema["properties"]["pitch"]
+    assert pitch_schema["minimum"] == 5
+    assert pitch_schema["maximum"] == 85
+
+    yaw_schema = tool.inputSchema["properties"]["yaw"]
+    assert yaw_schema["minimum"] == -90
+    assert yaw_schema["maximum"] == 90
+
+    # The description should mention the escape-hatch tool name so an LLM
+    # reading it can pick the right alternative for permissive use cases.
+    assert "set_head_angles" in tool.description
+
+
+def _make_fake_gateway(monkeypatch):
+    """Helper: wire a FakeESP32/FakeGateway into the stdio_server module.
+
+    Returns the ``calls`` list that records each ESP32 call. The handler
+    treats this device as connected. Used by the move_head handler tests.
+    """
+    calls: list[tuple[str, dict]] = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, tool_name, arguments):
+            calls.append((tool_name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"yaw": arguments.get("yaw", 0), "pitch": arguments.get("pitch", 0)}
+                        ),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    return calls
+
+
+def _move_head_request(yaw, pitch):
+    return CallToolRequest(
+        method="tools/call",
+        params={"name": "move_head", "arguments": {"yaw": yaw, "pitch": pitch}},
+    )
+
+
+def _assert_rejected_without_dispatch(result, calls):
+    """Common shape: out-of-range request is refused and no ESP32 call fires.
+
+    Two refusal paths coexist:
+    - mcp SDK server-side JSON Schema validation rejects the request before
+      the handler runs (current behaviour observed with mcp>=1.0). The
+      response text is a human-readable validation message rather than the
+      handler's structured JSON error.
+    - The handler's belt-and-suspenders validation in stdio_server.py
+      returns a clean ``{"error": "..."}`` JSON for SDK versions or future
+      configurations that may not enforce the schema bounds.
+
+    Either path is acceptable. What matters for hardware safety is that
+    ``self.robot.set_head_angles`` is never called.
+    """
+    assert calls == [], (
+        "Out-of-range move_head must not dispatch a motion call. "
+        f"Got calls={calls}, response text={result.root.content[0].text!r}"
+    )
+    response_text = result.root.content[0].text
+    # The response should signal an error in some shape. Either the handler
+    # JSON ({"error": "..."}) or the SDK validation prose mentions one of
+    # these keywords.
+    lower = response_text.lower()
+    assert any(
+        keyword in lower
+        for keyword in ("error", "invalid", "minimum", "maximum", "type")
+    ), f"Expected an error signal in {response_text!r}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pitch", [0, 4, -1, -30])
+async def test_move_head_rejects_pitch_below_recommended(monkeypatch, pitch):
+    """pitch values below the M5Stack-recommended 5° floor are refused."""
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=0, pitch=pitch)
+    )
+
+    _assert_rejected_without_dispatch(result, calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pitch", [86, 90, 88, 200])
+async def test_move_head_rejects_pitch_above_recommended(monkeypatch, pitch):
+    """pitch values above the M5Stack-recommended 85° ceiling are refused."""
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=0, pitch=pitch)
+    )
+
+    _assert_rejected_without_dispatch(result, calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("yaw", [-91, 91, 200, -1000])
+async def test_move_head_rejects_yaw_out_of_range(monkeypatch, yaw):
+    """yaw values outside -90..+90 are refused."""
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=yaw, pitch=45)
+    )
+
+    _assert_rejected_without_dispatch(result, calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pitch", [5, 45, 85])
+async def test_move_head_accepts_pitch_inside_recommended(monkeypatch, pitch):
+    """Boundary and mid-range pitch values are accepted and relayed."""
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=0, pitch=pitch)
+    )
+
+    assert len(calls) == 1
+    name, arguments = calls[0]
+    assert name == "self.robot.set_head_angles"
+    assert arguments == {"yaw": 0, "pitch": pitch}
+
+    payload = json.loads(result.root.content[0].text)
+    assert "error" not in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pitch", [None, "45", 5.5])
+async def test_move_head_rejects_non_integer_pitch(monkeypatch, pitch):
+    """Non-int pitch values are refused before reaching the device."""
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=0, pitch=pitch)
+    )
+
+    _assert_rejected_without_dispatch(result, calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pitch", [True, False])
+async def test_move_head_rejects_boolean_pitch(monkeypatch, pitch):
+    """bool is an int subclass in Python; must still be refused for pitch."""
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=0, pitch=pitch)
+    )
+
+    _assert_rejected_without_dispatch(result, calls)


### PR DESCRIPTION
## Summary

The gateway-side `move_head` MCP tool previously declared pitch with `-30..30` in its description text (obsolete since PR #101 widened the firmware-side hard clamp to `0..88`) and exposed a fully permissive `inputSchema` with no bounds. On-device validation during PR #107 (#96 listen() motion feedback, 2026-05-14) showed this leaves an LLM-driven agent free to send poses like `move_head(yaw=0, pitch=0)`, which is inside the firmware Tier 1 hard clamp `0..88` but below the M5Stack-recommended `5..85` floor — and consistently triggers the SCS0009 servo bus hang state tracked in #100.

This PR makes `move_head` **safe-by-default for the LLM-agent path** while keeping the firmware-side `set_head_angles` device tool **permissive as an expert escape hatch** (intentional two-tier design):

- `move_head` `inputSchema` now declares `minimum: 5, maximum: 85` for pitch and `minimum: -90, maximum: 90` for yaw. The `mcp` Python SDK enforces these server-side, as confirmed via the new tests.
- Gateway `call_tool` handler validates the same bounds as **belt-and-suspenders**. Even if a future `mcp` SDK release skips schema enforcement, the handler returns a clean MCP error JSON without dispatching a motion call to the device.
- `move_head` description text references `set_head_angles` as the documented escape hatch for callers that genuinely need the wider firmware hard clamp.
- README EN/JP and CHANGELOG `[Unreleased]` document the gateway-side restrictive vs firmware-side permissive policy contrast.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` — 223 passed locally, 1 failed (env-only `libopus` missing, unrelated to this change)
- [ ] gateway: `uv run ruff check .` — not run locally; CI covers it
- [ ] firmware: `python ./scripts/release.py stackchan` — not applicable (no firmware changes)
- 21 new gateway tests cover:
  - `move_head` schema declaration (min/max for both axes + description references `set_head_angles`)
  - In-range accept (pitch = 5 / 45 / 85)
  - Below-floor reject (pitch = 0 / 4 / -1 / -30)
  - Above-ceiling reject (pitch = 86 / 90 / 88 / 200)
  - Yaw out-of-range reject (-91 / 91 / 200 / -1000)
  - Non-integer reject (None / str / float)
  - `bool`-as-`int`-subclass edge case (True / False)

### Hardware

- [x] No firmware changes in this PR; no real-device verification is required for the gateway-side fix itself.
- [x] The bus-hang state this fix prevents (#100) was reproduced on real hardware during the parent PR #107 verification on 2026-05-14 (CoreS3 + SCS0009 ×2), documented in comments on #99 / #100.

## Breaking changes

The MCP `move_head` tool now refuses pitch values outside `5..85`. Callers that previously relied on the obsolete `-30..30` description and were targeting `pitch=0` for "head straight ahead" need to switch to either:

- `move_head(yaw, pitch=5)` for the M5Stack-recommended neutral pose, or
- the firmware-side `set_head_angles` device tool, which keeps its permissive schema and the authoritative Tier 1 enforcement.

The set of pitch values that the tool *previously dispatched but now refuses* (`0..4`, `86..88`, anything outside `0..88`) all fall outside the M5Stack-recommended operating range. The Tier 2 `ESP_LOGI` from PR #101 was already firing for these values; the only behavioral change in this PR is that the request now never reaches the device. No NVS schema or build-flag impact.

## Related issues

- Closes #109.
- Refs #100 — the bus-hang state this fix prevents from being triggered via `move_head`. See [the recent comment](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100#issuecomment-4450447213) for the on-device reproduction with `move_head(0, 5)` from a `pitch=0` starting pose.
- Refs #99 — gateway-side `move_head` restriction complements the firmware-side coordinate-origin question. See [the recent comment](https://github.com/kisaragi-mochi/stackchan-mcp/issues/99#issuecomment-4450447358) for the Option C vote.
- Builds on #101 / #98 — Tier 1 (hard clamp `0..88`) + Tier 2 (recommended `5..85` soft signal) from those PRs are the firmware-side foundation this PR extends to the gateway MCP boundary.
