### PR TITLE
feat(firmware): #143 introduce MotionDriver abstraction + opt-in servo-delegated motion path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Added a `MotionDriver` abstraction for StackChan servo motion and an
+  opt-in `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION` path that delegates
+  move timing to the SCS0009 via single-shot `WritePos(..., time, 0)`
+  commands plus `ReadMove()` polling, while keeping the existing
+  host-interpolation path as the default fallback. The MCP tool surface
+  is unchanged; this prepares real-device validation of the delegated
+  path for
+  [#143](https://github.com/kisaragi-mochi/stackchan-mcp/issues/143).
+
 - Fixed user-configured WebSocket gateway URLs (e.g.
   `ws://192.168.x.y:8765`) being silently overwritten on every boot by
   the upstream xiaozhi OTA-config response. `Ota::CheckVersion()` still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,27 @@ change is called out under a `Firmware` subsection of the release entry.
   opt-in `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION` path that delegates
   move timing to the SCS0009 via single-shot `WritePos(..., time, 0)`
   commands plus `ReadMove()` polling, while keeping the existing
-  host-interpolation path as the default fallback. The MCP tool surface
-  is unchanged; this prepares real-device validation of the delegated
-  path for
+  host-interpolation path as the default fallback (default `n`). The
+  MCP tool surface is unchanged. Real-device verification on
+  M5Stack CoreS3 + SCS0009 ×2 shows the delegated path substantially
+  mitigates the bus-hang surface historically tracked under
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100):
+  single-axis large-angle reversals, two-axis moves with mid-range
+  pitch from a clean state, and pitch-only large-angle reversals
+  (including end-stop proximity) all complete cleanly. A residual hang
+  trigger requiring two-axis simultaneous dispatch combined with either
+  pitch end-stop proximity or cumulative session load remains;
+  mitigations are split to
+  [#147](https://github.com/kisaragi-mochi/stackchan-mcp/issues/147) /
+  [#148](https://github.com/kisaragi-mochi/stackchan-mcp/issues/148) /
+  [#149](https://github.com/kisaragi-mochi/stackchan-mcp/issues/149).
+  A related boot-init `current_deg` mismatch corner case after PMIC
+  OFF/ON is tracked under
+  [#150](https://github.com/kisaragi-mochi/stackchan-mcp/issues/150).
+  Default flip is deferred to a subsequent release after these
+  mitigations land. The `position_unknown` sentinel detects and reports
+  any residual trip on the firmware side; recovery still requires
+  PMIC OFF/ON. Refs
   [#143](https://github.com/kisaragi-mochi/stackchan-mcp/issues/143).
 
 - Fixed user-configured WebSocket gateway URLs (e.g.

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1096,6 +1096,14 @@ choice STACKCHAN_SERVO_DRIVER
             period. Scheduled for removal in Phase B of the migration.
 endchoice
 
+config STACKCHAN_SERVO_DELEGATED_MOTION
+    bool "Use SCS0009 delegated motion timing"
+    default n
+    help
+        Enable the Issue #143 motion path that sends one WritePos command
+        per requested move and polls ReadMove for completion. When disabled,
+        the firmware keeps the existing host-side interpolation loop.
+
 endif # BOARD_TYPE_STACKCHAN
 
 endmenu

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -601,7 +601,6 @@ private:
     bool si12t_ok_ = false;
     esp_timer_handle_t touch_poll_timer_ = nullptr;
     esp_timer_handle_t touch_revert_timer_ = nullptr;
-    esp_timer_handle_t servo_wobble_timer_ = nullptr;
 
     // Touch detection state (single-thread access from the touch_poll_timer_
     // callback, which runs on the ESP_TIMER_TASK).
@@ -620,31 +619,68 @@ private:
     // Servo wobble sub-state. Keeps the previously-set angles untouched
     // before/after the wobble so that an external set_head_angles call is
     // not silently overwritten beyond the wobble window.
-    int servo_wobble_step_ = 0;       // 0..3 sequence index
-    bool servo_wobble_active_ = false;
+    std::atomic<int> servo_wobble_step_{0};       // 0..3 sequence index
+    std::atomic<bool> servo_wobble_active_{false};
 
-    // Issue #1: Servo motion task — interpolate WritePos to avoid SCS0009 bus
-    // collisions on large-angle reversals. A dedicated FreeRTOS task ticks at
-    // MOTION_TICK_MS, walks current_deg → target_deg over move_duration_ms, and
-    // issues short MOTION_PER_WRITE_TIME_MS WritePos commands so the servo never
-    // receives a discontinuous jump.
+    // Shared motion state. This stays on the board singleton because boot-init
+    // ReadPos restore / re-sync phases seed the same state before and after the
+    // concrete MotionDriver is selected. Drivers only borrow these references.
     struct AxisMotion {
         int target_deg = 0;
         int start_deg = 0;
         int current_deg = 0;
         uint32_t move_start_ms = 0;
+        // For the delegated driver: time the WritePos for this request
+        // was successfully ACK'd by the servo (i.e. when the physical
+        // motion actually began on the SCS0009's internal clock). May
+        // be later than move_start_ms when the dispatch is delayed by
+        // Tick wake or retry rounds. ApplyReadMoveResult's stuck-high
+        // timeout is measured from dispatch_start_ms, not from staging,
+        // so that degraded-bus latency does not cause premature force-
+        // clear while the servo is genuinely still mid-motion. 0 means
+        // "not yet dispatched"; ApplyReadMoveResult skips the
+        // stuck-high check until dispatch_start_ms is populated by
+        // FinishDispatch's write_ok branch. HostInterpolation path
+        // does not consult this field.
+        uint32_t dispatch_start_ms = 0;
         uint32_t move_duration_ms = 0;
         bool moving = false;
+        // Monotonic counter incremented by ServoDelegatedMotionDriver::
+        // StartMove on each dispatch stage. Used by Tick() to detect
+        // when a newer StartMove has raced in between the snapshot at
+        // the top of Tick() and the post-WritePos / post-ReadMove
+        // commit (motion_mutex_ is dropped while the bus operation
+        // runs). esp_timer_get_time()/1000 has 1 ms resolution and is
+        // not unique enough on its own — two StartMove calls within
+        // the same millisecond would collide on move_start_ms. The
+        // HostInterpolation path does not consult this field; the
+        // monotonic counter is owned by the delegated driver.
+        uint64_t request_token = 0;
+        // Set by the delegated driver when ApplyReadMoveResult's
+        // 5-consecutive-failure force-clear fires: WritePos ACK
+        // confirmed the servo received the command, but ReadMove
+        // polling never observed completion. current_deg holds the
+        // last optimistic commit (the requested target), but the
+        // physical head may be mid-trajectory or at the wrong angle.
+        // The next StartMove on this axis treats position_unknown as
+        // a "force re-dispatch" signal (no-op skip is suppressed),
+        // so a same-target retry surfaces the failure rather than
+        // hiding it behind a stale-but-equal current_deg. The
+        // HostInterpolation path does not consult this field.
+        bool position_unknown = false;
     };
+    class MotionDriver;
     // TODO: motion_mutex_/scs_bus_mutex_/servo_task_handle_ have no destroy path; board is singleton via DECLARE_BOARD.
     AxisMotion yaw_motion_;
     AxisMotion pitch_motion_;
     SemaphoreHandle_t motion_mutex_ = nullptr;     // protects AxisMotion fields
     SemaphoreHandle_t scs_bus_mutex_ = nullptr;    // serializes UART access (WritePos/ReadPos)
+    std::unique_ptr<MotionDriver> motion_driver_;
     TaskHandle_t servo_task_handle_ = nullptr;
     static constexpr uint32_t MOTION_TICK_MS = 20;
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
+    static constexpr uint32_t MOTION_POLL_INTERVAL_MS = 50;
 
     // Issue #80 / #98: pitch is guarded by two complementary tiers.
     //
@@ -789,6 +825,695 @@ private:
         if (pos > 1000) pos = 1000;
         return pos;
     }
+
+    static uint16_t clamp_u16(uint32_t v) {
+        if (v > std::numeric_limits<uint16_t>::max()) {
+            return std::numeric_limits<uint16_t>::max();
+        }
+        return static_cast<uint16_t>(v);
+    }
+
+    class MotionDriver {
+    public:
+        virtual ~MotionDriver() = default;
+
+        // Non-blocking. Both axes are dispatched within a single call.
+        // WriteHeadAngles holds motion_mutex_ while calling this method; Tick()
+        // and getters take the mutex internally for their own state access.
+        virtual void StartMove(float yaw_deg, float pitch_deg,
+                               uint32_t duration_ms) = 0;
+
+        // Last-known committed angle for each axis.
+        virtual float GetYawDeg() const = 0;
+        virtual float GetPitchDeg() const = 0;
+
+        // True iff at least one axis is currently in motion.
+        virtual bool IsMoving() const = 0;
+
+        // Called from ServoTask body at a driver-dependent cadence.
+        virtual void Tick() = 0;
+
+        // Optional hooks for drivers that need setup or shutdown.
+        virtual bool Initialize() { return true; }
+        virtual void Shutdown() {}
+    };
+
+    class HostInterpolationMotionDriver final : public MotionDriver {
+    public:
+        HostInterpolationMotionDriver(ScsBus& scs_bus,
+                                      SemaphoreHandle_t& scs_bus_mutex,
+                                      SemaphoreHandle_t& motion_mutex,
+                                      AxisMotion& yaw_motion,
+                                      AxisMotion& pitch_motion)
+            : scs_bus_(scs_bus),
+              scs_bus_mutex_(scs_bus_mutex),
+              motion_mutex_(motion_mutex),
+              yaw_motion_(yaw_motion),
+              pitch_motion_(pitch_motion) {}
+
+        void StartMove(float yaw_deg, float pitch_deg,
+                       uint32_t duration_ms) override {
+            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+            int yaw = static_cast<int>(yaw_deg);
+            int pitch = static_cast<int>(pitch_deg);
+
+            yaw_motion_.target_deg = yaw;
+            yaw_motion_.start_deg = yaw_motion_.current_deg;
+            yaw_motion_.move_start_ms = now_ms;
+            yaw_motion_.move_duration_ms = duration_ms;
+            yaw_motion_.moving = (yaw_motion_.target_deg != yaw_motion_.current_deg);
+
+            pitch_motion_.target_deg = pitch;
+            pitch_motion_.start_deg = pitch_motion_.current_deg;
+            pitch_motion_.move_start_ms = now_ms;
+            pitch_motion_.move_duration_ms = duration_ms;
+            pitch_motion_.moving = (pitch_motion_.target_deg != pitch_motion_.current_deg);
+        }
+
+        float GetYawDeg() const override {
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            int yaw = yaw_motion_.current_deg;
+            xSemaphoreGive(motion_mutex_);
+            return static_cast<float>(yaw);
+        }
+
+        float GetPitchDeg() const override {
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            int pitch = pitch_motion_.current_deg;
+            xSemaphoreGive(motion_mutex_);
+            return static_cast<float>(pitch);
+        }
+
+        bool IsMoving() const override {
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            bool moving = yaw_motion_.moving || pitch_motion_.moving;
+            xSemaphoreGive(motion_mutex_);
+            return moving;
+        }
+
+        void Tick() override {
+            constexpr TickType_t kInterFrameGap = pdMS_TO_TICKS(10);
+
+            vTaskDelay(pdMS_TO_TICKS(MOTION_TICK_MS));
+
+            AxisMotion yaw_local;
+            AxisMotion pitch_local;
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            yaw_local = yaw_motion_;
+            pitch_local = pitch_motion_;
+            xSemaphoreGive(motion_mutex_);
+
+            if (!yaw_local.moving && !pitch_local.moving) return;
+
+            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+
+            int new_yaw_current = yaw_local.current_deg;
+            bool new_yaw_moving = yaw_local.moving;
+            if (yaw_local.moving) {
+                uint32_t elapsed = now_ms - yaw_local.move_start_ms;
+                if (elapsed >= yaw_local.move_duration_ms) {
+                    new_yaw_current = yaw_local.target_deg;
+                    new_yaw_moving = false;
+                } else {
+                    int delta = yaw_local.target_deg - yaw_local.start_deg;
+                    new_yaw_current = yaw_local.start_deg +
+                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / yaw_local.move_duration_ms);
+                }
+            }
+
+            int new_pitch_current = pitch_local.current_deg;
+            bool new_pitch_moving = pitch_local.moving;
+            if (pitch_local.moving) {
+                uint32_t elapsed = now_ms - pitch_local.move_start_ms;
+                if (elapsed >= pitch_local.move_duration_ms) {
+                    new_pitch_current = pitch_local.target_deg;
+                    new_pitch_moving = false;
+                } else {
+                    int delta = pitch_local.target_deg - pitch_local.start_deg;
+                    new_pitch_current = pitch_local.start_deg +
+                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / pitch_local.move_duration_ms);
+                }
+            }
+
+            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            if (yaw_local.moving) {
+                int yaw_pos = YawDegToPos(new_yaw_current);
+                int r = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, MOTION_PER_WRITE_TIME_MS, 0);
+                if (!ServoWritePosOk(r)) {
+                    ESP_LOGW(TAG, "Motion yaw WritePos failed: r=%d (deg=%d, pos=%d)",
+                             r, new_yaw_current, yaw_pos);
+                }
+            }
+            vTaskDelay(kInterFrameGap);
+            if (pitch_local.moving) {
+                int pitch_pos = PitchDegToPos(new_pitch_current);
+                int r = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, MOTION_PER_WRITE_TIME_MS, 0);
+                if (!ServoWritePosOk(r)) {
+                    ESP_LOGW(TAG, "Motion pitch WritePos failed: r=%d (deg=%d, pos=%d)",
+                             r, new_pitch_current, pitch_pos);
+                }
+            }
+            xSemaphoreGive(scs_bus_mutex_);
+
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            if (yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
+                yaw_motion_.current_deg = new_yaw_current;
+            }
+            if (!new_yaw_moving && yaw_motion_.target_deg == yaw_local.target_deg
+                && yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
+                yaw_motion_.moving = false;
+            }
+            if (pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
+                pitch_motion_.current_deg = new_pitch_current;
+            }
+            if (!new_pitch_moving && pitch_motion_.target_deg == pitch_local.target_deg
+                && pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
+                pitch_motion_.moving = false;
+            }
+            xSemaphoreGive(motion_mutex_);
+        }
+
+    private:
+        ScsBus& scs_bus_;
+        SemaphoreHandle_t& scs_bus_mutex_;
+        SemaphoreHandle_t& motion_mutex_;
+        AxisMotion& yaw_motion_;
+        AxisMotion& pitch_motion_;
+    };
+
+    class ServoDelegatedMotionDriver final : public MotionDriver {
+    public:
+        ServoDelegatedMotionDriver(ScsBus& scs_bus,
+                                   SemaphoreHandle_t& scs_bus_mutex,
+                                   SemaphoreHandle_t& motion_mutex,
+                                   AxisMotion& yaw_motion,
+                                   AxisMotion& pitch_motion)
+            : scs_bus_(scs_bus),
+              scs_bus_mutex_(scs_bus_mutex),
+              motion_mutex_(motion_mutex),
+              yaw_motion_(yaw_motion),
+              pitch_motion_(pitch_motion) {}
+
+        // StartMove only mutates AxisMotion state (under the caller's
+        // motion_mutex_ per the MotionDriver::StartMove contract) and marks
+        // each axis as having a pending dispatch. The actual WritePos is
+        // performed by Tick() on the servo_motion task, so callers running
+        // on timer tasks (e.g. TouchPollCb -> StartServoWobble) never block
+        // on UART I/O. This mirrors HostInterpolationMotionDriver's
+        // "StartMove writes state; Tick drives the bus" split and keeps
+        // timer-task latency bounded.
+        void StartMove(float yaw_deg, float pitch_deg,
+                       uint32_t duration_ms) override {
+            uint16_t clamped = clamp_u16(duration_ms);
+            if (duration_ms > clamped) {
+                static bool duration_overflow_warned = false;
+                if (!duration_overflow_warned) {
+                    ESP_LOGW(TAG,
+                             "Servo-delegated motion duration overflow: axis=yaw/pitch requested_ms=%u clamped_ms=%u",
+                             (unsigned)duration_ms, (unsigned)clamped);
+                    duration_overflow_warned = true;
+                } else {
+                    ESP_LOGD(TAG,
+                             "Servo-delegated motion duration overflow: axis=yaw/pitch requested_ms=%u clamped_ms=%u",
+                             (unsigned)duration_ms, (unsigned)clamped);
+                }
+            }
+
+            int yaw = static_cast<int>(yaw_deg);
+            int pitch = static_cast<int>(pitch_deg);
+
+            // Per-axis no-op detection: when the axis is idle AND the request
+            // matches the last-known current_deg AND the position is not
+            // marked unknown, skip staging a dispatch. Issuing WritePos in
+            // that case would start a delegated motion toward host-side
+            // current_deg, which may diverge from the physical position
+            // (e.g. after a boot ReadPos-failure path where current_deg was
+            // seeded to BOOT_INIT_* via the safe fallback but the head sits
+            // elsewhere). HostInterpolation path keeps its always-WritePos
+            // behaviour for backward compatibility.
+            //
+            // position_unknown is the recovery signal from a prior ReadMove
+            // force-clear: current_deg holds the requested target but
+            // physical completion was never confirmed, so we MUST re-dispatch
+            // (even when yaw == current_deg) to surface a persistent failure
+            // rather than silently treat the axis as at-target.
+            //
+            // motion_mutex_ is held by the WriteHeadAngles caller per the
+            // MotionDriver::StartMove contract (declared at the base class).
+            // Taking it again here would deadlock the non-recursive FreeRTOS
+            // semaphore — read {yaw,pitch}_motion_ directly.
+            bool yaw_noop =
+                !yaw_motion_.moving && !yaw_motion_.position_unknown &&
+                yaw == yaw_motion_.current_deg;
+            bool pitch_noop =
+                !pitch_motion_.moving && !pitch_motion_.position_unknown &&
+                pitch == pitch_motion_.current_deg;
+
+            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+            if (!yaw_noop) {
+                yaw_motion_.start_deg = yaw_motion_.current_deg;
+                yaw_motion_.target_deg = yaw;
+                yaw_motion_.move_start_ms = now_ms;
+                // dispatch_start_ms stays 0 until Tick's FinishDispatch
+                // confirms a WritePos ACK. ApplyReadMoveResult's stuck-
+                // high timeout skips the check while dispatch_start_ms
+                // is 0, so retry latency does not eat into the
+                // servo-internal duration budget.
+                yaw_motion_.dispatch_start_ms = 0;
+                yaw_motion_.move_duration_ms = clamped;
+                yaw_motion_.moving = true;
+                yaw_motion_.request_token = ++next_request_token_;
+                // NOTE: position_unknown is NOT cleared here. It is
+                // cleared by FinishDispatch only after a successful
+                // WritePos ACK. Clearing it on stage would let
+                // dispatch retry exhaustion (WritePos failing 5 times
+                // in a row) leave position_unknown=false despite no
+                // confirmed physical motion — then the next
+                // same-target StartMove would no-op-skip on
+                // current_deg==target_deg, hiding the underlying bus
+                // failure.
+                yaw_pending_dispatch_ = true;
+                // Fresh request: reset the per-axis dispatch retry
+                // budget so previous failures don't shorten this
+                // request's retry runway.
+                yaw_dispatch_failures_ = 0;
+            }
+            if (!pitch_noop) {
+                pitch_motion_.start_deg = pitch_motion_.current_deg;
+                pitch_motion_.target_deg = pitch;
+                pitch_motion_.move_start_ms = now_ms;
+                pitch_motion_.dispatch_start_ms = 0;
+                pitch_motion_.move_duration_ms = clamped;
+                pitch_motion_.moving = true;
+                pitch_motion_.request_token = ++next_request_token_;
+                pitch_pending_dispatch_ = true;
+                pitch_dispatch_failures_ = 0;
+            }
+        }
+
+        float GetYawDeg() const override {
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            int yaw = yaw_motion_.current_deg;
+            xSemaphoreGive(motion_mutex_);
+            return static_cast<float>(yaw);
+        }
+
+        float GetPitchDeg() const override {
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            int pitch = pitch_motion_.current_deg;
+            xSemaphoreGive(motion_mutex_);
+            return static_cast<float>(pitch);
+        }
+
+        bool IsMoving() const override {
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            bool moving = yaw_motion_.moving || pitch_motion_.moving;
+            xSemaphoreGive(motion_mutex_);
+            return moving;
+        }
+
+        void Tick() override {
+            vTaskDelay(pdMS_TO_TICKS(MOTION_POLL_INTERVAL_MS));
+
+            AxisMotion yaw_local;
+            AxisMotion pitch_local;
+            bool yaw_dispatch = false;
+            bool pitch_dispatch = false;
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            yaw_local = yaw_motion_;
+            pitch_local = pitch_motion_;
+            yaw_dispatch = yaw_pending_dispatch_;
+            pitch_dispatch = pitch_pending_dispatch_;
+            // Do NOT clear pending_dispatch here. The flag is consumed in
+            // FinishDispatch only on success (or when the per-axis retry
+            // budget is exhausted). Failed WritePos preserves
+            // pending_dispatch=true so the next tick retries the same
+            // target — without retry, a transient ACK timeout would
+            // silently drop the request and StartMove callers would
+            // observe a "succeeded" motion that never reaches the servo.
+            xSemaphoreGive(motion_mutex_);
+
+            // Step 1: dispatch any pending WritePos that StartMove staged.
+            // This is the I/O previously executed inside StartMove on the
+            // caller's task. By moving it onto the servo_motion task here,
+            // timer-task callers (TouchPollCb -> StartServoWobble) don't
+            // pay UART ACK latency.
+            if (yaw_dispatch || pitch_dispatch) {
+                int yaw_r = 0;
+                int pitch_r = 0;
+                uint16_t yaw_dur =
+                    static_cast<uint16_t>(yaw_local.move_duration_ms);
+                uint16_t pitch_dur =
+                    static_cast<uint16_t>(pitch_local.move_duration_ms);
+                int yaw_pos = YawDegToPos(yaw_local.target_deg);
+                int pitch_pos = PitchDegToPos(pitch_local.target_deg);
+
+                // Per-axis freshness gate immediately before each
+                // WritePos. A single snapshot before both writes leaves a
+                // window between the yaw dispatch and the pitch
+                // freshness check where a newer StartMove can race in,
+                // so the pitch dispatch could still send a stale
+                // physical command. Checking each axis individually
+                // under motion_mutex_ narrows the window per axis.
+                //
+                // Lock ordering: scs_bus_mutex_ → motion_mutex_ (held
+                // only at the per-axis freshness gate, never across
+                // WritePos). Other paths take motion_mutex_ alone
+                // (StartMove, wobble) or scs_bus_mutex_ then
+                // motion_mutex_ (Tick step-2 ReadMove). No path takes
+                // motion_mutex_ before scs_bus_mutex_, so the
+                // lock-ordering cycle that would cause a deadlock does
+                // not exist.
+                constexpr TickType_t kInterFrameGap = pdMS_TO_TICKS(10);
+                bool yaw_live = false;
+                bool pitch_live = false;
+                xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+                if (yaw_dispatch) {
+                    xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                    yaw_live = yaw_motion_.request_token == yaw_local.request_token;
+                    xSemaphoreGive(motion_mutex_);
+                    if (yaw_live) {
+                        yaw_r = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, yaw_dur, 0);
+                    }
+                }
+                if (pitch_dispatch) {
+                    // SCS0009 bus stability: insert the same inter-frame
+                    // gap the host-interpolation Tick uses between two
+                    // consecutive WritePos on the shared bus. Without
+                    // this, back-to-back yaw + pitch dispatches can
+                    // re-introduce the bus-hang signature originally
+                    // observed during the boot-init climb. Held under
+                    // scs_bus_mutex_ — same pattern as the
+                    // HostInterpolationMotionDriver::Tick path.
+                    if (yaw_live) {
+                        vTaskDelay(kInterFrameGap);
+                    }
+                    xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                    pitch_live = pitch_motion_.request_token == pitch_local.request_token;
+                    xSemaphoreGive(motion_mutex_);
+                    if (pitch_live) {
+                        pitch_r = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, pitch_dur, 0);
+                    }
+                }
+                xSemaphoreGive(scs_bus_mutex_);
+
+                bool yaw_ok = !yaw_live || ServoWritePosOk(yaw_r);
+                bool pitch_ok = !pitch_live || ServoWritePosOk(pitch_r);
+                if (yaw_live && !yaw_ok) {
+                    ESP_LOGW(TAG,
+                             "Motion yaw WritePos failed: r=%d (deg=%d, pos=%d)",
+                             yaw_r, yaw_local.target_deg, yaw_pos);
+                }
+                if (pitch_live && !pitch_ok) {
+                    ESP_LOGW(TAG,
+                             "Motion pitch WritePos failed: r=%d (deg=%d, pos=%d)",
+                             pitch_r, pitch_local.target_deg, pitch_pos);
+                }
+
+                // dispatch_now_ms captures the time WritePos completed
+                // (ACK or timeout). FinishDispatch will use this for
+                // axis.dispatch_start_ms on success, so that
+                // ApplyReadMoveResult's stuck-high check measures
+                // elapsed from when the servo actually accepted the
+                // command — not from staging time.
+                uint32_t dispatch_now_ms =
+                    static_cast<uint32_t>(esp_timer_get_time() / 1000);
+                xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                // Commit / consume pending only if the snapshot we
+                // dispatched is still the live request AND we actually
+                // performed the WritePos (yaw_live / pitch_live).
+                // Superseded dispatches (token mismatch at either the
+                // pre-WritePos freshness gate or here) drop the retry
+                // counter so the new request — which has its own
+                // request_token and pending flag set by the racing
+                // StartMove — starts its retry budget fresh.
+                if (yaw_dispatch) {
+                    if (yaw_live &&
+                        yaw_motion_.request_token == yaw_local.request_token) {
+                        FinishDispatch("yaw", yaw_motion_, yaw_local.target_deg,
+                                       yaw_ok, dispatch_now_ms,
+                                       yaw_pending_dispatch_,
+                                       yaw_dispatch_failures_,
+                                       yaw_readmove_failures_);
+                    } else {
+                        yaw_dispatch_failures_ = 0;
+                    }
+                }
+                if (pitch_dispatch) {
+                    if (pitch_live &&
+                        pitch_motion_.request_token == pitch_local.request_token) {
+                        FinishDispatch("pitch", pitch_motion_,
+                                       pitch_local.target_deg, pitch_ok,
+                                       dispatch_now_ms,
+                                       pitch_pending_dispatch_,
+                                       pitch_dispatch_failures_,
+                                       pitch_readmove_failures_);
+                    } else {
+                        pitch_dispatch_failures_ = 0;
+                    }
+                }
+                xSemaphoreGive(motion_mutex_);
+
+                // This tick's bus budget is spent on the dispatch. Skip the
+                // ReadMove poll path; the next tick will pick up the
+                // in-flight motion.
+                return;
+            }
+
+            // Step 2: ReadMove poll for in-flight motion.
+            if (!yaw_local.moving && !pitch_local.moving) return;
+
+            int yaw_move = -1;
+            int pitch_move = -1;
+            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            if (yaw_local.moving) {
+                yaw_move = scs_bus_.ReadMove(SERVO_YAW_ID);
+            }
+            if (pitch_local.moving) {
+                pitch_move = scs_bus_.ReadMove(SERVO_PITCH_ID);
+            }
+            xSemaphoreGive(scs_bus_mutex_);
+
+            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            // request_token guards against a newer StartMove racing in
+            // between the Tick snapshot and this commit; ms-resolution
+            // move_start_ms can collide for back-to-back requests.
+            if (yaw_local.moving &&
+                yaw_motion_.request_token == yaw_local.request_token) {
+                ApplyReadMoveResult("yaw", yaw_motion_, yaw_move, now_ms,
+                                    yaw_readmove_failures_);
+            }
+            if (pitch_local.moving &&
+                pitch_motion_.request_token == pitch_local.request_token) {
+                ApplyReadMoveResult("pitch", pitch_motion_, pitch_move, now_ms,
+                                    pitch_readmove_failures_);
+            }
+            xSemaphoreGive(motion_mutex_);
+        }
+
+    private:
+        static constexpr int kReadMoveFailureLimit = 5;
+        static constexpr int kDispatchFailureLimit = 5;
+        // Settle margin past move_duration_ms before treating a
+        // stuck-high ReadMove (servo returns 1 forever after the
+        // requested completion) as a failure. Without this bound,
+        // a degraded servo / register path would keep moving=true
+        // indefinitely; wobble would never advance and same-target
+        // recovery would never run.
+        static constexpr uint32_t kReadMoveStuckMarginMs = 1000;
+        // Margin below move_duration_ms in which an early ReadMove==0
+        // is allowed as a genuine completion (the SCS0009's internal
+        // interpolation can finish slightly early). A ReadMove==0
+        // arriving further before the commanded completion is
+        // implausible and likely a stuck-low / false-zero status read
+        // from a degraded register path; treat it as suspicious and
+        // mark position_unknown so the next StartMove forces a fresh
+        // dispatch instead of trusting the stale optimistic commit.
+        static constexpr uint32_t kReadMoveEarlyMarginMs = 200;
+
+        // Finalises a dispatched WritePos. Caller holds motion_mutex_.
+        // - write_ok==true:  commit current_deg = target, consume the
+        //   pending_dispatch flag, reset dispatch + ReadMove failure
+        //   counters. ReadMove poll then tracks the in-flight delegated
+        //   motion to completion.
+        // - write_ok==false: keep pending_dispatch=true so the next tick
+        //   retries the same target (transient ACK timeout / UART error
+        //   should not silently drop the request). Bound the retry by
+        //   kDispatchFailureLimit; when exhausted, log once, consume
+        //   pending_dispatch, and clear moving so the axis returns to
+        //   idle rather than spinning the retry loop forever.
+        // readmove_failures is reset on success only; it tracks ReadMove
+        // polling and is independent of WritePos ack semantics.
+        static void FinishDispatch(const char* axis_name, AxisMotion& axis,
+                                   int target_deg, bool write_ok,
+                                   uint32_t dispatch_now_ms,
+                                   bool& pending_dispatch,
+                                   int& dispatch_failures,
+                                   int& readmove_failures) {
+            if (write_ok) {
+                axis.current_deg = target_deg;
+                // dispatch_start_ms records when the servo actually
+                // received the GOAL_POSITION / GOAL_TIME write. This
+                // (not the staging timestamp in move_start_ms) is what
+                // ApplyReadMoveResult uses for the stuck-high timeout,
+                // so degraded-bus dispatch latency doesn't eat into
+                // the servo-internal duration budget.
+                axis.dispatch_start_ms = dispatch_now_ms;
+                // Confirmed WritePos ACK supersedes any prior
+                // position_unknown mark. The new WritePos+ReadMove
+                // cycle is what proves (or fails to prove) the
+                // physical position.
+                axis.position_unknown = false;
+                pending_dispatch = false;
+                dispatch_failures = 0;
+                readmove_failures = 0;
+                return;
+            }
+            dispatch_failures++;
+            if (dispatch_failures >= kDispatchFailureLimit) {
+                ESP_LOGW(TAG,
+                         "Motion %s WritePos retries exhausted: current_deg=%d target_deg=%d; %d consecutive dispatch failures, abandoning request and marking position unknown",
+                         axis_name, axis.current_deg, axis.target_deg,
+                         kDispatchFailureLimit);
+                pending_dispatch = false;
+                axis.moving = false;
+                // A WritePos ACK timeout is NOT proof that the servo
+                // ignored the command — the command may have reached
+                // the servo while only the ACK/readback path failed.
+                // In that case the physical head has already moved to
+                // target_deg, but current_deg still holds the old
+                // value. Without position_unknown=true here, the next
+                // same-old-position StartMove would no-op-skip on the
+                // stale current_deg and silently drop the recovery
+                // request — exactly the degraded-bus condition this
+                // path is meant to handle. Mark unknown so a same-
+                // target retry forces a fresh dispatch and either
+                // confirms (FinishDispatch write_ok clears the flag)
+                // or surfaces another failure.
+                axis.position_unknown = true;
+                dispatch_failures = 0;
+            }
+            // else: pending_dispatch stays true; next Tick will retry the
+            // same target (same start_deg / move_start_ms / move_duration_ms).
+        }
+
+        static void ApplyReadMoveResult(const char* axis_name,
+                                        AxisMotion& axis,
+                                        int read_move,
+                                        uint32_t now_ms,
+                                        int& failures) {
+            if (read_move >= 0) {
+                failures = 0;
+                if (read_move == 0) {
+                    // Sanity check against a stuck-low / false-zero
+                    // status register: FinishDispatch optimistically
+                    // committed current_deg to target_deg on WritePos
+                    // ACK, so a transient ReadMove==0 returned before
+                    // the servo could physically reach target would
+                    // make the host treat the axis as "at target" and
+                    // let the next same-target StartMove no-op-skip.
+                    // If the elapsed time since confirmed dispatch is
+                    // implausibly short relative to the commanded
+                    // move_duration_ms (allowing kReadMoveEarlyMarginMs
+                    // for genuine early arrival), treat the zero as
+                    // suspicious and mark the position unknown.
+                    if (axis.dispatch_start_ms != 0 &&
+                        axis.move_duration_ms > kReadMoveEarlyMarginMs) {
+                        uint32_t elapsed = now_ms - axis.dispatch_start_ms;
+                        uint32_t plausible_min =
+                            axis.move_duration_ms - kReadMoveEarlyMarginMs;
+                        if (elapsed < plausible_min) {
+                            ESP_LOGW(TAG,
+                                     "Motion %s ReadMove=0 implausibly early: current_deg=%d target_deg=%d, elapsed=%ums but commanded duration=%ums (early margin=%ums); marking position unknown",
+                                     axis_name, axis.current_deg, axis.target_deg,
+                                     (unsigned)elapsed,
+                                     (unsigned)axis.move_duration_ms,
+                                     (unsigned)kReadMoveEarlyMarginMs);
+                            axis.moving = false;
+                            axis.position_unknown = true;
+                            return;
+                        }
+                    }
+                    axis.moving = false;
+                    return;
+                }
+                // read_move > 0: servo reports still moving. Bound the
+                // wait by move_duration_ms + kReadMoveStuckMarginMs to
+                // guard against a stuck-high ReadMove (the servo or
+                // register path degrades such that the motion-status
+                // bit never clears even after the requested completion
+                // time has elapsed).
+                //
+                // Elapsed is measured from dispatch_start_ms (when the
+                // servo actually received the command via a successful
+                // WritePos ACK), not from move_start_ms (staging time),
+                // so degraded-bus dispatch latency does not cause
+                // premature force-clear while the servo is genuinely
+                // still mid-motion. If dispatch_start_ms is still 0 the
+                // WritePos has not yet ACK'd; skip the timeout check
+                // until the dispatch is confirmed. Unsigned subtraction
+                // stays wrap-safe across the uint32 ms counter.
+                if (axis.dispatch_start_ms == 0) {
+                    return;
+                }
+                uint32_t elapsed = now_ms - axis.dispatch_start_ms;
+                if (elapsed > axis.move_duration_ms + kReadMoveStuckMarginMs) {
+                    ESP_LOGW(TAG,
+                             "Motion %s ReadMove stuck-high: current_deg=%d target_deg=%d, %ums past commanded completion; marking position unknown and force-clearing moving",
+                             axis_name, axis.current_deg, axis.target_deg,
+                             (unsigned)(elapsed - axis.move_duration_ms));
+                    axis.moving = false;
+                    axis.position_unknown = true;
+                }
+                return;
+            }
+
+            failures++;
+            if (failures >= kReadMoveFailureLimit) {
+                ESP_LOGW(TAG,
+                         "Motion %s ReadMove failed: current_deg=%d target_deg=%d; %d consecutive ReadMove failures, marking position unknown and force-clearing moving (next StartMove will re-dispatch even if target matches current_deg)",
+                         axis_name, axis.current_deg, axis.target_deg,
+                         kReadMoveFailureLimit);
+                axis.moving = false;
+                // Without this flag, a subsequent same-target StartMove
+                // would no-op-skip on current_deg==target_deg and the
+                // bus failure would stay hidden behind the optimistic
+                // commit. Marking the position unknown forces the next
+                // StartMove to re-dispatch and surface (or recover from)
+                // the underlying ReadMove fault.
+                axis.position_unknown = true;
+                failures = 0;
+            }
+        }
+
+        ScsBus& scs_bus_;
+        SemaphoreHandle_t& scs_bus_mutex_;
+        SemaphoreHandle_t& motion_mutex_;
+        AxisMotion& yaw_motion_;
+        AxisMotion& pitch_motion_;
+        int yaw_readmove_failures_ = 0;
+        int pitch_readmove_failures_ = 0;
+        // Set by StartMove when staging a dispatch for an axis. Cleared by
+        // FinishDispatch only on a successful WritePos (or when the
+        // per-axis retry budget kDispatchFailureLimit is exhausted), so
+        // transient bus failures retry on the next tick instead of being
+        // silently dropped. motion_mutex_ guards both fields.
+        bool yaw_pending_dispatch_ = false;
+        bool pitch_pending_dispatch_ = false;
+        // Consecutive WritePos dispatch failures per axis. motion_mutex_
+        // guards both fields.
+        int yaw_dispatch_failures_ = 0;
+        int pitch_dispatch_failures_ = 0;
+        // Monotonically increasing request id. Each StartMove that stages
+        // a dispatch picks ++next_request_token_ and writes it into the
+        // corresponding AxisMotion::request_token. Tick() then uses
+        // request_token equality (rather than move_start_ms, which only
+        // has ms resolution) to detect whether a snapshot is still the
+        // live request. motion_mutex_ guards this counter.
+        uint64_t next_request_token_ = 0;
+    };
 
     void InitializePowerSaveTimer() {
         power_save_timer_ = new PowerSaveTimer(-1, 60, 300);
@@ -1162,6 +1887,26 @@ private:
                 return;
             }
 
