### PR TITLE
fix(firmware): #113 add missing trailing comma in freenove-esp32s3-display-2.8-lcd/config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,19 @@ change is called out under a `Firmware` subsection of the release entry.
   power-on" (#121 Problem 1 / hypotheses 1–3) remains under
   investigation and is unaffected by this change.
 
+- Fixed a missing trailing comma in
+  `firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json`
+  that caused `release.py` to fail to parse the file and silently skip
+  the `sdkconfig_append` entries for the
+  `freenove-esp32s3-display-2.8-lcd` board variant. The variant builds
+  now pick up `CONFIG_LANGUAGE_EN_US=y`,
+  `CONFIG_SR_WN_WN9S_HIESP=y`, and `CONFIG_SR_WN_WN9_HIESP=y` as
+  intended, and the spurious `[ERROR] Failed to parse ...` line is no
+  longer printed during any `release.py` invocation. The default
+  `release.py stackchan` build, which only targets the `stackchan`
+  board, is unaffected. Closes
+  [#113](https://github.com/kisaragi-mochi/stackchan-mcp/issues/113).
+
 ## [0.7.0] - 2026-05-14
 
 ### Gateway

--- a/firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json
+++ b/firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json
@@ -6,7 +6,7 @@
             "sdkconfig_append": [
                 "CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/16m.csv\"",
-                "CONFIG_LANGUAGE_EN_US=y"
+                "CONFIG_LANGUAGE_EN_US=y",
                 "CONFIG_SR_WN_WN9S_HIESP=y",
                 "CONFIG_SR_WN_WN9_HIESP=y"
             ]


### PR DESCRIPTION
## Summary

`firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json` was missing the trailing comma between the third and fourth `sdkconfig_append` entries (after `"CONFIG_LANGUAGE_EN_US=y"`), making the file invalid JSON. `firmware/scripts/release.py` failed to parse it and silently skipped the variant's `sdkconfig_append` block:

```
[ERROR] Failed to parse main/boards/freenove-esp32s3-display-2.8-lcd/config.json: Expecting ',' delimiter: line 10 column 17 (char 338)
```

The default `release.py stackchan` build, which only targets the `stackchan` board, was unaffected — the error only blocked the `freenove-esp32s3-display-2.8-lcd` variant. Any build of that specific variant produced an image that did not enable its declared `CONFIG_LANGUAGE_EN_US=y`, `CONFIG_SR_WN_WN9S_HIESP=y`, and `CONFIG_SR_WN_WN9_HIESP=y` overrides.

This PR adds the trailing comma, so the file parses cleanly under `python -m json.tool`, the spurious parse-error log line disappears, and the `freenove-esp32s3-display-2.8-lcd` variant picks up its three declared overrides during `release.py` builds.

A matching entry has been added under `CHANGELOG.md` `[Unreleased]` / `Firmware`.

## Test plan

### Code-level

- [x] firmware: `python -m json.tool firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json` parses without raising.
- [x] firmware: ran the same `python -m json.tool` parse check across all `main/boards/**/config.json` files in the tree; all 130 files parse cleanly (no other latent JSON syntax errors in board configs).
- [ ] gateway: `uv run pytest` — Not applicable, no gateway changes.
- [ ] gateway: `uv run ruff check .` — Not applicable, no gateway changes.
- [ ] firmware: `python ./scripts/release.py stackchan` — Not run on this PR; the default `stackchan` build was already unaffected by the bug (the error only blocked the `freenove-esp32s3-display-2.8-lcd` variant), and the fix is a single-character JSON syntax correction.

### Hardware

- [ ] Not applicable / hardware not available: this change only affects the `freenove-esp32s3-display-2.8-lcd` board variant. No `freenove-esp32s3-display-2.8-lcd` hardware on hand to do an end-to-end build-and-flash verification. The `stackchan` board (M5Stack CoreS3) build behavior is unchanged by this PR.

## Breaking changes

None. JSON-syntax-only correction; behavior change is scoped to the `freenove-esp32s3-display-2.8-lcd` variant, which now picks up the `sdkconfig_append` entries that were always declared but silently dropped due to the parse failure.

## Related issues

Closes #113.