### PR TITLE
docs(changelog): add #141 entry for firmware-v1.6.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,29 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Added a post-init `ReadPos` re-sync step ("Phase 0'") to
+  `InitializeServo()` that re-reads the SCS0009 actual position after
+  the boot-init `WriteHeadAngles` interpolation completes and
+  overwrites `pitch_motion_.current_deg` / `yaw_motion_.current_deg`
+  with the actual physical position. This eliminates the firmware-side
+  / SCS0009-actual mismatch that the #138 safe-fallback intentionally
+  leaves behind on the PMIC long-press OFF / ON boot path, where
+  Phase 0's `WriteHeadAngles(0, 45, ...)` is a no-op of effect because
+  `current_deg` was seeded equal to the target. Without Phase 0',
+  `move_head(0, 45)` immediately after such a boot returned
+  `pitch_motion_started: 0` (firmware sees `current_deg == target`, no
+  interpolation starts), and `get_head_angles` returned the actual
+  position (e.g. 38°) — a contradictory observation hard to attribute
+  correctly without firmware-internals knowledge. Phase 0 is also now
+  distance-aware: its duration is computed from the actual
+  `current_deg → BOOT_INIT_*_DEG` delta at a new
+  `BOOT_INIT_TARGET_DEG_PER_SEC = 15 °/s` cap, floored at
+  `BOOT_INIT_MOVE_MS = 3000 ms` to keep the SCS0009 wake-up latency
+  window covered. New `BOOT_INIT_TARGET_DEG_PER_SEC` constant is
+  additive; existing `BOOT_INIT_YAW_DEG=0` / `BOOT_INIT_PITCH_DEG=45`
+  semantics preserved. Closes
+  [#141](https://github.com/kisaragi-mochi/stackchan-mcp/issues/141).
+
 - Refactored `ServoDelegatedMotionDriver` (opt-in via
   `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y`) so that bus dispatch
   and `ReadMove` polling happen per-axis under a short-hold


### PR DESCRIPTION
## Summary

Add the `[Unreleased]` Firmware CHANGELOG entry for the Phase 0' post-init `ReadPos` re-sync change introduced by PR #142 (Closes #141), which was merged after the `firmware-v1.5.0` tag but missed `CHANGELOG.md`. This commit attributes the change to the upcoming `firmware-v1.6.0` release.

## Why

`firmware-v1.5.0` was tagged at `5cf7fa4` on 2026-05-16. PR #142 (commit `e219f00`) was merged afterward, so it belongs in the next firmware release. The CHANGELOG was not updated at merge time. This PR fills that gap as part of the `firmware-v1.6.0` release preparation.

## What changed

- `CHANGELOG.md` — single new entry under `[Unreleased]` > Firmware, placed above the existing Phase 2 `ServoDelegatedMotionDriver` entry.

No firmware / gateway source code, build, or CI changes.

## Validation

- Pre-PR codex review (standard, 1 round): clean approve — "差分はCHANGELOG.mdへの追記のみで、既存の実装内容と矛盾するような明確な不具合は見当たりませんでした。リリースノートとしての整合性も既存の記述スタイルに沿っています。"
- `git diff main..HEAD --stat` confirms only `CHANGELOG.md` is touched.
- Entry text cross-checked against PR #142 description and against `firmware/main/boards/stackchan/stackchan.cc` (`InitializeServo()` / `BOOT_INIT_TARGET_DEG_PER_SEC` / `BOOT_INIT_MOVE_MS`).

## Out of scope

The pre-existing `[Unreleased]` Firmware entries that actually shipped in `firmware-v1.4.1` / `firmware-v1.5.0` and were never promoted to dated CHANGELOG sections are a separate housekeeping issue. They will be tracked under a follow-up issue rather than reshuffled here, to keep this PR's diff minimal during release preparation.

## Hardware

Not applicable — docs-only change.

## Breaking changes

None.

Refs #141, #142.