+#if CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION
+            motion_driver_ = std::make_unique<ServoDelegatedMotionDriver>(
+                scs_bus_, scs_bus_mutex_, motion_mutex_,
+                yaw_motion_, pitch_motion_);
+#else
+            motion_driver_ = std::make_unique<HostInterpolationMotionDriver>(
+                scs_bus_, scs_bus_mutex_, motion_mutex_,
+                yaw_motion_, pitch_motion_);
+#endif
+            if (!motion_driver_->Initialize()) {
+                ESP_LOGE(TAG, "Failed to initialize motion driver; disabling servo");
+                motion_driver_.reset();
+                vSemaphoreDelete(motion_mutex_);
+                motion_mutex_ = nullptr;
+                vSemaphoreDelete(scs_bus_mutex_);
+                scs_bus_mutex_ = nullptr;
+                servo_ok_ = false;
+                return;
+            }
+
             // Issue #121 (Problem 1, "downward drop on power-on") + #123
             // (boot-init diagnostics).
             //
@@ -1381,6 +2126,7 @@ private:
                     vSemaphoreDelete(scs_bus_mutex_);
                     scs_bus_mutex_ = nullptr;
                 }
+                motion_driver_.reset();
                 servo_task_handle_ = nullptr;
                 servo_ok_ = false;
                 return;
