### PR TITLE
fix(firmware): #123 distinguish get_head_angles ReadPos transient failure from bus hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,31 @@ change is called out under a `Firmware` subsection of the release entry.
   direction E. Refs
   [#115](https://github.com/kisaragi-mochi/stackchan-mcp/issues/115).
 
+- Improved `get_head_angles` MCP-tool diagnostics so that transient
+  `ReadPos` failures can be distinguished from a genuine SCS0009 bus
+  hang. The handler now retries `ReadPos` up to three times (50 ms
+  inter-attempt delay) per servo ID while holding `scs_bus_mutex_`
+  across the whole sequence. The success-path JSON output
+  (`{"yaw":N,"pitch":N}`) is unchanged; on persistent failure the tool
+  now returns
+  `{"yaw":null,"pitch":null,"error":"ReadPos failed ...","servo_ok":bool,"yaw_attempts":N,"pitch_attempts":N}`
+  instead of the previous sentinel `{"yaw":-144,"pitch":-194}` (the
+  `-1` return from `ReadPos` run through the same
+  `(pos-zero) * 5 / 16` degree-conversion math as a valid raw position,
+  which was indistinguishable from a hang at the MCP layer and
+  contributed to the hang judgments recorded in
+  [#1](https://github.com/kisaragi-mochi/stackchan-mcp/issues/1) /
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100) /
+  [#118](https://github.com/kisaragi-mochi/stackchan-mcp/issues/118)).
+  The serial-log line is also expanded to include `servo_ok`, raw
+  `ReadPos` values, and attempt counts. As a further investigation
+  aid, `InitializeServo()` now logs pre- and post-init `ReadPos` raw
+  values and tick timestamps around the boot-init `WriteHeadAngles`
+  call, making the "unintended downward drop on power-on" investigation
+  ([#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121))
+  data-driven via the serial log. Refs
+  [#123](https://github.com/kisaragi-mochi/stackchan-mcp/issues/123).
+
 ## [0.7.0] - 2026-05-14
 
 ### Gateway

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -1090,8 +1090,16 @@ private:
                 return;
             }
 
+            // Issue #123: log boot-init pre-WritePos position with tick so
+            // the "unintended downward drop on power-on" (#121 hypothesis 1/2)
+            // becomes data-driven. ServoTask has not been created yet, so no
+            // scs_bus_mutex_ contention is possible at this point.
             int yaw_pos_actual = scs_bus_.ReadPos(SERVO_YAW_ID);
             int pitch_pos_actual = scs_bus_.ReadPos(SERVO_PITCH_ID);
+            ESP_LOGI(TAG,
+                     "Boot pre-init ReadPos: yaw_raw=%d pitch_raw=%d tick=%u",
+                     yaw_pos_actual, pitch_pos_actual,
+                     (unsigned)xTaskGetTickCount());
             if (yaw_pos_actual >= 0) {
                 yaw_motion_.current_deg = (yaw_pos_actual - 460) * 5 / 16;
                 ESP_LOGI(TAG, "Restored yaw_motion_.current_deg=%d from ReadPos=%d",
@@ -1157,10 +1165,29 @@ private:
             constexpr int BOOT_INIT_YAW_DEG = 0;
             constexpr int BOOT_INIT_PITCH_DEG = 45;
             constexpr uint32_t BOOT_INIT_MOVE_MS = 1000;
+            TickType_t boot_init_start_tick = xTaskGetTickCount();
             WriteHeadAngles(BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG, BOOT_INIT_MOVE_MS);
             vTaskDelay(pdMS_TO_TICKS(BOOT_INIT_MOVE_MS + 100));
-            ESP_LOGI(TAG, "Boot-time servo init complete: yaw=%d pitch=%d",
-                     BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG);
+
+            // Issue #123: capture post-init ReadPos so the boot-init effect
+            // is observable in the serial log. ServoTask is now running, so
+            // hold scs_bus_mutex_ across the ReadPos pair.
+            int post_yaw_pos = -1;
+            int post_pitch_pos = -1;
+            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            post_yaw_pos = scs_bus_.ReadPos(SERVO_YAW_ID);
+            post_pitch_pos = scs_bus_.ReadPos(SERVO_PITCH_ID);
+            xSemaphoreGive(scs_bus_mutex_);
+            TickType_t boot_init_end_tick = xTaskGetTickCount();
+            ESP_LOGI(TAG,
+                     "Boot-time servo init complete: target yaw=%d pitch=%d "
+                     "(move=%ums), post-ReadPos: yaw_raw=%d pitch_raw=%d, "
+                     "elapsed_ms=%u",
+                     BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG,
+                     (unsigned)BOOT_INIT_MOVE_MS,
+                     post_yaw_pos, post_pitch_pos,
+                     (unsigned)((boot_init_end_tick - boot_init_start_tick) *
+                                portTICK_PERIOD_MS));
         }
     }
 
@@ -2375,27 +2402,84 @@ private:
         // Get current head angles
         mcp_server.AddTool(
             "self.robot.get_head_angles",
-            "Get the current head angles (yaw, pitch) of the robot in degrees.",
+            "Get the current head angles (yaw, pitch) of the robot in degrees. "
+            "Returns {\"yaw\":N,\"pitch\":N} on success; "
+            "on persistent ReadPos failure returns "
+            "{\"yaw\":null,\"pitch\":null,\"error\":...,\"servo_ok\":bool,"
+            "\"yaw_attempts\":N,\"pitch_attempts\":N}.",
             PropertyList(),
             [this](const PropertyList& properties) -> ReturnValue {
+                // Issue #123: retry ReadPos a few times before falling back
+                // to an explicit error reply. Single-call ReadPos failures
+                // (e.g. servo mid-motion, transient bus contention) are a
+                // known transient mode that InitializeServo() already treats
+                // as warning-and-continue; the previous behaviour of running
+                // `ReadPos==-1` through the same `(pos-zero)*5/16` math as a
+                // valid position produced sentinel `{-144,-194}` that was
+                // indistinguishable from a genuine bus hang at the MCP layer
+                // (see #1 / #100 / #118 hang judgments).
+                constexpr int kReadPosRetryMax = 3;
+                constexpr uint32_t kReadPosRetryDelayMs = 50;
+
                 int yaw_pos = -1;
                 int pitch_pos = -1;
+                int yaw_attempts = 0;
+                int pitch_attempts = 0;
                 if (servo_ok_) {
                     xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-                    yaw_pos = scs_bus_.ReadPos(SERVO_YAW_ID);
-                    pitch_pos = scs_bus_.ReadPos(SERVO_PITCH_ID);
+                    for (int i = 0; i < kReadPosRetryMax; i++) {
+                        yaw_attempts = i + 1;
+                        yaw_pos = scs_bus_.ReadPos(SERVO_YAW_ID);
+                        if (yaw_pos >= 0) break;
+                        if (i + 1 < kReadPosRetryMax) {
+                            vTaskDelay(pdMS_TO_TICKS(kReadPosRetryDelayMs));
+                        }
+                    }
+                    for (int i = 0; i < kReadPosRetryMax; i++) {
+                        pitch_attempts = i + 1;
+                        pitch_pos = scs_bus_.ReadPos(SERVO_PITCH_ID);
+                        if (pitch_pos >= 0) break;
+                        if (i + 1 < kReadPosRetryMax) {
+                            vTaskDelay(pdMS_TO_TICKS(kReadPosRetryDelayMs));
+                        }
+                    }
                     xSemaphoreGive(scs_bus_mutex_);
                 }
-                int yaw = (yaw_pos - 460) * 5 / 16;
-                int pitch = (pitch_pos - 620) * 5 / 16;
+
                 cJSON* root = cJSON_CreateObject();
-                cJSON_AddNumberToObject(root, "yaw", yaw);
-                cJSON_AddNumberToObject(root, "pitch", pitch);
+                const bool yaw_ok = yaw_pos >= 0;
+                const bool pitch_ok = pitch_pos >= 0;
+                if (yaw_ok && pitch_ok) {
+                    int yaw = (yaw_pos - 460) * 5 / 16;
+                    int pitch = (pitch_pos - 620) * 5 / 16;
+                    cJSON_AddNumberToObject(root, "yaw", yaw);
+                    cJSON_AddNumberToObject(root, "pitch", pitch);
+                } else {
+                    cJSON_AddNullToObject(root, "yaw");
+                    cJSON_AddNullToObject(root, "pitch");
+                    char err[160];
+                    snprintf(err, sizeof(err),
+                             "ReadPos failed: yaw_raw=%d (attempts=%d) "
+                             "pitch_raw=%d (attempts=%d) servo_ok=%d",
+                             yaw_pos, yaw_attempts,
+                             pitch_pos, pitch_attempts,
+                             servo_ok_ ? 1 : 0);
+                    cJSON_AddStringToObject(root, "error", err);
+                    cJSON_AddBoolToObject(root, "servo_ok", servo_ok_);
+                    cJSON_AddNumberToObject(root, "yaw_attempts", yaw_attempts);
+                    cJSON_AddNumberToObject(root, "pitch_attempts", pitch_attempts);
+                }
                 char* str = cJSON_PrintUnformatted(root);
                 std::string result(str);
                 cJSON_free(str);
                 cJSON_Delete(root);
-                ESP_LOGI(TAG, "get_head_angles: %s", result.c_str());
+                ESP_LOGI(TAG,
+                         "get_head_angles: servo_ok=%d yaw_raw=%d (attempts=%d) "
+                         "pitch_raw=%d (attempts=%d) result=%s",
+                         servo_ok_ ? 1 : 0,
+                         yaw_pos, yaw_attempts,
+                         pitch_pos, pitch_attempts,
+                         result.c_str());
                 return result;
             });
 


### PR DESCRIPTION
## Summary

- `get_head_angles` no longer reports the sentinel `{"yaw":-144,"pitch":-194}` reply (which was `ReadPos==-1` run through the same `(pos-zero) * 5 / 16` degree-conversion math as a valid raw position) on transient `ReadPos` failure. The handler now retries `ReadPos` up to three times per servo ID (50 ms inter-attempt delay) while holding `scs_bus_mutex_` across the whole sequence. The success-path JSON output (`{"yaw":N,"pitch":N}`) is unchanged; on persistent failure the tool returns an explicit error JSON instead.
- `InitializeServo()` now logs pre- and post-init `ReadPos` raw values and tick timestamps around the boot-init `WriteHeadAngles` call, so the "unintended downward drop on power-on" investigation (#121) can be driven from the serial log.

Closes #123. Refs #1 (closed), #20, #100, #118, #121.

## Background

The previous `get_head_angles` implementation in `firmware/main/boards/stackchan/stackchan.cc:2380-2400` ran `ReadPos==-1` (single-call failure) through the same `(pos-zero) * 5 / 16` math as a valid raw position, producing:

```
yaw   = (-1 - 460) * 5 / 16 = -144
pitch = (-1 - 620) * 5 / 16 = -194
```

This sentinel was indistinguishable from a genuine SCS0009 bus hang at the MCP layer, and contributed to the hang judgments recorded in #1 / #100 / #118 that could not be cross-validated against orthogonal evidence (a failed `move_head`, audible servo stall, or no observable motion). `InitializeServo()` itself (line 1093-1115) already treats `ReadPos == -1` as an expected transient event (`ESP_LOGW` and continue), so the MCP layer's collapse of "transient ReadPos miss" and "bus hang" into a single sentinel reply was inconsistent with the firmware's own internal handling.

## Changes

### Firmware

- `firmware/main/boards/stackchan/stackchan.cc`
  - `get_head_angles` MCP handler: bounded retry (3 attempts, 50 ms delay) per servo ID; explicit error JSON on persistent failure; expanded `ESP_LOGI` line including `servo_ok`, raw `ReadPos` values, and attempt counts.
  - `InitializeServo()`: pre-/post-init `ReadPos` raw values and tick timestamps around the PR #117 boot-init `WriteHeadAngles` call (post-init `ReadPos` pair is guarded by `scs_bus_mutex_` since `ServoTask` is running at that point).

### Docs

- `CHANGELOG.md`: new `[Unreleased] Firmware` entry.

## JSON output shape

| State | Output |
|---|---|
| Both `ReadPos` succeed (any attempt) | `{"yaw":N,"pitch":N}` — unchanged from previous success path |
| `servo_ok_==false` or all retries exhausted | `{"yaw":null,"pitch":null,"error":"ReadPos failed: yaw_raw=<int> (attempts=<int>) pitch_raw=<int> (attempts=<int>) servo_ok=<0/1>","servo_ok":<bool>,"yaw_attempts":<int>,"pitch_attempts":<int>}` |

## Gateway compatibility

`gateway/stackchan_mcp/stt/orchestrator.py::_extract_head_angles` already validates `yaw` / `pitch` with `isinstance(..., int | float)` (line 197) and raises `RuntimeError("Device tool 'self.robot.get_head_angles' returned invalid angles")` when they are not numeric. With the new firmware behaviour:

- Success path is unchanged → no observable difference to callers.
- Failure path now yields `null` values, which fail the isinstance check and raise → the existing exception path in `_begin_listen_motion` (line 230-244) handles this with `_shield_listen_motion_cleanup`. Previously the sentinel `-144 / -194` passed the isinstance check as valid floats and was forwarded as a `set_head_angles` target, which is the riskier behaviour this PR removes.

## Out of scope

- Changes to `set_head_angles` / `move_head` MCP handlers — separate PR if needed.
- Changes to the underlying SCSCL / FeetechScs driver code — license-sensitive, not touched.
- Real-device push-down re-verification of #118 acceptance criterion 6 — follow-up once this PR is flashed. With retry-aware `get_head_angles` plus orthogonal `move_head` trial, hang vs transient-failure judgments can now be cross-validated.

## Test plan

- [ ] CI: firmware build (`docker run --cpus=4 ... release.py stackchan`) succeeds — `#112` workaround applies.
- [ ] CI: gateway pytest passes (no changes to gateway code, expected pass).
- [ ] Real-device verification (post-flash, follow-up):
  - [ ] `get_head_angles` under normal conditions returns `{"yaw":N,"pitch":N}` (backward-compatible success shape).
  - [ ] Serial monitor shows the expanded `get_head_angles: servo_ok=1 yaw_raw=N (attempts=1) pitch_raw=N (attempts=1) result=...` line on each call.
  - [ ] Serial monitor shows `Boot pre-init ReadPos: ... tick=...` and `Boot-time servo init complete: ... post-ReadPos: ... elapsed_ms=...` lines on boot.
  - [ ] Repeat the `#118` manual end-stop push-down + power-cycle sequence and capture: (a) `get_head_angles` output (sentinel vs explicit error vs success), (b) a `move_head` trial to orthogonally confirm bus state, (c) serial log of boot-init pre/post `ReadPos`. The combination should let #118 criterion 6 be decided on data rather than on the ambiguous sentinel alone.
