### PR TITLE
chore(firmware): #152 Phase 1 — integrate smooth_ui_toolkit v2.12.0 as ESP-IDF component dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build firmware with ESP-IDF Docker image
         working-directory: firmware

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Build firmware with ESP-IDF Docker image
         # Same build command the regular CI Build workflow uses, so a

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "firmware/components/smooth_ui_toolkit"]
+	path = firmware/components/smooth_ui_toolkit
+	url = https://github.com/Forairaaaaa/smooth_ui_toolkit.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Added [`smooth_ui_toolkit`](https://github.com/Forairaaaaa/smooth_ui_toolkit)
+  v2.12.0 (MIT, Copyright (c) 2023 Forairaaaaa) as a git-submodule
+  ESP-IDF component dependency under
+  `firmware/components/smooth_ui_toolkit/`, wired into the main
+  component via `PRIV_REQUIRES`. No source-level consumer yet; this
+  stages the dependency for the upcoming motion-subsystem migration
+  tracked in
+  [#152](https://github.com/kisaragi-mochi/stackchan-mcp/issues/152)
+  (Phase 1). Contributors building from source must run
+  `git submodule update --init --recursive` after pulling.
+
 - Added a `MotionDriver` abstraction for StackChan servo motion and an
   opt-in `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION` path that delegates
   move timing to the SCS0009 via single-shot `WritePos(..., time, 0)`

--- a/README.ja.md
+++ b/README.ja.md
@@ -95,6 +95,15 @@ ESP-IDF や Docker のセットアップは不要。
 
 #### オプション B: ソースから Docker でビルド（コントリビュータ向け）
 
+このリポジトリは `firmware/components/` 配下に git submodule を使っています。
+`--recursive` を付けずに clone した場合は、先に初期化してください:
+
+```bash
+git submodule update --init --recursive
+```
+
+その後ビルド:
+
 ```bash
 cd firmware
 docker run --rm --cpus=4 --ulimit nofile=65536:65536 \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ No ESP-IDF or Docker setup needed.
 
 #### Option B: Build from source with Docker (for contributors)
 
+This repository uses git submodules under `firmware/components/`. If you
+cloned without `--recursive`, initialize them first:
+
+```bash
+git submodule update --init --recursive
+```
+
+Then build:
+
 ```bash
 cd firmware
 docker run --rm --cpus=4 --ulimit nofile=65536:65536 \

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1046,6 +1046,7 @@ idf_component_register(SRCS ${SOURCES}
                         efuse
                         bt
                         fatfs
+                        smooth_ui_toolkit
                         ${MAIN_PRIV_REQUIRES_EXTRA}
                     )
 


### PR DESCRIPTION
## Summary

Phase 1 of #152: integrate
[`smooth_ui_toolkit`](https://github.com/Forairaaaaa/smooth_ui_toolkit)
v2.12.0 (MIT, Copyright (c) 2023 Forairaaaaa) as a git-submodule
ESP-IDF component dependency under
`firmware/components/smooth_ui_toolkit/`. Wired into the `main`
component via `PRIV_REQUIRES`.

No source-level consumer yet — this stages the dependency for the
upcoming motion-subsystem migration (Issue #152 Phases 2-4). The
acceptance bar for Phase 1 is a clean Docker build with the library
available to the linker.

## Why

Issue #152 plans to replace the hand-rolled motion subsystem with the
m5stack/StackChan official motion architecture, which depends on
`smooth_ui_toolkit::SpringAnimation` for physics-based servo motion
shaping. Phase 1 brings the dependency into the build tree so
Phases 2-4 can import it without rework of the dependency layer.

The integration mirrors the m5stack/StackChan pattern: a submodule
under `firmware/components/smooth_ui_toolkit/`, declared in `main` via
`PRIV_REQUIRES`. Required because the project's top-level
`CMakeLists.txt` sets `MINIMAL_BUILD ON`, so placing the submodule
under `firmware/components/` is not sufficient on its own — `main`
must explicitly request it for the component to enter the build graph.

## Validation

- `git submodule update --init --recursive` initializes the submodule
  cleanly at tag `v2.12.0` (commit `2a18ff5`).
- Docker build via the canonical `release.py stackchan` path
  (`docker run --rm --cpus=4 --ulimit nofile=65536:65536
  -v $PWD:/project -w /project espressif/idf:v5.5.2
  python ./scripts/release.py stackchan`) completes without errors.
- `build/xiaozhi.bin` and `build/merged-binary.bin` are produced.
- No source-level consumer yet, so the linker may dead-strip the
  library symbols — that is expected and acceptable for Phase 1.
  Phase 2 will trigger linkage when motion subsystem code begins
  consuming `smooth_ui_toolkit::SpringAnimation`.

## Files changed

- `.gitmodules` (new)
- `firmware/components/smooth_ui_toolkit` (new submodule pointer at v2.12.0)
- `firmware/main/CMakeLists.txt` (`PRIV_REQUIRES` adds `smooth_ui_toolkit`)
- `README.md` / `README.ja.md` (added `git submodule update --init --recursive` note under Option B)
- `CHANGELOG.md` (`[Unreleased]` → `Firmware` entry)

## License

`smooth_ui_toolkit` is MIT (Copyright (c) 2023 Forairaaaaa). It
attaches to the MIT side of the firmware tree and does not interact
with the GPL-3.0 SCServo_lib boundary in
`firmware/main/boards/stackchan/`. No file under that GPL boundary is
touched by this PR.

## Note for contributors

After pulling this branch (or `main` after merge), run:

```
git submodule update --init --recursive
```

before rebuilding the firmware. This is documented in the updated
Option B section of `README.md` / `README.ja.md`.

Refs #152