@@ -1424,10 +2170,10 @@ private:
             // motion at 30 deg/s+, exceeding the 15 deg/s cap.
             int phase0_yaw_delta;
             int phase0_pitch_delta;
-            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            phase0_yaw_delta = BOOT_INIT_YAW_DEG - yaw_motion_.current_deg;
-            phase0_pitch_delta = BOOT_INIT_PITCH_DEG - pitch_motion_.current_deg;
-            xSemaphoreGive(motion_mutex_);
+            phase0_yaw_delta =
+                BOOT_INIT_YAW_DEG - static_cast<int>(motion_driver_->GetYawDeg());
+            phase0_pitch_delta =
+                BOOT_INIT_PITCH_DEG - static_cast<int>(motion_driver_->GetPitchDeg());
             if (phase0_yaw_delta < 0) phase0_yaw_delta = -phase0_yaw_delta;
             if (phase0_pitch_delta < 0) phase0_pitch_delta = -phase0_pitch_delta;
             int phase0_max_delta = phase0_yaw_delta > phase0_pitch_delta
@@ -1441,7 +2187,67 @@ private:
             TickType_t boot_init_start_tick = xTaskGetTickCount();
             WriteHeadAngles(BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG,
                             phase0_duration_ms);
-            vTaskDelay(pdMS_TO_TICKS(phase0_duration_ms + 100));
+            // Two-phase boot-init wait:
+            //
+            // (1) Mandatory minimum: vTaskDelay until
+            //     phase0_duration_ms + 100 ms has elapsed. This must
+            //     run UNCONDITIONALLY — independent of IsMoving() —
+            //     because phase0_duration_ms is floored to
+            //     BOOT_INIT_MOVE_MS specifically to cover the
+            //     SCS0009 wake-up window on the PMIC OFF/ON path,
+            //     even when WriteHeadAngles is a no-op (Phase 2
+            //     safe-fallback seeded current_deg to exactly the
+            //     boot target → motion_driver_->IsMoving() == false
+            //     immediately → Phase 0' ReadPos would otherwise run
+            //     inside the wake-up latency window and exhaust).
+            //
+            // (2) Optional extension: while motion_driver_->IsMoving()
+            //     reports a motion still in flight, keep waiting up
+            //     to a safety deadline. This covers the ServoDelegated
+            //     path where the actual servo motion can start late
+            //     due to dispatch retry latency (max 5 ×
+            //     MOTION_POLL_INTERVAL_MS = 250 ms) — phase (1)'s
+            //     budget may finish before the servo has completed
+            //     its internal interpolation in that worst case.
+            TickType_t boot_init_min_deadline =
+                xTaskGetTickCount() +
+                pdMS_TO_TICKS(phase0_duration_ms + 100);
+            // Safety extension covers the worst-case ServoDelegated
+            // dispatch latency. Each retry round dispatches yaw and
+            // pitch sequentially under scs_bus_mutex_, so one fully-
+            // timing-out round on both axes costs approximately:
+            //   MOTION_POLL_INTERVAL_MS (50 ms tick wake)
+            // + yaw WritePos ACK timeout (~100 ms; SCSCL's
+            //   SCSerial::IOTimeOut = 100 ms, FeetechScs comparable)
+            // + kInterFrameGap (10 ms)
+            // + pitch WritePos ACK timeout (~100 ms)
+            // ≈ 260 ms per retry round.
+            //
+            // 4 failing rounds + 1 successful round bound the
+            // worst-case dispatch latency at roughly 4 × 260 ≈ 1040 ms.
+            // Add a settle margin so the wait outlasts a genuine
+            // delayed dispatch instead of breaking while IsMoving()
+            // is legitimately true. 2000 ms covers the full retry
+            // budget plus margin.
+            //
+            // HostInterpolation path is unaffected (dispatch latency
+            // is 0 there; the wait exits well before this deadline
+            // regardless).
+            TickType_t boot_init_safety_deadline =
+                boot_init_min_deadline + pdMS_TO_TICKS(2000);
+            while ((int32_t)(xTaskGetTickCount() -
+                             boot_init_min_deadline) < 0) {
+                vTaskDelay(pdMS_TO_TICKS(50));
+            }
+            while (motion_driver_->IsMoving()) {
+                if ((int32_t)(xTaskGetTickCount() -
+                              boot_init_safety_deadline) >= 0) {
+                    ESP_LOGW(TAG,
+                             "Boot init Phase 0 wait safety deadline elapsed while motion_driver_ still reports moving; proceeding to Phase 0' ReadPos anyway");
+                    break;
+                }
+                vTaskDelay(pdMS_TO_TICKS(50));
+            }
 
             // Issue #123: capture post-init ReadPos so the boot-init effect
             // is observable in the serial log. ServoTask is now running, so
