### PR TITLE
fix(firmware): #121 snap-suppress boot WritePos to stop SCS0009 power-on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,39 @@ change is called out under a `Firmware` subsection of the release entry.
   board, is unaffected. Closes
   [#113](https://github.com/kisaragi-mochi/stackchan-mcp/issues/113).
 
+- Added a boot-time snap-suppress hold to `InitializeServo()` to
+  mitigate the [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
+  Problem 1 "downward drop on power-on" symptom. Immediately after the
+  existing pre-init `ReadPos` diagnostic, the firmware now issues a
+  `WritePos(id, current_pos, time=0, speed=0)` per servo, which the
+  SCS0009 treats as a new target equal to its current position and uses
+  to truncate any in-progress "snap-to-last-target" motion. Background:
+  the SCS0009 retains its commanded set-point across power cycles
+  (Hypothesis 1 in #121, confirmed by the firmware-v1.4.1 clean-install
+  reproduction in which `Boot pre-init ReadPos` still matched the
+  pre-power-off pose exactly after a full NVS reset on the ESP32 side,
+  demonstrating the set-point lives in the servo itself). When `VM_EN`
+  asserts at hardware power-on the servo restores torque and snaps
+  toward that retained target before any firmware-side speed limiting
+  can apply, audible as a mechanical end-stop impact when the previous
+  session ended near `pitch=0°`. Efficacy is observable in the serial
+  log via new `Boot snap-suppress yaw/pitch hold(pos=...): r=...`
+  lines; if `ReadPos` already captured an end-stop position the hold is
+  a no-op for that boot and a deeper fix (e.g. firmware-controlled
+  `VM_EN` sequencing through the PY32 IO-expander) would be required,
+  tracked separately. The pitch hold is additionally gated on the
+  `ReadPos` raw value falling inside the same `SAFE_PITCH_MIN..
+  SAFE_PITCH_MAX` range as every other pitch servo-write boundary in
+  the firmware: out-of-range reads (e.g. the head was hand-pushed past
+  an end-stop pre-boot, or the previous session's set-point fell
+  outside the safe range) skip the hold and let the subsequent
+  interpolating boot-init climb to `(yaw=0°, pitch=45°)` drive the
+  head back into the safe range through the existing speed-limited
+  path, instead of pinning the servo against an out-of-range raw
+  position. Refs
+  [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
+  Problem 1.
+
 ## [0.7.0] - 2026-05-14
 
 ### Gateway

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -1090,16 +1090,111 @@ private:
                 return;
             }
 
-            // Issue #123: log boot-init pre-WritePos position with tick so
-            // the "unintended downward drop on power-on" (#121 hypothesis 1/2)
-            // becomes data-driven. ServoTask has not been created yet, so no
-            // scs_bus_mutex_ contention is possible at this point.
-            int yaw_pos_actual = scs_bus_.ReadPos(SERVO_YAW_ID);
+            // Issue #121 (Problem 1, "downward drop on power-on") + #123
+            // (boot-init diagnostics).
+            //
+            // Background: the SCS0009 retains its commanded set-point
+            // across power cycles (Hypothesis 1 in #121, confirmed by
+            // the firmware-v1.4.1 clean-install reproduction -- after a
+            // full NVS reset on the ESP32 side, the boot pre-init
+            // `ReadPos` still matched the pre-power-off pose exactly,
+            // demonstrating the set-point lives in the servo itself,
+            // not in firmware-side NVS). When VM_EN asserts at boot,
+            // the servo restores torque and snaps toward that retained
+            // target before any firmware-side speed limiting can apply
+            // -- audible as a mechanical end-stop impact when the
+            // previous session ended near pitch=0, and visible as a
+            // downward drop in general.
+            //
+            // The mitigation is a `WritePos(id, current_pos, time=0,
+            // speed=0)` per servo, which the SCS0009 treats as a new
+            // target equal to its current position. This interrupts any
+            // in-progress snap motion and leaves the servo stationary
+            // at the raw position the immediately-preceding `ReadPos`
+            // observed, until the subsequent interpolating boot-init
+            // climb begins.
+            //
+            // Efficacy depends on the `ReadPos` + `WritePos` pair
+            // completing while the servo is still mid-snap. To minimize
+            // that window, pitch (the only axis that exhibits the
+            // downward drop) is read AND held BEFORE the yaw axis is
+            // touched on the SCS0009 bus -- any yaw `ReadPos` /
+            // `WritePos` / ACK wait interposed between the pitch
+            // `ReadPos` and pitch `WritePos` would widen the window
+            // and risk the snap completing into an end-stop before the
+            // pitch hold reaches the servo. The unified "Boot pre-init
+            // ReadPos" diagnostic line (#123) is emitted after both
+            // holds because it is purely informational and not on the
+            // timing-critical path. If a `ReadPos` value lands close
+            // to a previous session's commanded target (e.g. raw pitch
+            // near 620 for pitch=0 deg), the snap was likely still in
+            // progress and the hold is expected to truncate it; if a
+            // `ReadPos` value is already at an end-stop or fails, the
+            // hold for that boot is a no-op or skipped and a deeper
+            // fix (e.g. firmware-controlled VM_EN sequencing through
+            // the PY32 IO-expander) would be required, tracked
+            // separately.
+
+            // Phase 1a: pitch first -- read and immediately hold.
             int pitch_pos_actual = scs_bus_.ReadPos(SERVO_PITCH_ID);
+            if (pitch_pos_actual >= 0) {
+                // Bound the snap-suppress hold to the SAFE_PITCH_MIN..
+                // SAFE_PITCH_MAX range applied at every other pitch
+                // servo-write boundary in this file (see PitchDegToPos
+                // and the Phase 2 restored_pitch clamp below). If the
+                // boot `ReadPos` lands outside that range -- for example
+                // because the servo bus came back online holding a
+                // previous session's out-of-range set-point, or the
+                // head was hand-pushed beyond an end-stop -- writing
+                // the raw position back would bypass that safety
+                // boundary and pin the servo against the stall current
+                // it is held there from. In that case skip the hold
+                // and let the subsequent interpolating boot-init climb
+                // to (yaw=0, pitch=45) drive the head back into the
+                // safe range through the existing speed-limited path.
+                constexpr int PITCH_SAFE_RAW_MIN =
+                    620 + SAFE_PITCH_MIN * 16 / 5;  // raw 620 at deg=0
+                constexpr int PITCH_SAFE_RAW_MAX =
+                    620 + SAFE_PITCH_MAX * 16 / 5;  // raw 901 at deg=88
+                if (pitch_pos_actual >= PITCH_SAFE_RAW_MIN &&
+                    pitch_pos_actual <= PITCH_SAFE_RAW_MAX) {
+                    int pitch_hold_r = scs_bus_.WritePos(
+                        SERVO_PITCH_ID, pitch_pos_actual, 0, 0);
+                    ESP_LOGI(TAG,
+                             "Boot snap-suppress pitch hold(pos=%d): r=%d",
+                             pitch_pos_actual, pitch_hold_r);
+                } else {
+                    ESP_LOGW(TAG,
+                             "Boot snap-suppress pitch skipped: ReadPos=%d outside safe raw range [%d, %d]; relying on boot-init climb",
+                             pitch_pos_actual,
+                             PITCH_SAFE_RAW_MIN, PITCH_SAFE_RAW_MAX);
+                }
+            }
+
+            // Phase 1b: yaw second -- no analogous snap-into-end-stop
+            // failure mode, so timing is not critical.
+            int yaw_pos_actual = scs_bus_.ReadPos(SERVO_YAW_ID);
+            if (yaw_pos_actual >= 0) {
+                int yaw_hold_r = scs_bus_.WritePos(
+                    SERVO_YAW_ID, yaw_pos_actual, 0, 0);
+                ESP_LOGI(TAG,
+                         "Boot snap-suppress yaw hold(pos=%d): r=%d",
+                         yaw_pos_actual, yaw_hold_r);
+            }
+
+            // Phase 1c (diagnostic, #123): unified pre-init ReadPos log
+            // with tick timestamp. Off the timing-critical path
+            // intentionally; ServoTask has not been created yet, so no
+            // `scs_bus_mutex_` contention is possible at this point.
             ESP_LOGI(TAG,
                      "Boot pre-init ReadPos: yaw_raw=%d pitch_raw=%d tick=%u",
                      yaw_pos_actual, pitch_pos_actual,
                      (unsigned)xTaskGetTickCount());
+
+            // Phase 2: software-side current_deg restore. Order does not
+            // affect the SCS0009 bus -- these only update firmware-side
+            // motion state for the upcoming interpolating boot-init
+            // climb.
             if (yaw_pos_actual >= 0) {
                 yaw_motion_.current_deg = (yaw_pos_actual - 460) * 5 / 16;
                 ESP_LOGI(TAG, "Restored yaw_motion_.current_deg=%d from ReadPos=%d",


### PR DESCRIPTION
## Summary

Add a boot-time snap-suppress hold WritePos pair in `InitializeServo()` to mitigate the "downward drop on power-on" symptom tracked as #121 Problem 1.

This is a **partial mitigation** — it catches snap motion when the SCS0009 bus is responsive at boot time, but is intentionally skipped (with diagnostic logging) when the bus is in the post-`VM_EN` startup-latency window or hung, so that out-of-range positions are never written back. The full PMIC OFF/ON path requires the follow-up `ReadPos` retry + safe `current_deg` fallback tracked in #138.

## Background

The SCS0009 retains its commanded set-point across power cycles (Hypothesis 1 in #121, confirmed by the firmware-v1.4.1 clean-install reproduction: after a full NVS reset on the ESP32 side, the boot pre-init `ReadPos` still matched the pre-power-off pose exactly, demonstrating the set-point lives in the servo itself, not in firmware-side NVS).

When `VM_EN` asserts at hardware power-on, the servo restores torque and snaps toward that retained target before any firmware-side speed limiting can apply — audible as a mechanical end-stop impact when the previous session ended near `pitch=0` (#121 Problem 1, originally surfaced during the #117 real-device verification recorded in #118).

## Change

Immediately after the existing pre-init `ReadPos` diagnostic, issue `WritePos(id, current_pos, time=0, speed=0)` per servo. The SCS0009 treats this as "new target equal to current position" and uses it to truncate any in-progress snap motion.

Two safeguards:

1. **Pitch first, yaw second.** Pitch is the only axis that exhibits the downward drop. Pitch is read AND held BEFORE yaw is touched on the SCS0009 bus, so yaw's `ReadPos` / `WritePos` / ACK wait cannot delay pitch's hold. The unified "Boot pre-init ReadPos" diagnostic line is emitted AFTER both holds for the same reason.

2. **Safe-range gating on pitch.** The pitch hold is gated on the `ReadPos` raw value falling inside `SAFE_PITCH_MIN..SAFE_PITCH_MAX` (raw `[620, 901]`, matching `PitchDegToPos`'s clamp boundary). Out-of-range reads skip the hold and let the subsequent interpolating boot-init climb to `(yaw=0, pitch=45)` drive the head back into the safe range, instead of pinning the servo against an out-of-range position.

## When this works vs when it is intentionally skipped

| Scenario | What happens | Hold behavior |
|---|---|---|
| ESP32-only reset (`esptool` hard-reset, ServoTask reload after disconnect) — VM_EN stays HIGH | Servo torque is never released; no snap motion occurs. | Hold WritePos issues; ACK `r=0`. Effectively a no-op since the servo is already at position, but the path is exercised. |
| PMIC long-press OFF / ON — VM_EN cycles LOW → HIGH | Servo wakes up from cold; observed `~200 ms` of bus startup latency where both `ReadPos` and `WritePos` return `-1`. If `Boot pre-init ReadPos` lands inside that window, the hold is skipped by the `ReadPos >= 0` gate. | Hold is intentionally skipped — no unknown / out-of-range WritePos is issued. |

The PMIC OFF/ON path is the original #121 Problem 1 scenario and is **not fully solved by this PR alone**. The follow-up #138 tracks `ReadPos` retry on boot (to absorb the startup-latency window) and a safe `current_deg` fallback (to prevent `ServoTask`'s default `current_deg=0` start point from causing end-stop-direction WritePos calls when `ReadPos` ultimately fails).

## Test plan

### Code-level

- [x] firmware: `python ./scripts/release.py stackchan` (`xiaozhi.bin` size `0x2cde10`, 29% partition free)
- [ ] gateway: `uv run pytest` — not applicable (firmware-only change)
- [ ] gateway: `uv run ruff check .` — not applicable

### Hardware

ESP32 hard-reset path (verified, `CONFIG_STACKCHAN_SERVO_FEETECH=y`):

```
I (1465) Servo bus init: OK (Level=1, ACK enabled)
I (1465) Boot snap-suppress pitch hold(pos=762): r=0
I (1475) Boot snap-suppress yaw hold(pos=464): r=0
I (1475) Boot pre-init ReadPos: yaw_raw=464 pitch_raw=762 tick=134
I (1485) Restored yaw_motion_.current_deg=1 from ReadPos=464
I (1495) Restored pitch_motion_.current_deg=44 from ReadPos=762 (clamped to safe range 0..88)
I (5605) Boot-time servo init complete: target yaw=0 pitch=45 (move=4000ms),
                                         post-ReadPos: yaw_raw=464 pitch_raw=762,
                                         elapsed_ms=4100
```

- [x] Both holds issue with `r=0` (SCS0009 ACK success)
- [x] Pitch safe-range gate accepts raw 762 (∈ `[620, 901]`)
- [x] Pitch hold emitted before yaw hold (timing-critical order)
- [x] Diagnostic `Boot pre-init ReadPos` emitted after holds (off timing-critical path)
- [x] Post-climb `post-ReadPos` shows `yaw≈0°`, `pitch≈44°` (within ±2° of boot-init target)
- [x] Device boots without crash; existing `get_head_angles` MCP tool returns valid raw values after climb
- [ ] Existing `move_head`, `take_photo`, `set_volume` tools — not re-verified this session (unaffected code paths)

PMIC long-press OFF/ON path (skip-path verified). Setup: head deliberately moved to `{yaw≈0, pitch=10}` (raw 463 / 652), then CoreS3 power-button 6 s long-press → short-press. Head held by hand at `pitch≈45°` during power-on for `~5 s` to prevent end-stop contact during this verification.

```
I (1275) Servo power ENABLED via PY32 pin 0 (VM EN HIGH confirmed)
I (1495) Servo bus init: OK
I (1535) Boot pre-init ReadPos: yaw_raw=-1 pitch_raw=-1 tick=140
W (1535) Failed to ReadPos(yaw); current_deg stays at 0
W (1535) Failed to ReadPos(pitch); current_deg stays at 0
W (1585) Motion pitch WritePos failed: r=-1 (deg=0, pos=620)
W (1635) Motion pitch WritePos failed: r=-1 (deg=0)
W (1685) Motion pitch WritePos failed: r=-1 (deg=1)
   ... (~350 ms of WritePos r=-1 from the ServoTask interpolator) ...
I (5635) Boot-time servo init complete: target yaw=0 pitch=45 (move=4000ms),
                                         post-ReadPos: yaw_raw=462 pitch_raw=760,
                                         elapsed_ms=4100
```

- [x] `Boot pre-init ReadPos` ran at tick 140 ms (inside the SCS0009 startup-latency window) and returned `-1` for both axes
- [x] Snap-suppress holds both skipped by the `ReadPos >= 0` gate (no `Boot snap-suppress ... hold(pos=N): r=N` lines emitted for this boot)
- [x] Subsequent `WriteHeadAngles(0, 45, 4000)` `WritePos` failed with `r=-1` for `~350 ms`, then succeeded as the SCS0009 came online
- [x] Post-climb `post-ReadPos` shows raw `462 / 760` — bus self-recovered as soon as `WritePos` started succeeding
- [x] No `Boot snap-suppress pitch skipped: ReadPos=N outside safe raw range [620, 901]` line was triggered this session (would fire when `ReadPos` succeeds but lands outside `[620, 901]`)

Driver coverage:

- [x] `CONFIG_STACKCHAN_SERVO_FEETECH=y` (MIT default driver)
- [ ] `CONFIG_STACKCHAN_SERVO_SCSCL` (GPL opt-in driver) — same call path, not exercised this session

## Pre-PR codex review

4 rounds of `codex-companion review --base main --wait`. P2 findings addressed across rounds:

1. The initial pitch hold wrote the raw `ReadPos` value back, bypassing `PitchDegToPos`'s `SAFE_PITCH_MIN..SAFE_PITCH_MAX` clamp. Fixed by gating the hold on the raw value falling inside `[620, 901]`; out-of-range reads skip the hold.
2. The first ordering attempt issued yaw's `ReadPos` + `WritePos` (and the unified diagnostic log) before pitch's hold, widening the window in which pitch could still be mid-snap toward an end-stop. Reordered to pitch-first.
3. Even after reordering hold-issuance, the second draft still did `ReadPos(YAW)` and the diagnostic log between `ReadPos(PITCH)` and `WritePos(PITCH)`. Restructured to phases: `ReadPos(PITCH)` → pitch hold, then `ReadPos(YAW)` → yaw hold, then the diagnostic log (off the timing-critical path), then current_deg restore.
4. Clear: "差分は起動時のサーボ保持処理と変更履歴の追加に限られており、既存の初期化フローや安全範囲との整合を崩す明確な不具合は見当たりませんでした。"

## License boundary

Touches only `firmware/main/boards/stackchan/stackchan.cc` (MIT). The GPL-3.0 SCServo_lib files in the same directory are not modified.

## Breaking changes

None. New WritePos hold calls and ESP_LOGI lines are additive in `InitializeServo()`; existing behavior is preserved when the holds either succeed or skip.

## Related issues

- Refs #121 (Problem 1 only; Problem 2 climb-speed was addressed in PR #125)
- Builds on PR #117 (boot-init pose, #115) and PR #124 (pre-init `ReadPos` diagnostic, #123)
- Related: #138 (follow-up) — `ReadPos` retry on boot + safe `current_deg` fallback to address the PMIC OFF/ON path
- Related: #100 (SCS0009 bus hang)
- Related: #102 (Tailscale TLS handshake intermittent fail — observed during this PR's verification session)
