### PR TITLE
docs: #122 cross-platform serial port hints in flash instructions

### DIFF
--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -115,6 +115,10 @@ jobs:
             ### Quick flash (clean install — resets NVS / Wi-Fi config)
 
             ```bash
+            # Replace --port with your platform's serial device:
+            #   macOS:   /dev/cu.usbmodem* (e.g. /dev/cu.usbmodem1101)
+            #   Linux:   /dev/ttyUSB0 or /dev/ttyACM0
+            #   Windows: COM3 (or whichever it shows up as in Device Manager)
             esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
               write_flash 0x0 merged-binary.bin
             ```
@@ -122,6 +126,10 @@ jobs:
             ### App-only update (preserves NVS — keeps your Wi-Fi setup)
 
             ```bash
+            # Replace --port with your platform's serial device:
+            #   macOS:   /dev/cu.usbmodem* (e.g. /dev/cu.usbmodem1101)
+            #   Linux:   /dev/ttyUSB0 or /dev/ttyACM0
+            #   Windows: COM3 (or whichever it shows up as in Device Manager)
             esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
               write_flash 0x20000 xiaozhi.bin
             ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -77,6 +77,11 @@
 [Releases ページ](https://github.com/kisaragi-mochi/stackchan-mcp/releases) から最新の `firmware-v*` リリースを開き、`merged-binary.bin`（必要なら `xiaozhi.bin` も）をダウンロード。あとは `esptool.py` で焼くだけ:
 
 ```bash
+# --port は使っている OS のシリアルデバイス名に置き換えてください:
+#   macOS:   /dev/cu.usbmodem* (例: /dev/cu.usbmodem1101)
+#   Linux:   /dev/ttyUSB0 または /dev/ttyACM0
+#   Windows: COM3 (デバイスマネージャに表示されるポート名)
+
 # 新規インストール（NVS が消えるので Wi-Fi 設定はやり直し）:
 esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 merged-binary.bin
@@ -98,6 +103,8 @@ docker run --rm --ulimit nofile=65536:65536 \
 # → releases/v2.2.6_stackchan.zip
 
 # フラッシュ (CoreS3 を USB 接続後)
+# --port は使っている OS のシリアルデバイス名に置き換えてください
+# — オプション A の表（macOS/Linux/Windows）を参照
 esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 build/merged-binary.bin
 ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ There are two paths. **Option A** is recommended for first-time users — no too
 Download the latest firmware bundle from the [Releases page](https://github.com/kisaragi-mochi/stackchan-mcp/releases) — pick the most recent `firmware-v*` release and grab `merged-binary.bin` (and optionally `xiaozhi.bin`). Then flash with `esptool.py`:
 
 ```bash
+# Replace --port with your platform's serial device:
+#   macOS:   /dev/cu.usbmodem* (e.g. /dev/cu.usbmodem1101)
+#   Linux:   /dev/ttyUSB0 or /dev/ttyACM0
+#   Windows: COM3 (or whichever it shows up as in Device Manager)
+
 # Clean install (resets NVS — Wi-Fi settings will need to be re-entered):
 esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 merged-binary.bin
@@ -97,7 +102,9 @@ docker run --rm --ulimit nofile=65536:65536 \
   python ./scripts/release.py stackchan
 # → releases/v2.2.6_stackchan.zip
 
-# Flash (after USB-connecting the CoreS3)
+# Flash (after USB-connecting the CoreS3).
+# Replace --port with your platform's serial device — see the Option A
+# note above for the macOS/Linux/Windows mapping.
 esptool.py --chip esp32s3 --port /dev/cu.usbmodem1101 -b 460800 \
   write_flash 0x0 build/merged-binary.bin
 ```


### PR DESCRIPTION
## Summary

Add macOS/Linux/Windows serial port mapping notes to the documented esptool snippets so non-macOS users can adapt the examples without guessing the right port path.

- `README.md` Option A snippet: 4-line port hint added at the top of the bash block, covering both clean-install and app-only-update invocations.
- `README.md` Option B snippet: flash line references the Option A note above (no duplication).
- `README.ja.md`: mirrors the EN change in Japanese (dual-language convention).
- `.github/workflows/firmware-release.yml`: both Quick flash and App-only update blocks in the default GitHub Release body carry the same hint, so every future `firmware-v*` Release page surfaces it.

The concrete macOS example (`/dev/cu.usbmodem1101`) is preserved as the visible default — the hint is additive, no change to the most-likely-copy-pasted command.

## Why

External bug reporter on #110 (Pi 4 gateway operator on Linux) hit this gap when receiving a build-from-source workaround. The post-yank retraction comment on the same Issue surfaced the same friction point. Docs currently show only the macOS form (`/dev/cu.usbmodem1101`), with no in-doc hint pointing at Linux / Windows conventions.

## Validation

- [x] `README.md` flash snippets carry the cross-platform port hint at each block.
- [x] `README.ja.md` mirrors the change in Japanese.
- [x] `.github/workflows/firmware-release.yml` default release body includes the hint in both snippets.
- [x] Pre-PR codex review (standard, base=main): no findings.
- [x] Self-check: no personal IP / absolute paths / `.env` / verbatim quote / persona leak in diff.
- [ ] Workflow body rendering check: recommended via a `workflow_dispatch` smoke run before the next `firmware-v*` tag.

## Out of scope

- Board-specific READMEs under `firmware/main/boards/*/` (upstream xiaozhi-esp32 content, divergence would complicate future subtree pulls).
- Replacing concrete examples with `<port>` placeholders everywhere (concrete-example-plus-hint reads better for new users).
- Device-detection / auto-port-discovery scripts (separate feature scope, not docs).

Closes #122