@@ -1527,9 +2333,21 @@ private:
                     xSemaphoreGive(motion_mutex_);
                 }
             } else {
+                // Phase 0' ReadPos failed: current_deg holds the
+                // Phase 2 restored-or-seeded value, which has NOT
+                // been physically verified. Mark the axis position
+                // unknown so the ServoDelegated path's no-op gate
+                // does not silently skip a same-target recovery
+                // command. The HostInterpolation path ignores this
+                // flag; on that path the next WriteHeadAngles still
+                // dispatches a fresh interpolation as before.
+                xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                yaw_motion_.position_unknown = true;
+                xSemaphoreGive(motion_mutex_);
                 ESP_LOGW(TAG,
                          "Phase 0' yaw re-sync skipped: ReadPos failed; "
-                         "leaving current_deg at restored-or-seeded value");
+                         "leaving current_deg at restored-or-seeded value "
+                         "and marking position unknown for delegated no-op gate");
             }
             if (post_pitch_pos >= 0) {
                 int actual_pitch_deg = (post_pitch_pos - 620) * 5 / 16;
@@ -1554,9 +2372,13 @@ private:
                     xSemaphoreGive(motion_mutex_);
                 }
             } else {
+                xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                pitch_motion_.position_unknown = true;
+                xSemaphoreGive(motion_mutex_);
                 ESP_LOGW(TAG,
                          "Phase 0' pitch re-sync skipped: ReadPos failed; "
-                         "leaving current_deg at restored-or-seeded value");
+                         "leaving current_deg at restored-or-seeded value "
+                         "and marking position unknown for delegated no-op gate");
             }
         }
     }
