### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-14
+
 ### Gateway
 
 - `listen()` now accepts optional visual/motion feedback arguments:

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2009,7 +2009,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Promote `[Unreleased]` to `[0.7.0] - 2026-05-14` and bump the gateway version. v0.7.0 contains two coordinated gateway-side changes accumulated since v0.6.0:

- **listen() motion feedback** — new optional `motion="face-only"` / `motion="look-up"` arguments for visible capture feedback (PR #107, closes #96). Default `motion="none"` preserves prior behaviour byte-identically.
- **move_head pitch range hardening** — gateway-side `move_head` MCP tool now refuses pitch values outside `5..85` at the MCP boundary (PR #111, closes #109). The firmware-side `set_head_angles` device tool keeps its permissive schema (intentional two-tier design, see README "Y-axis (pitch) safe range"). This prevents the SCS0009 servo bus hang state tracked in #100 from being triggered by a default `move_head(yaw=0, pitch=0)` pose-reset.

No firmware changes are bundled in this gateway release. The prior `firmware-vX.Y.Z` stream (`firmware-v1.3.0` from v0.6.0) remains the recommended pairing for clients that need the gateway-driven listening trigger.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` — 240 passed locally (1 env-only `libopus` failure unrelated)
- [x] `gateway/pyproject.toml` version: `0.6.0` → `0.7.0`
- [x] `gateway/uv.lock` regenerated via `uv lock`
- [x] CHANGELOG `[Unreleased]` promoted to `[0.7.0] - 2026-05-14`

### Hardware

- [x] No firmware changes in this release; no real-device verification required for the release cut itself.
- [x] The two PRs being released (#107 / #111) each had their own real-device verification documented in their PR descriptions and in comments on #99 / #100.

## Breaking changes

`move_head` pitch values outside `5..85` are now refused at the MCP boundary. Callers that previously targeted `pitch=0` for "head straight ahead" should switch to `move_head(yaw, pitch=5)` (the M5Stack-recommended neutral) or use the firmware-side `set_head_angles` device tool, which keeps its permissive schema.

Per Keep a Changelog / SemVer pre-1.0 convention, this is shipped as a minor bump (0.6.0 → 0.7.0) rather than a major bump. The set of pitch values that previously dispatched but are now refused (`0..4`, `86..88`) all fell outside the M5Stack-recommended operating range; the Tier 2 `ESP_LOGI` from PR #101 had already been firing for these values.

## Related issues

- Closes #96 (via PR #107 merged into main).
- Closes #109 (via PR #111 merged into main).
- Refs #100 / #99 for the on-device reproduction context behind the move_head hardening.
- Refs #108 for follow-up `look_up_pitch` tuning.

## Post-merge

Once merged, push `v0.7.0` tag at the merge commit. `.github/workflows/publish.yml` is triggered on `v*` tags and verifies the tag commit is on `origin/main` before publishing to PyPI.