### PR TITLE
fix(scripts): #131 mask CONFIG_DEFAULT_WEBSOCKET_TOKEN value in release.py stdout

### DIFF
--- a/firmware/scripts/release.py
+++ b/firmware/scripts/release.py
@@ -327,6 +327,14 @@ def _merge_sdkconfig_overrides(*groups: list[str]) -> list[str]:
 
     return [entry for entry in result if entry is not None]
 
+
+def _mask_sdkconfig_append_for_log(entry: str) -> str:
+    """Mask sensitive Kconfig assignment values before printing them."""
+    key, sep, _value = entry.partition("=")
+    if sep and re.search(r"(TOKEN|SECRET|PASSWORD)", key, re.IGNORECASE):
+        return f'{key}="<MASKED>"'
+    return entry
+
 ################################################################################
 # Check board_type in CMakeLists
 ################################################################################
@@ -419,7 +427,7 @@ def release(board_type: str, config_filename: str = "config.json", *, filter_nam
         if local_sdkconfig_append:
             print("local_sdkconfig_defaults: sdkconfig.defaults.local")
         for item in sdkconfig_append:
-            print(f"sdkconfig_append: {item}")
+            print(f"sdkconfig_append: {_mask_sdkconfig_append_for_log(item)}")
 
         os.environ.pop("IDF_TARGET", None)
 


### PR DESCRIPTION
## Summary

- Mask sensitive Kconfig assignment values when release.py echoes sdkconfig_append lines.
- Treat keys containing TOKEN, SECRET, or PASSWORD as sensitive and print them as "<MASKED>".

## Why

- sdkconfig.defaults.local is the documented place for personal CONFIG_DEFAULT_WEBSOCKET_TOKEN values.
- Build logs should not expose those token values when troubleshooting output is shared.

## Test plan

- PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile firmware/scripts/release.py
- Added a temporary CONFIG_DEFAULT_WEBSOCKET_TOKEN="example-token" to firmware/sdkconfig.defaults.local, ran the release.py echo path without a Docker build, and confirmed stdout contains CONFIG_DEFAULT_WEBSOCKET_TOKEN="<MASKED>" but not example-token.
- Confirmed empty TOKEN values and SECRET/PASSWORD keys are masked by direct helper assertions.
- git diff --check
- Codex companion review --base main --wait
- No firmware/scripts Python tests are present.

## Refs

Closes #131
