### PR TITLE
feat(firmware): #115 add boot-time servo init to fall-safe neutral pose (yaw=0, pitch=45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
+### Firmware
+
+- The firmware now actively positions the head at a fall-safe neutral
+  pose (`yaw=0°`, `pitch=45°`) at the end of `InitializeServo()`, before
+  any MCP command can arrive. Previously the head retained whatever
+  angle it was left at on power-down, which could include end-stop
+  positions (e.g. `pitch=0°`) that triggered the SCS0009 bus hang
+  documented in
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
+  on the first user-driven motion. The new boot-time positioning uses
+  the existing interpolating `WriteHeadAngles` path with a 1-second
+  move duration plus a 100 ms settle delay, mirroring the `goHome()`
+  pattern in `m5stack/StackChan` and the timing established in
+  `mongonta0716/stackchan-arduino`. Existing pitch guards (`0..88`
+  hard clamp / `5..85` recommended range) continue to apply
+  unchanged. Implements
+  [#99](https://github.com/kisaragi-mochi/stackchan-mcp/issues/99)
+  Option C and the boot-init aspect of
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
+  direction E. Refs
+  [#115](https://github.com/kisaragi-mochi/stackchan-mcp/issues/115).
+
 ## [0.7.0] - 2026-05-14
 
 ### Gateway

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -1132,6 +1132,35 @@ private:
                 servo_ok_ = false;
                 return;
             }
+
+            // Issue #115: boot-time initialization to a fall-safe neutral
+            // pose. Without this, the head retains whatever angle it was
+            // left at on power-down — including end-stop positions (e.g.
+            // pitch=0) that trigger the SCS0009 bus-hang documented in
+            // #100 on the very first user-driven motion. By the time any
+            // MCP command can arrive, we want the head already moved to
+            // the center of the M5Stack-recommended 5..85° pitch range,
+            // well clear of both mechanical end-stops.
+            //
+            // Design follows the goHome() pattern in m5stack/StackChan
+            // (apps/app_setup/workers/servo.cpp:144) where the setup
+            // app calls motion.goHome(speed) at boot, and the 1-second
+            // positioning timing established in mongonta0716/stackchan-
+            // arduino attachServos(). 1000ms move via the existing
+            // interpolating WriteHeadAngles path keeps frame-rate stall
+            // currents low; the extra 100ms vTaskDelay covers servo
+            // settling before any subsequent motion can arrive.
+            //
+            // Implements #99 Option C and the boot-init aspect of #100
+            // direction E. Existing pitch guards (#80 / #98 / #109)
+            // continue to apply unchanged.
+            constexpr int BOOT_INIT_YAW_DEG = 0;
+            constexpr int BOOT_INIT_PITCH_DEG = 45;
+            constexpr uint32_t BOOT_INIT_MOVE_MS = 1000;
+            WriteHeadAngles(BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG, BOOT_INIT_MOVE_MS);
+            vTaskDelay(pdMS_TO_TICKS(BOOT_INIT_MOVE_MS + 100));
+            ESP_LOGI(TAG, "Boot-time servo init complete: yaw=%d pitch=%d",
+                     BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG);
         }
     }
 


### PR DESCRIPTION
## Summary

