### PR TITLE
docs: #116 fix README provenance attribution for SCServo_lib

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -500,7 +500,7 @@ X 軸 (yaw、`-90..+90°`) には同等のハードウェア制限はなく — 
 
 ### upstream
 
-`firmware/` は [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) のフォーク ([kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32)) を git subtree で取り込んでいます。upstream 同期手順は [`docs/firmware-sync.md`](docs/firmware-sync.md) を参照してください。SCServo_lib は公式 [stack-chan](https://github.com/mongonta0716/stack-chan) (タカヲさん) から移植したファームウェアコンポーネントです。
+`firmware/` は [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) のフォーク ([kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32)) を git subtree で取り込んでいます。upstream 同期手順は [`docs/firmware-sync.md`](docs/firmware-sync.md) を参照してください。`firmware/main/boards/stackchan/` 配下の SCServo_lib ソース (`SCS.{cc,h}`, `SCSCL.{cc,h}`, `SCSerial.{cc,h}`, `INST.h`, `SCServo.h`) は [Feetech](https://www.feetechrc.com/) の SCServo SDK 由来で、同じ `kisaragi-mochi/xiaozhi-esp32` フォークの `main/boards/stackchan/` ディレクトリ経由で firmware subtree merge 時に本リポジトリに取り込まれました。これらは GPL-3.0 のままです (`firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt` 参照)。
 
 ## 関連プロジェクト
 

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ The `gateway/` runs as an independent Python process and only talks to the ESP32
 
 ### upstream
 
-`firmware/` is taken in via git subtree from [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) — specifically the [kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32) fork. See [`docs/firmware-sync.md`](docs/firmware-sync.md) for the upstream sync playbook. SCServo_lib is a firmware component ported from the official [stack-chan](https://github.com/mongonta0716/stack-chan) (Takawo-san) repository.
+`firmware/` is taken in via git subtree from [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) (MIT) — specifically the [kisaragi-mochi/xiaozhi-esp32](https://github.com/kisaragi-mochi/xiaozhi-esp32) fork. See [`docs/firmware-sync.md`](docs/firmware-sync.md) for the upstream sync playbook. The SCServo_lib sources under `firmware/main/boards/stackchan/` (`SCS.{cc,h}`, `SCSCL.{cc,h}`, `SCSerial.{cc,h}`, `INST.h`, `SCServo.h`) originate from [Feetech](https://www.feetechrc.com/)'s SCServo SDK and entered this repository through the same `kisaragi-mochi/xiaozhi-esp32` fork's `main/boards/stackchan/` directory at the firmware subtree merge. They remain GPL-3.0 (see `firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt`).
 
 ## Related projects
 


### PR DESCRIPTION
## Summary

Fix the README provenance attribution for the SCServo_lib sources, as called out in #116.

The previous claim in `README.md` L551 / `README.ja.md` L503 was:

> SCServo_lib is a firmware component ported from the official mongonta0716/stack-chan (Takawo-san) repository.

This is inaccurate. `mongonta0716/stack-chan` is JavaScript / Moddable XS based and does not contain the C++ SCServo_lib files vendored here. The actual chain:

- The 8 files under `firmware/main/boards/stackchan/` (`SCS.{cc,h}`, `SCSCL.{cc,h}`, `SCSerial.{cc,h}`, `INST.h`, `SCServo.h`) originate from Feetech's SCServo SDK.
- They entered this repository via the `kisaragi-mochi/xiaozhi-esp32` fork's `main/boards/stackchan/` directory at the firmware subtree merge (commit `946ce6a`).

`README.md` and `README.ja.md` are updated in sync (dual-language convention). The `mongonta0716/stack-chan` references in the community-origin context (early header lines and the "Related projects" section) are unchanged — those credit the project's philosophical lineage, not the C++ code provenance.

## Scope (intentionally limited)

This addresses **only the README provenance-correction task** of #116. The license re-audit work — Feetech upstream license status verification, relicensing timeline, bit-identity check, Option 1 / 2 / 3 decision — is **deliberately out of scope** and remains tracked by #116. The provenance fix is correct regardless of the eventual license outcome.

## Validation

- [x] `README.md` L551 attribution updated to reflect the actual provenance chain.
- [x] `README.ja.md` L503 mirrors the EN change in Japanese.
- [x] `mongonta0716/stack-chan` references in L7, L42, L557 (EN) / L7, L42, L509 (JP) are unchanged — those credit the philosophical lineage and remain accurate.
- [x] License file path `firmware/main/boards/stackchan/SCServo_lib_LICENSE.txt` confirmed to exist.
- [x] Pre-PR codex adversarial-review (base=main): **verdict: approve, no material findings**. Codex independently verified (a) the subtree merge `946ce6a` introduces the 8 SCServo_lib files, (b) local file headers and the GPL-3.0 designation align with the updated README wording, and (c) `mongonta0716/stack-chan` is JavaScript / Moddable XS-based and does not contain those C++ files.
- [x] Self-check: no personal IP / absolute paths / `.env` / verbatim quote / persona leak in diff.

## Out of scope

- Feetech upstream license re-audit (tracked in #116).
- `LICENSE` top-level scope table changes (deferred until the license-path decision is made).
- `CONTRIBUTING.md` license-boundary policy update (deferred to #23 / #116 post-decision).

Refs #116