@@ -1571,79 +2393,110 @@ private:
     // which hung the SCS0009 bus on large-angle reversals (the second
     // servo's frame collided with the first servo still being driven).
     // Now it sets the target and lets the servo_motion task interpolate.
+    //
+    // The wobble-cancel + StartMove sequence runs under motion_mutex_ so a
+    // concurrent ServoWobbleStepAdvance() on servo_motion task cannot pass
+    // its active-load gate after this call has cleared
+    // servo_wobble_active_ but before it dispatches the user-driven
+    // target — which would let a stale wobble step overwrite the new
+    // command.
     void WriteHeadAngles(int yaw_deg, int pitch_deg,
                          uint32_t duration_ms = MOTION_DEFAULT_DURATION_MS) {
-        if (!servo_ok_) {
+        if (!servo_ok_ || motion_driver_ == nullptr) {
             ESP_LOGW(TAG, "WriteHeadAngles skipped: servo not initialized");
             return;
         }
-        uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
-
         xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-        yaw_motion_.target_deg = yaw_deg;
-        yaw_motion_.start_deg = yaw_motion_.current_deg;
-        yaw_motion_.move_start_ms = now_ms;
-        yaw_motion_.move_duration_ms = duration_ms;
-        yaw_motion_.moving = (yaw_motion_.target_deg != yaw_motion_.current_deg);
-
-        pitch_motion_.target_deg = pitch_deg;
-        pitch_motion_.start_deg = pitch_motion_.current_deg;
-        pitch_motion_.move_start_ms = now_ms;
-        pitch_motion_.move_duration_ms = duration_ms;
-        pitch_motion_.moving = (pitch_motion_.target_deg != pitch_motion_.current_deg);
+        if (servo_wobble_active_.load()) {
+            servo_wobble_active_.store(false);
+            servo_wobble_step_.store(0);
+        }
+        motion_driver_->StartMove(yaw_deg, pitch_deg, duration_ms);
         xSemaphoreGive(motion_mutex_);
     }
 
-    // Servo wobble: yaw -A -> +A -> -A -> 0, each step SERVO_WOBBLE_STEP_MS.
-    // Driven by servo_wobble_timer_ to avoid blocking the touch poll task.
-    static void ServoWobbleStepCb(void* arg) {
-        StackChanBoard* self = static_cast<StackChanBoard*>(arg);
-        self->ServoWobbleStepAdvance();
-    }
-
+    // Servo wobble: yaw -A -> +A -> -A -> 0. Each step is dispatched only
+    // after the active MotionDriver reports idle, so the delegated path never
+    // overwrites an in-flight SCS0009 internal motion.
+    //
+    // Entire body runs under motion_mutex_. Without that hold, a concurrent
+    // non-wobble WriteHeadAngles() could clear servo_wobble_active_ AFTER
+    // this function has passed the active-load + IsMoving gate but BEFORE
+    // the switch reaches dispatch, which would let a wobble step
+    // overwrite the user's freshly-staged target. Holding the mutex makes
+    // "wobble-active check → idle check → step dispatch" atomic w.r.t.
+    // any external StartMove() request.
     void ServoWobbleStepAdvance() {
+        if (!servo_ok_ || motion_driver_ == nullptr) {
+            return;
+        }
+        xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+        if (!servo_wobble_active_.load()) {
+            xSemaphoreGive(motion_mutex_);
+            return;
+        }
+        // Direct AxisMotion field access under motion_mutex_; calling
+        // motion_driver_->IsMoving() here would re-take the non-recursive
+        // semaphore and deadlock.
+        bool moving = yaw_motion_.moving || pitch_motion_.moving;
+        if (moving) {
+            xSemaphoreGive(motion_mutex_);
+            return;
+        }
         const int A = SERVO_WOBBLE_AMPLITUDE_DEG;
-        switch (servo_wobble_step_) {
-            case 0: WriteHeadAngles(-A, 0, SERVO_WOBBLE_STEP_MS); break;
-            case 1: WriteHeadAngles(+A, 0, SERVO_WOBBLE_STEP_MS); break;
-            case 2: WriteHeadAngles(-A, 0, SERVO_WOBBLE_STEP_MS); break;
-            case 3: WriteHeadAngles(  0, 0, SERVO_WOBBLE_STEP_MS); break;
+        int step = servo_wobble_step_.load();
+        int target_yaw = 0;
+        int target_pitch = 0;
+        switch (step) {
+            case 0: target_yaw = -A; target_pitch = 0; break;
+            case 1: target_yaw = +A; target_pitch = 0; break;
+            case 2: target_yaw = -A; target_pitch = 0; break;
+            case 3: target_yaw =  0; target_pitch = 0; break;
             default:
-                servo_wobble_active_ = false;
+                servo_wobble_active_.store(false);
+                xSemaphoreGive(motion_mutex_);
                 return;
         }
-        servo_wobble_step_++;
-        if (servo_wobble_step_ <= 3) {
-            esp_timer_start_once(servo_wobble_timer_,
-                                 (uint64_t)SERVO_WOBBLE_STEP_MS * 1000);
-        } else {
-            servo_wobble_active_ = false;
+        // StartMove contract: caller holds motion_mutex_. Direct call
+        // (not via WriteHeadAngles) avoids the re-entrant mutex take.
+        motion_driver_->StartMove(target_yaw, target_pitch, SERVO_WOBBLE_STEP_MS);
+        servo_wobble_step_.store(step + 1);
+        if (step + 1 > 3) {
+            servo_wobble_active_.store(false);
         }
+        xSemaphoreGive(motion_mutex_);
     }
 
     void StartServoWobble() {
-        if (!servo_ok_) {
+        if (!servo_ok_ || motion_driver_ == nullptr) {
             ESP_LOGW(TAG, "Servo wobble skipped: servo not initialized");
             return;
         }
-        if (servo_wobble_active_) {
-            // Restart from step 0 if a new wobble is requested mid-flight.
-            esp_timer_stop(servo_wobble_timer_);
-        }
-        if (servo_wobble_timer_ == nullptr) {
-            esp_timer_create_args_t args = {
-                .callback = &StackChanBoard::ServoWobbleStepCb,
-                .arg = this,
-                .dispatch_method = ESP_TIMER_TASK,
-                .name = "servo_wobble",
-                .skip_unhandled_events = true,
-            };
-            ESP_ERROR_CHECK(esp_timer_create(&args, &servo_wobble_timer_));
-        }
-        servo_wobble_step_ = 0;
-        servo_wobble_active_ = true;
-        // Kick off the first step immediately.
-        ServoWobbleStepAdvance();
+        // Stage the wobble; the actual ServoWobbleStepAdvance() is
+        // performed on servo_motion task next tick (see ServoTaskMain).
+        // Calling ServoWobbleStepAdvance() directly from here — which is
+        // commonly reached via the ESP_TIMER_TASK touch-poll callback —
+        // would race with the servo_motion task's own per-tick
+        // ServoWobbleStepAdvance() at idle: the atomic step load/store
+        // does not exclude the read-switch-store compound operation, so
+        // two callers can both observe step==0 and end up dispatching
+        // step 0 and step 1 concurrently. Centralising advance on the
+        // servo_motion task makes the step sequence deterministic, at
+        // the cost of a single MOTION_POLL_INTERVAL_MS / MOTION_TICK_MS
+        // delay on the first wobble step (well under human perception).
+        //
+        // motion_mutex_ also serialises this restart against a
+        // concurrent ServoWobbleStepAdvance() running on servo_motion:
+        // without the hold, a final-step advancement finishing at the
+        // same moment as this restart could overwrite our step=0 /
+        // active=true with step+1 or active=false, silently dropping
+        // the new stroke's wobble. The mutex is staging-only (no UART
+        // I/O is performed under it), so taking it from ESP_TIMER_TASK
+        // is bounded to sub-millisecond hold time.
+        xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+        servo_wobble_step_.store(0);
+        servo_wobble_active_.store(true);
+        xSemaphoreGive(motion_mutex_);
     }
 
     static void ServoTaskTrampoline(void* arg) {
@@ -1651,87 +2504,14 @@ private:
     }
 
     void ServoTaskMain() {
-        constexpr TickType_t kInterFrameGap = pdMS_TO_TICKS(10);
-
         while (true) {
-            vTaskDelay(pdMS_TO_TICKS(MOTION_TICK_MS));
-            if (!servo_ok_) continue;
-
-            AxisMotion yaw_local;
-            AxisMotion pitch_local;
-            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            yaw_local = yaw_motion_;
-            pitch_local = pitch_motion_;
-            xSemaphoreGive(motion_mutex_);
-
-            if (!yaw_local.moving && !pitch_local.moving) continue;
-
-            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
-
-            int new_yaw_current = yaw_local.current_deg;
-            bool new_yaw_moving = yaw_local.moving;
-            if (yaw_local.moving) {
-                uint32_t elapsed = now_ms - yaw_local.move_start_ms;
-                if (elapsed >= yaw_local.move_duration_ms) {
-                    new_yaw_current = yaw_local.target_deg;
-                    new_yaw_moving = false;
-                } else {
-                    int delta = yaw_local.target_deg - yaw_local.start_deg;
-                    new_yaw_current = yaw_local.start_deg +
-                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / yaw_local.move_duration_ms);
-                }
+            if (!servo_ok_ || motion_driver_ == nullptr) {
+                vTaskDelay(pdMS_TO_TICKS(MOTION_TICK_MS));
+                continue;
             }
-
-            int new_pitch_current = pitch_local.current_deg;
-            bool new_pitch_moving = pitch_local.moving;
-            if (pitch_local.moving) {
-                uint32_t elapsed = now_ms - pitch_local.move_start_ms;
-                if (elapsed >= pitch_local.move_duration_ms) {
-                    new_pitch_current = pitch_local.target_deg;
-                    new_pitch_moving = false;
-                } else {
-                    int delta = pitch_local.target_deg - pitch_local.start_deg;
-                    new_pitch_current = pitch_local.start_deg +
-                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / pitch_local.move_duration_ms);
-                }
-            }
-
-            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-            if (yaw_local.moving) {
-                int yaw_pos = YawDegToPos(new_yaw_current);
-                int r = scs_bus_.WritePos(SERVO_YAW_ID, yaw_pos, MOTION_PER_WRITE_TIME_MS, 0);
-                if (!ServoWritePosOk(r)) {
-                    ESP_LOGW(TAG, "Motion yaw WritePos failed: r=%d (deg=%d, pos=%d)",
-                             r, new_yaw_current, yaw_pos);
-                }
-            }
-            vTaskDelay(kInterFrameGap);
-            if (pitch_local.moving) {
-                int pitch_pos = PitchDegToPos(new_pitch_current);
-                int r = scs_bus_.WritePos(SERVO_PITCH_ID, pitch_pos, MOTION_PER_WRITE_TIME_MS, 0);
-                if (!ServoWritePosOk(r)) {
-                    ESP_LOGW(TAG, "Motion pitch WritePos failed: r=%d (deg=%d, pos=%d)",
-                             r, new_pitch_current, pitch_pos);
-                }
-            }
-            xSemaphoreGive(scs_bus_mutex_);
-
-            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            if (yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
-                yaw_motion_.current_deg = new_yaw_current;
-            }
-            if (!new_yaw_moving && yaw_motion_.target_deg == yaw_local.target_deg
-                && yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
-                yaw_motion_.moving = false;
-            }
-            if (pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
-                pitch_motion_.current_deg = new_pitch_current;
-            }
-            if (!new_pitch_moving && pitch_motion_.target_deg == pitch_local.target_deg
-                && pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
-                pitch_motion_.moving = false;
-            }
-            xSemaphoreGive(motion_mutex_);
+            motion_driver_->Tick();
+            ServoWobbleStepAdvance();
+            taskYIELD();
         }
     }
 


### PR DESCRIPTION
## Summary

Refactor the StackChan board's servo motion subsystem from the current 50 Hz host-side linear-interpolation loop (the `ServoTask` overwrite path historically associated with the `SCS0009` bus-hang signature seen across #1 / #100 / #137 / #138 / #141) to a new `MotionDriver` abstraction with a co-existing SCS0009-delegated **single-shot `WritePos(id, pos, time=duration_ms, 0)` + `ReadMove(id)` polling** path used by every reference implementation.

The change is structured around a `MotionDriver` abstract base so that the existing host-interpolation path and the new servo-delegated path co-exist behind a single Kconfig switch without `#ifdef` proliferation. This PR delivers Phase 1 of the staged rollout (introduce the abstraction + the new driver, **default `n`**); Phase 2 (default flip) and Phase 3 / cleanup (host path removal, tracked under #144) are gated on the follow-up investigations called out in "Out of scope" below.

Closes the implementation portion of #143. Real-device verification on the maintainer's hardware (M5Stack CoreS3 + SCS0009 ×2, FeetechScs MIT default driver) demonstrates that the delegated path **dramatically mitigates** the bus-hang surface but does **not eliminate** it: a residual hang trigger requiring two-axis simultaneous dispatch combined with either pitch end-stop proximity or cumulative-load drift remains, and is split into follow-up Issues (#147 / #148 / #149) tracked below.

## What this PR introduces

- **`MotionDriver` abstract base class** (private nested in `firmware/main/boards/stackchan/stackchan.cc`) with `StartMove` / `Tick` / `GetYawDeg` / `GetPitchDeg` / `IsMoving` / `Initialize` / `Shutdown`.
- **`HostInterpolationMotionDriver`**: the existing 50 Hz overwrite path, lifted from `ServoTask` and `WriteHeadAngles` with minimal behavioural change. Real-device behaviour on the default Kconfig path is byte-equivalent to today's `main`.
- **`ServoDelegatedMotionDriver`** (new, opt-in):
  - `StartMove` stages a target; the actual `WritePos` is performed by `Tick` on the `servo_motion` task, so callers running on `ESP_TIMER_TASK` (`TouchPollCb` → `StartServoWobble`) never block on UART I/O.
  - `Tick` step 1 dispatches any pending `WritePos` under `scs_bus_mutex_` with a per-axis freshness gate (request-token equality) immediately before each `WritePos`, plus a 10 ms inter-frame gap matching the host-interpolation path's bus-stability practice.
  - `Tick` step 2 polls `ReadMove(id)` for in-flight motion and converges per-axis state to idle.
  - `position_unknown` sentinel on `AxisMotion` is set on every path that loses physical verification (`ReadMove == -1` force-clear, `ReadMove` stuck-high past `dispatch_start_ms + move_duration_ms + kReadMoveStuckMarginMs`, `WritePos` retry exhaustion, implausibly-early `ReadMove == 0`, Phase 0' post-`ReadPos` failure) and cleared only after a confirmed `WritePos` ACK in `FinishDispatch`. This prevents a degraded bus from being silently re-interpreted as "at target" by the per-axis no-op gate.
  - `dispatch_start_ms` (set after a confirmed `WritePos` ACK) is used for the stuck-high timeout instead of staging time, so dispatch-retry latency does not eat into the servo-internal duration budget.
- **Single Kconfig switch** `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION` (**default `n`**) at `InitializeServo()`. This is the only `#if` introduced by the PR; motion logic stays path-agnostic.
- **Boot-init Phase 0 wait** is now a two-phase wait: mandatory minimum `vTaskDelay(phase0_duration_ms + 100)` (still covers the SCS0009 wake-up window on the PMIC OFF/ON path, even when `WriteHeadAngles` is a Phase 2 safe-fallback no-op) followed by an optional `motion_driver_->IsMoving()` extension up to a safety deadline (covers worst-case ServoDelegated dispatch-retry latency).
- **`WriteHeadAngles` / `ServoTaskMain`** reduced to thin wrappers around `motion_driver_->StartMove` / `motion_driver_->Tick`. Wobble cancel + `StartMove` run atomically under `motion_mutex_` so a concurrent `ServoWobbleStepAdvance` on `servo_motion` cannot dispatch a stale wobble step on top of a user-driven target.
- **`StartServoWobble`** stages `servo_wobble_step_=0, servo_wobble_active_=true` under `motion_mutex_` and lets `servo_motion` task perform the actual `ServoWobbleStepAdvance` next tick. This serialises wobble restart against in-flight step advancement and removes the dual-caller race that existed when the timer-task path called `ServoWobbleStepAdvance` directly.

## Review history (21 rounds)

Standard `codex-companion review` × 11 + `codex-companion adversarial-review` × 10. Both review streams converged to "no actionable findings" / "ready for real-device verification" before the first version of this PR was opened. Key issues caught and fixed across the review history:

- Non-recursive mutex re-entrance on the delegated path (P1; would have deadlocked first boot motion)
- Synchronous UART I/O on `ESP_TIMER_TASK` from `StartMove`, fixed by the staging-only `StartMove` + `Tick`-dispatch split
- Cross-task race between `ServoWobbleStepAdvance` (`servo_motion`) and `StartServoWobble` (`ESP_TIMER_TASK`)
- `WritePos` retry exhaustion silently dropping a request (a request that may have reached the servo while only the ACK path failed) — fixed by `position_unknown=true` on exhaustion
- `move_start_ms` ms-resolution collision for back-to-back `StartMove` calls within the same millisecond — fixed by monotonic `request_token`
- Stuck-high `ReadMove == 1` keeping `moving=true` indefinitely — bounded by `dispatch_start_ms + move_duration_ms + kReadMoveStuckMarginMs`
- False-low `ReadMove == 0` returned before the servo could physically reach target — caught by `kReadMoveEarlyMarginMs` plausibility check
- Boot Phase 0 wait being driven from staging time rather than confirmed dispatch — fixed by the two-phase wait
- Phase 0' post-`ReadPos` failure leaving seeded `current_deg` eligible for no-op suppression — fixed by setting `position_unknown=true` per axis when re-sync fails

A residual class of theoretical race windows (`motion_mutex` release → `scs_bus_mutex` acquisition gap, microseconds) remains; mitigation strategies were evaluated and judged to fall under the real-device stress testing rather than further per-round mutex layering.

## Real-device verification

Verification was performed on the maintainer's M5Stack CoreS3 + SCS0009 ×2 hardware (FeetechScs MIT default driver build) via the gateway MCP tools and pyserial monitor with the delegated path enabled (`CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y` in `firmware/sdkconfig.defaults.local`).

### 1. Boot init on the delegated path

Boot completes cleanly with `motion_driver_` set to `ServoDelegatedMotionDriver`. Phase 1a / 1b / 1c / 2 / 0 / 0' all fire as designed:

```
I (1075) StackChanBoard: PY32 IO expander READY (version=0x41, attempt=1/5)
I (1275) StackChanBoard: Servo power ENABLED via PY32 pin 0 (VM EN HIGH confirmed)
I (1495) StackChanBoard: Servo bus init: OK (Level=1, ACK enabled)
I (1935) StackChanBoard: Boot snap-suppress yaw hold(pos=314): r=0      ← Phase 1a (#137)
I (1935) StackChanBoard: Boot pre-init ReadPos: yaw_raw=314 (attempts=3) pitch_raw=-1 (attempts=5)
I (1935) StackChanBoard: Restored yaw_motion_.current_deg=-45 from ReadPos=314
W (1945) StackChanBoard: Failed to ReadPos(pitch) after 5 attempts; seeded current_deg=45
                        (BOOT_INIT_PITCH_DEG) to avoid end-stop walk during boot-init climb  ← #139 safe seed
I (5055) StackChanBoard: Boot-time servo init complete: target yaw=0 pitch=45 (move=3000ms),
                        post-ReadPos: yaw_raw=458 (attempts=1) pitch_raw=700 (attempts=1)
I (5055) StackChanBoard: Phase 0' pitch re-sync: current_deg 45 -> 25 (actual ReadPos=700, clamped to safe range 0..88)  ← #142 Phase 0'
```

Phase 0' post-init `ReadPos` re-sync correctly catches the safe-seed/actual mismatch (45 → 25 here) and the `position_unknown=true → next StartMove cannot no-op-skip` lifecycle is exercised as designed. A corner case where Phase 0' also fails its `ReadPos` retry (longer SCS0009 wake-up latency after a prior protection-mode recovery) leaves the safe seed authoritative. `get_head_angles` only observes the discrepancy (it returns the actual `ReadPos` value without updating the firmware's internal `current_deg`); reconciliation requires a user-driven `move_head` with `target ≠ safe-seed` to dispatch a fresh `WritePos`, after which subsequent moves work normally because `current_deg` is updated by `FinishDispatch`. This corner case is filed as **#150** with three proposed fix options.

### 2. Hang trigger narrowing (E1–E6) on the delegated path

Six experiments were run on the same hardware to disambiguate the hang trigger. Each row used 10 reversals; "result" reports whether the bus survived all 10 (✅) or hung at some reversal (❌).

| # | Sequence | yaw axis | pitch axis | pitch end-stop | cumulative load entering | Result |
|---|---|---|---|---|---|---|
| **E1** | `(+60, 30) ↔ (-60, 30)` | reversal | dispatch once (no-op after) | none | clean (PMIC OFF/ON) | **✅ 10/10** |
| **E2** | `(+45, 80) ↔ (-45, 10)` | reversal | reversal | **close** (8°/10° from limit) | clean | **❌ R3** |
| **E4** (after E1) | `(+45, 60) ↔ (-45, 25)` | reversal | reversal | avoided | E1 cumulative | **❌ R1** |
| **E4-fresh** | `(+45, 60) ↔ (-45, 25)` | reversal | reversal | avoided | clean (PMIC OFF/ON) | **✅ 10/10** |
| **E5** | `(0, 80) ↔ (0, 10)` | no-op (fixed 0) | reversal | **close** | E1 + E4 cumulative | **✅ 10/10** |
| **E6** | `(0, 60) ↔ (0, 25)` | no-op (fixed 0) | reversal | avoided | E1 + E4 + E5 cumulative | **✅ 10/10** |

Firmware-internal evidence at E4's R1 hang (captured via pyserial monitor):

```
I (738725) StackChanBoard: set_head_angles: yaw=45 pitch=60 motion_started=1/1      ← R1a staging
I (745025) StackChanBoard: set_head_angles: yaw=-45 pitch=25 motion_started=1/1     ← R1b staging
W (746065) StackChanBoard: Motion yaw ReadMove failed: ... 5 consecutive ReadMove
                          failures, marking position unknown and force-clearing moving
W (746075) StackChanBoard: Motion pitch ReadMove failed: ... 5 consecutive ReadMove
                          failures, marking position unknown and force-clearing moving
I (751785) StackChanBoard: get_head_angles: ReadPos failed -1 attempts=3 result=null
```

The PR's `position_unknown` sentinel fires correctly (5 consecutive `ReadMove` failures → `position_unknown=true` → `force-clear moving`), but the underlying SCS0009 bus stays in the same hard protection-mode trip state previously observed in #100; recovery still requires a PMIC long-press OFF/ON, not just a soft retry. Physical observation at hang time: torque held (head does not fall, cannot be moved by hand), no audible servo-stall buzz — consistent with an SCS0009 internal control-layer fault rather than a stall-current overload.

### 3. Hypothesis disposition

The two original hypotheses from the Issue body and previous PR description are revisited against the E1–E6 evidence:

| Hypothesis | Original verdict (light-load) | E1–E6 verdict | Status |
|---|---|---|---|
| **A: 50 Hz host-side `WritePos` overwrite is the sole root cause** | Confirmed | E4 R1 hang on delegated path under cumulative load disproves "sole" | **Partial: 50 Hz overwrite is a major contributor, but not the only trigger** |
| **B: `pitch=0` (or near end-stop) directly induces hang** | Disproved (static end-stop OK) | Pitch end-stop reached repeatedly via single-axis dispatch (E5) does not hang; only combines with two-axis simultaneous dispatch to trigger | **Refined: end-stop proximity contributes only when combined with two-axis dispatch** |

**Refined trigger condition** (E1–E6 minimal model):

```
Hang trigger = (two-axis simultaneous dispatch in same Tick) × ((pitch end-stop proximity) OR (cumulative dispatch load))
```

- Two-axis simultaneous dispatch is **necessary** (pitch-only or yaw-only repetitions never hang in E1 / E5 / E6).
- Pitch end-stop proximity (E2) **or** cumulative load (E4 after E1) is **sufficient** as the second factor.
- Two-axis simultaneous dispatch with mid-range pitch and clean cumulative state (E4-fresh) is safe.

### 4. Mitigation value vs limits of this PR

The delegated path **dramatically lowers** the bus traffic (≈ 100× fewer packets per second on motion vs the 50 Hz overwrite path) and therefore the rate at which the SCS0009 protection-mode trip threshold is approached. Under light or medium load (single-axis large-angle reversal of either axis, two-axis moves with mid-range pitch from a clean state), the delegated path completely mitigates the historical hang surface.

Under heavy load matching the refined trigger condition (two-axis simultaneous dispatch combined with end-stop proximity or accumulated session load), the bus can still trip. The `position_unknown` sentinel detects and reports this on the firmware side, but recovery requires PMIC OFF/ON; the firmware cannot reset the SCS0009 internal protection state from software.

This is why **default `n` is preserved in this PR**: shipping an opt-in path that mitigates substantially and detects residual trips, while explicitly leaving Phase 2 default flip and `firmware-vX.Y.Z` release to a subsequent change after the follow-up mitigations land.

## Acceptance criteria progress (Issue #143)

- [x] `MotionDriver` abstraction in place; only `InitializeServo()` is `#ifdef`-gated.
- [x] `HostInterpolationMotionDriver` path runs byte-equivalent to today's `main` on the default Kconfig.
- [x] `ServoDelegatedMotionDriver` boot-init Phase 0 / 0' / 1a / 1b / 1c / 2 succeeds end-to-end (delegated build verified via full pyserial boot log capture).
- [x] `ServoDelegatedMotionDriver` single-shot `WritePos` + `ReadMove` polling reproduces the Issue body's described mechanism on real hardware.
- [x] `position_unknown` sentinel fires on the false-low `ReadMove` path and on 5-consecutive-`ReadMove == -1` (both verified empirically).
- [x] Same-mechanism #100 bus hang reproducible on host-path under light load (prior verification round).
- [x] **E1**: 10× single-axis yaw reversal `(+60, 30) ↔ (-60, 30)` on delegated path — completes cleanly.
- [x] **E4-fresh**: 10× two-axis large reversal `(+45, 60) ↔ (-45, 25)` on delegated path, clean cumulative state — completes cleanly.
- [x] **E5**: 10× pitch-only large reversal with end-stop proximity `(0, 80) ↔ (0, 10)` on delegated path — completes cleanly.
- [x] **E6**: 10× pitch-only large reversal `(0, 60) ↔ (0, 25)` on delegated path — completes cleanly.
- [ ] **E2 / E4-cumulative**: two-axis simultaneous dispatch with end-stop proximity or cumulative load — **residual hang documented; mitigations split to #147 / #148 / #149**.
- [ ] 10× ESP32-only reset + 10× PMIC long-press OFF/ON boot-cycle matrix — partial (boot init verified; full matrix deferred to follow-up).
- [ ] GPL `CONFIG_STACKCHAN_SERVO_SCSCL=y` build gate — deferred to follow-up; API surface is identical and `ServoWritePosOk` already abstracts the return-value semantic.
- [ ] Default flip — **explicitly out of scope of this PR; gated on #147 / #148 / #149 mitigations and a re-verification round**.

## License boundary

Touches only:

- `firmware/main/boards/stackchan/stackchan.cc` (MIT) — main work site.
- `firmware/main/Kconfig.projbuild` (MIT) — one new entry.
- `CHANGELOG.md` — `[Unreleased]` Firmware bullet.

No changes to the GPL-3.0 `SC*.{cc,h}` SDK files in `firmware/main/boards/stackchan/`. License headers preserved untouched. The new `MotionDriver` interface and both implementations live entirely in the MIT side of the tree and use the `ScsBus` typedef (which resolves to `FeetechScs` (MIT) by default via `firmware/main/boards/stackchan/config.json`, or to `SCSCL` (GPL) when `CONFIG_STACKCHAN_SERVO_SCSCL=y`). They do not add new `#include`s of GPL headers from MIT files beyond what `stackchan.cc` already does.

`ServoWritePosOk(int r)` (already at `stackchan.cc:21-28`) absorbs the `FeetechScs` / `SCSCL` `WritePos` return-value semantic difference. Both new driver implementations route success / failure checks through this helper, not direct integer comparisons.

## Out of scope (split to follow-up Issues)

- **#144** — Remove `HostInterpolationMotionDriver` and its supporting state. Pre-conditions: this PR merged, default flipped to delegated in a subsequent release, one release of co-existence with no regressions filed.
- **#145** — `bug(firmware): touch wobble lands at pitch=0 (head pointing down) instead of preserving pre-wobble pitch`. Independent UX issue surfaced during prior light-load verification; not introduced by this refactor (the wobble's hard-coded `target_pitch = 0` predates the change and was preserved verbatim by the abstraction).
- **#147** — `feat(firmware): axis-stagger sequential dispatch for two-axis moves to mitigate SCS0009 bus hang`. Primary mitigation for the residual E2 / E4-cumulative hang trigger documented in this PR.
- **#148** — `feat(firmware): pitch end-stop proximity soft warning and optional clamp for delegated dispatch`. Supporting mitigation for the end-stop proximity factor in the trigger condition.
- **#149** — `feat(firmware): cumulative dispatch cooldown period for SCS0009 protection-threshold mitigation`. Supporting mitigation for the cumulative-load factor in the trigger condition.
- **#150** — `bug(firmware): boot pre-init safe-seed + delegated no-op gate leaves physical pitch out-of-sync with firmware current_deg after PMIC OFF/ON`. Corner case in the interaction of #138 / #139 / #142 / this PR; three fix options documented.
- **#151** — `feat(firmware): runtime ESP_LOG level adjustment via MCP tool for hang-investigation visibility`. Diagnostic improvement, would have shortened the E1–E6 narrowing time significantly.
- **Default flip** of `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION` and the associated `firmware-vX.Y.Z` release are explicitly out of scope of this PR. They are gated on the mitigation work in #147 / #148 / #149 and a re-verification round on real hardware.

## Test plan for reviewers / repo owner

- [ ] Build the default Kconfig (host-interpolation): `cd firmware && docker run --rm --cpus=4 -v "$PWD":/project -w /project espressif/idf:v5.5.2 python ./scripts/release.py stackchan`. Expect identical real-device behaviour to current `main` (default is unchanged by this PR).
- [ ] Build with `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y` appended to `sdkconfig.defaults.local`. Expect a successful build with the same `merged-binary.bin` / `xiaozhi.bin` layout.
- [ ] Flash the delegated build to a CoreS3 + SCS0009 ×2 unit and confirm boot-init Phase 0 → 0' completes (`yaw=0`, `pitch=~45` after re-sync, depending on hardware-specific backlash).
- [ ] Confirm light/medium load on the delegated build: single-axis large-angle reversals, two-axis moves with mid-range pitch from a clean state — all should complete without bus hang.
- [ ] Acknowledge the residual hang surface documented in §2 (E2 / E4-cumulative) as a known limitation handled via follow-up Issues, not a blocker for this opt-in path.
- [ ] Review CHANGELOG `[Unreleased]` Firmware entry for accurate "mitigates substantially, does not eliminate" framing.

## Summary recommendation

Merge as **opt-in (`default n`)** for the structural value: the `MotionDriver` abstraction simplifies all future motion-subsystem work, `HostInterpolationMotionDriver` provides a strict regression baseline, and `ServoDelegatedMotionDriver` provides a measured-better-than-status-quo path that early adopters can opt into and report against. Default flip remains gated on follow-up mitigations.

Refs #143. Phase B cleanup tracked under #144. Follow-up wobble landing UX bug tracked under #145. Residual hang mitigations tracked under #147 / #148 / #149. Boot-init corner case tracked under #150. Diagnostic-log improvement tracked under #151.
