### PR TITLE
feat(firmware): #121 slow the boot-init climb from 1s/45° to 4s/45° (~11°/s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,23 @@ change is called out under a `Firmware` subsection of the release entry.
   data-driven via the serial log. Refs
   [#123](https://github.com/kisaragi-mochi/stackchan-mcp/issues/123).
 
+- The boot-time `WriteHeadAngles` interpolated move added in #115 /
+  PR #117 now runs over 4 seconds instead of 1, dropping the
+  effective angular speed for the post-power-on climb to the
+  fall-safe neutral pose from approximately 45°/s to approximately
+  11°/s. On-device feedback identified the original 1-second
+  duration as startling ("ブルンっ" / audible servo stress) on the
+  CoreS3 + SCS0009 hardware. The move is otherwise unchanged — same
+  target (`yaw=0°`, `pitch=45°`), same path through
+  `WriteHeadAngles` / the `servo_motion` task, same 100 ms
+  post-settle vTaskDelay margin (so total boot-init now takes about
+  4.1 seconds instead of 1.1 seconds before the first MCP command
+  can arrive). Refs
+  [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
+  Problem 2 (climb speed); the separate "unintended downward drop on
+  power-on" (#121 Problem 1 / hypotheses 1–3) remains under
+  investigation and is unaffected by this change.
+
 ## [0.7.0] - 2026-05-14
 
 ### Gateway

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -1164,7 +1164,18 @@ private:
             // continue to apply unchanged.
             constexpr int BOOT_INIT_YAW_DEG = 0;
             constexpr int BOOT_INIT_PITCH_DEG = 45;
-            constexpr uint32_t BOOT_INIT_MOVE_MS = 1000;
+            // Issue #121: at the original 1000 ms duration the
+            // post-power-on climb to 45° produced ~45°/s angular speed,
+            // perceived on-device as startling ("ブルンっ" + audible
+            // stress). Bumping the interpolated move to 4000 ms drops
+            // the effective rate to ~11°/s while keeping the motion
+            // monotonic through the existing `WriteHeadAngles` ->
+            // `servo_motion` task path. The 100 ms post-settle margin
+            // is unchanged. This is the cheap fix for #121 Problem 2;
+            // the separate "unintended downward drop on power-on"
+            // (#121 Problem 1 / hypotheses 1-3) still requires a
+            // root-cause investigation tracked separately.
+            constexpr uint32_t BOOT_INIT_MOVE_MS = 4000;
             TickType_t boot_init_start_tick = xTaskGetTickCount();
             WriteHeadAngles(BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG, BOOT_INIT_MOVE_MS);
             vTaskDelay(pdMS_TO_TICKS(BOOT_INIT_MOVE_MS + 100));


### PR DESCRIPTION
## Summary

- Slow the boot-time `WriteHeadAngles(0, 45, DURATION_MS)` move from `1000 ms` to `4000 ms`, dropping the post-power-on climb-speed from ~45°/s to ~11°/s on the CoreS3 + SCS0009 hardware.
- The 100 ms post-settle `vTaskDelay` margin is unchanged, so total boot-init takes ~4.1 s instead of ~1.1 s before the first MCP command can be served.
- Refs #121 (Problem 2 only — climb speed). The separate "unintended downward drop on power-on" observation (#121 Problem 1 / hypotheses 1–3) is **out of scope** for this PR; it requires serial-log capture of the boot pre-init `ReadPos` values (the primitives for which are added in PR #124).

## Motivation

On-device feedback during the 2026-05-15 #118 re-verification session identified the original 1000 ms boot-init duration as startling — perceived audibly as "ブルンっ" / servo stress, and visually as too-fast a climb to the fall-safe neutral pose. The 1000 ms timing inherited the `mongonta0716/stackchan-arduino` precedent of a 1-second `WritePos` + 1-second `vTaskDelay` boot sequence, which works well at small starting-pose deltas but is felt as aggressive on the full pitch range (0..45°) that the #117 boot-init can exercise after a push-down + power-cycle.

A 4 second duration brings the angular rate down to ~11°/s, well inside what M5Stack-recommended motion settings consider comfortable for the SCS0009 on this chassis, while remaining short enough that the boot-init still completes before the device's WebSocket handshake to the gateway is established.

## Implementation

Single-constant change, plus a multi-line comment explaining the rationale and scope:

```cpp
// firmware/main/boards/stackchan/stackchan.cc

// Issue #121: at the original 1000 ms duration the
// post-power-on climb to 45° produced ~45°/s angular speed,
// perceived on-device as startling ("ブルンっ" + audible
// stress). Bumping the interpolated move to 4000 ms drops
// the effective rate to ~11°/s while keeping the motion
// monotonic through the existing `WriteHeadAngles` ->
// `servo_motion` task path. The 100 ms post-settle margin
// is unchanged. This is the cheap fix for #121 Problem 2;
// the separate "unintended downward drop on power-on"
// (#121 Problem 1 / hypotheses 1-3) still requires a
// root-cause investigation tracked separately.
constexpr uint32_t BOOT_INIT_MOVE_MS = 4000;
```

No other changes to control flow, safety guards, or interpolation logic — the existing `WriteHeadAngles` -> `servo_motion` task path handles the longer duration identically.

## Relationship with PR #124

- PR #124 (`fix(firmware): #123 distinguish get_head_angles ReadPos transient failure from bus hang`) is **independent**. It adds retry-aware `get_head_angles` and boot-init pre/post `ReadPos` logging. It does not touch `BOOT_INIT_MOVE_MS`.
- Either PR can merge first. Whichever lands first becomes a no-op for the unrelated lines in the second PR's diff.
- The boot-init pre/post `ReadPos` logs added by PR #124 will become the primary diagnostic for #121 Problem 1 root-cause once flashed with both PRs merged.

## Test plan

- [ ] CI: firmware build succeeds.
- [ ] CI: gateway test passes (no gateway changes, expected pass).
- [ ] On-device verification (post-flash, follow-up):
  - [ ] Power-cycle the device after firmware flash; observe the boot-init climb. Expectation: motion feels smooth, ~4 seconds duration, no "ブルンっ"-magnitude servo stress in the climb phase. (The brief downward twitch from #121 Problem 1 at torque-restoration is expected to remain present until that issue's separate root-cause work lands.)
  - [ ] Post-boot `get_head_angles` returns `{"yaw":N, "pitch":N}` with `pitch ≈ 45 ± 2°` (criterion preserved from #117).
  - [ ] Normal `move_head` operation continues to work afterwards (no regression on the user-driven motion path).