Adds boot-time servo initialization to a fall-safe neutral pose (`yaw=0°`, `pitch=45°`), eliminating the cold-boot SCS0009 bus-hang surface (#100) and the fall-risk pose retention across power cycles.

## Problem

`InitializeServo()` previously only opened the UART bus and read `current_deg` via `ReadPos()` — it did not actively position the head at boot. Two consequences:

1. **Fall-risk pose retention.** The head boots into whatever angle it was left at on power-down (including hand-pushed positions or end-stop contact). There was no defined "safe rest pose".
2. **Cold-boot bus-hang trigger.** If power-off happened with pitch near `0°` (mechanical end-stop region), the first `move_head` into the M5Stack-recommended `5..85°` range triggered the SCS0009 bus hang state documented in #100. `get_head_angles` returned `{"yaw":-144,"pitch":-194}`, and recovery required a CoreS3 power-button long-press.

Confirmed by inspecting both the local firmware and its direct upstream `kisaragi-mochi/xiaozhi-esp32` `main/boards/stackchan/stackchan.cc` — neither path issued a boot-time `WritePos`.

## Change

In `InitializeServo()`, after the `servo_motion` task is started, issue a boot-time `WriteHeadAngles(0, 45, 1000)` followed by `vTaskDelay(pdMS_TO_TICKS(1100))` so the head is at the fall-safe neutral pose before any MCP command can arrive.

- **`pitch=45°` rationale.** Center of M5Stack-recommended `5..85°` pitch range (Tier 2 guard from #98 / PR #101). Maximum margin from both mechanical end-stops. Aligns with the `look_up_pitch=50°` default landed in PR #107 (#96 listen() motion feedback).
- **Timing rationale.** 1000 ms move duration through the existing interpolating `WriteHeadAngles` path keeps per-frame stall current low; the additional 100 ms `vTaskDelay` covers servo settling before any subsequent motion can arrive.
- **Driver coverage.** Both `CONFIG_STACKCHAN_SERVO_FEETECH` (MIT FeetechScs default, #82 / #83) and `CONFIG_STACKCHAN_SERVO_SCSCL` (GPL SCServo_lib opt-in) build paths are covered uniformly via the existing `ScsBus` abstraction.
- **Existing guards unchanged.** Tier 1 hard clamp `0..88` (#80 / PR #81), Tier 2 recommended-range soft signal (#98 / PR #101), and gateway-side `move_head` schema bound (#109 / PR #111) all continue to apply.

## Reference implementations

- `m5stack/StackChan` `firmware/main/apps/app_setup/workers/servo.cpp` — the setup app calls `motion.goHome(666)` at boot via the dedicated `Motion::goHome(int speed)` method (`firmware/main/stackchan/motion/motion.cpp`). Same SCS0009 coordinate system (yaw `zero_pos=460`, pitch `zero_pos=620`, conversion `pos = zero + deg * 16/5`).
- `mongonta0716/stackchan-arduino` `src/Stackchan_servo.cpp::attachServos()` — empirical 1-second `WritePos` + 1-second `vTaskDelay` settle timing for the same SCS0009 hardware.

## Test plan

- [ ] Firmware build via `python ./scripts/release.py stackchan` succeeds.
- [ ] Flash `xiaozhi.bin` to `0x20000` on M5Stack CoreS3 with NVS preserved.
- [ ] On boot, the head physically moves to `pitch≈45°, yaw=0°` within ~1 second of servo bus init; `ESP_LOGI "Boot-time servo init complete: yaw=0 pitch=45"` appears in serial log.
- [ ] `mcp__stackchan-mcp__get_head_angles` post-boot returns `{"yaw":0, "pitch":45}` (±2°, accounting for servo settling).
- [ ] **Bus-hang regression test:** manually push the head to `pitch≈0°` (mechanical end-stop) before power cycle. On the next boot, the head moves to 45° without entering the bus-hang state (`-144`/`-194` sentinel values not observed in `get_head_angles`).
- [ ] `mcp__stackchan-mcp__move_head(yaw=0, pitch=10)` after a fresh boot completes cleanly — the first user-driven motion now always starts from inside the M5Stack-recommended range.
- [ ] Both `CONFIG_STACKCHAN_SERVO_FEETECH` (default) and `CONFIG_STACKCHAN_SERVO_SCSCL` build configurations behave identically.

## Relation

- Closes #115.
- Closes #99 (Option C — boot-time default at a safe in-range value).
- Refs #100 (direction E only; the SDK-level recovery directions A–D and the caller-side guard F remain open in #100).
- Builds on #80 / PR #81, #98 / PR #101, #109 / PR #111.

## License boundary

This change touches only `firmware/main/boards/stackchan/stackchan.cc` (MIT). The GPL-3.0 `SCServo_lib` files in the same directory are not modified.
