### PR TITLE
fix(firmware): #110 stop OTA response from overwriting NVS websocket.url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Fixed user-configured WebSocket gateway URLs (e.g.
+  `ws://192.168.x.y:8765`) being silently overwritten on every boot by
+  the upstream xiaozhi OTA-config response. `Ota::CheckVersion()` still
+  runs (firmware-version / activation / server-time / MQTT paths are
+  unchanged), but the `websocket` section of the response is no longer
+  written back into NVS by default. A new Kconfig option
+  `CONFIG_DISABLE_OTA_WEBSOCKET_CONFIG` (default `y`) gates this
+  behavior; setting it to `n` restores the original
+  xiaozhi-esp32 NVS overwrite path. The misleading comment in
+  `WebsocketProtocol::OpenAudioChannelInternal()` that claimed the
+  OTA-config path was already disabled has been corrected to reflect
+  the actual gating. Closes
+  [#110](https://github.com/kisaragi-mochi/stackchan-mcp/issues/110).
+
 - The firmware now actively positions the head at a fall-safe neutral
   pose (`yaw=0°`, `pitch=45°`) at the end of `InitializeServo()`, before
   any MCP command can arrive. Previously the head retained whatever

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -6,6 +6,29 @@ config OTA_URL
     help
         The application will access this URL to check for new firmwares and server address.
 
+config DISABLE_OTA_WEBSOCKET_CONFIG
+    bool "Ignore the websocket section of the OTA response"
+    default y
+    help
+        When enabled (default for this fork), the firmware parses the OTA
+        response normally but skips the NVS write-back for the optional
+        `websocket` section. The stackchan-mcp build always speaks to a
+        stackchan-mcp gateway directly — the WebSocket URL, token, and
+        fallback URL are owned by the user via the WiFi config UI or
+        CONFIG_DEFAULT_WEBSOCKET_URL / CONFIG_DEFAULT_WEBSOCKET_TOKEN /
+        CONFIG_DEFAULT_WEBSOCKET_FALLBACK_URL Kconfig values, not the
+        upstream OTA server.
+
+        Disable this option to restore the original xiaozhi-esp32
+        behavior, where the OTA server may overwrite NVS
+        websocket.{url,token,fallback_url} on every boot. That behavior
+        is what caused user-configured LAN gateway URLs (e.g.
+        ws://192.168.x.y:8765) to be silently replaced by the upstream
+        server's value (see GitHub issue #110).
+
+        The MQTT / firmware-version / activation / server-time sections
+        of the OTA response are unaffected by this option.
+
 config DEFAULT_WEBSOCKET_URL
     string "Default WebSocket gateway URL (fallback when NVS is empty)"
     default ""

--- a/firmware/main/ota.cc
+++ b/firmware/main/ota.cc
@@ -165,6 +165,19 @@ esp_err_t Ota::CheckVersion() {
     }
 
     has_websocket_config_ = false;
+#if CONFIG_DISABLE_OTA_WEBSOCKET_CONFIG
+    // The stackchan-mcp build owns the WebSocket URL/token/fallback_url
+    // via the WiFi config UI and the CONFIG_DEFAULT_WEBSOCKET_* Kconfig
+    // values. The upstream xiaozhi OTA server returns its own websocket
+    // section pointing at api.tenclass.net, which used to overwrite the
+    // user's NVS values on every boot (GitHub issue #110). We skip the
+    // write-back entirely; the section, if present, is logged for
+    // diagnostics only.
+    if (cJSON_HasObjectItem(root, "websocket")) {
+        ESP_LOGI(TAG, "OTA response includes a websocket section; ignored "
+                      "(CONFIG_DISABLE_OTA_WEBSOCKET_CONFIG=y).");
+    }
+#else
     cJSON *websocket = cJSON_GetObjectItem(root, "websocket");
     if (cJSON_IsObject(websocket)) {
         Settings settings("websocket", true);
@@ -184,6 +197,7 @@ esp_err_t Ota::CheckVersion() {
     } else {
         ESP_LOGI(TAG, "No websocket section found!");
     }
+#endif
 
     has_server_time_ = false;
     cJSON *server_time = cJSON_GetObjectItem(root, "server_time");

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -183,9 +183,11 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error) {
 
     Settings settings("websocket", false);
     // Read the gateway URL from NVS (set via the WiFi config UI's "websocket
-    // url" field on first boot, e.g. "ws://<your-gateway-lan-ip>:8765"). The
-    // legacy OTA-config code path is disabled in application.cc by design —
-    // this firmware always speaks to a stackchan-mcp gateway directly.
+    // url" field on first boot, e.g. "ws://<your-gateway-lan-ip>:8765").
+    // application.cc forces WebsocketProtocol regardless of the upstream OTA
+    // response, and CONFIG_DISABLE_OTA_WEBSOCKET_CONFIG (default y) prevents
+    // the upstream OTA server from overwriting the NVS values read below.
+    // This firmware always speaks to a stackchan-mcp gateway directly.
     std::string url = settings.GetString("url");
 #ifdef CONFIG_DEFAULT_WEBSOCKET_URL
 #ifdef CONFIG_FORCE_DEFAULT_WEBSOCKET_URL


### PR DESCRIPTION
## Summary

The xiaozhi-esp32 OTA-config code path was still writing the upstream
server's `websocket` section into NVS (`url` / `token` /
`fallback_url`) on every boot. For pre-built binaries pointed at a
self-hosted LAN gateway via the WiFi config UI, that silently replaced
the user-provided `ws://<lan-ip>:8765` value with the upstream
server's `wss://api.tenclass.net/xiaozhi/v1/` a few seconds after
provisioning, making the device unreachable from the user's gateway
without anyone touching the device again.

The misleading comment in `WebsocketProtocol::OpenAudioChannelInternal`
claimed the OTA-config path was "disabled in application.cc by
design", but in practice only the protocol selection was forced
(`InitializeProtocol` hardcodes `WebsocketProtocol`); the NVS
write-back at `ota.cc:167-186` ran unguarded on every boot.

## Changes

- Add `CONFIG_DISABLE_OTA_WEBSOCKET_CONFIG` (Kconfig bool, default
  `y`) that gates only the `websocket`-section write-back in
  `Ota::CheckVersion()`. Setting the option to `n` restores the
  original xiaozhi-esp32 NVS overwrite behavior.
- The firmware-version / activation / MQTT / server-time sections of
  the OTA response are unaffected. `Ota::CheckVersion()` continues to
  run normally so existing firmware-update / activation flows are
  preserved.
- When the option is enabled and the OTA response still includes a
  `websocket` section, log an info-level line so the ignored payload
  is visible on the serial console for debugging.
- Replace the inaccurate comment in `websocket_protocol.cc` with one
  that describes how the gating actually works.
- CHANGELOG entry added under Firmware [Unreleased].

## Why a Kconfig option (default `y`) rather than removing the code outright

The OTA `websocket` section is a real upstream xiaozhi-esp32 protocol
feature for fleets that fetch their server URL from the OTA endpoint
rather than configuring it on-device. Users who deliberately want
that behavior — e.g. running their own OTA endpoint that hands out
the gateway URL on first boot — can flip the Kconfig option to `n`
without forking the firmware. The default is `y` because this fork
forces `WebsocketProtocol` and owns the URL via the WiFi config UI
plus the existing `CONFIG_DEFAULT_WEBSOCKET_*` Kconfig fallback,
which means accepting an upstream-provided URL has no behavioral
value on a stackchan-mcp build and only hurts users.

## Test plan

- [ ] Build via `python scripts/release.py stackchan` in the
      ESP-IDF v5.5.2 Docker image and confirm the generated
      `xiaozhi.bin` / `merged-binary.bin` build cleanly.
- [ ] On a device with a `ws://<lan-ip>:8765` URL previously written
      to NVS (or freshly provisioned via the WiFi config UI), confirm
      after WiFi connect that:
  - serial log shows `OTA response includes a websocket section;
    ignored` (or no such line, if the upstream response omits the
    section);
  - the NVS `websocket.url` value remains unchanged across
    `Ota::CheckVersion()`;
  - `WebsocketProtocol: Adding websocket gateway candidate from
    websocket.url: ws://<lan-ip>:8765/` appears as expected.
- [ ] Toggle `CONFIG_DISABLE_OTA_WEBSOCKET_CONFIG=n` in
      `sdkconfig.defaults.local`, rebuild, and confirm the original
      overwrite behavior is restored (sanity check for the opt-out
      path).

Closes #110