### PR TITLE
feat(firmware): #152 Phase 3 — HostInterpolationMotionDriver spring physics with boot-init linear preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- #152 Phase 3 — replaced `HostInterpolationMotionDriver` linear
+  interpolation with `smooth_ui_toolkit` spring physics (`AnimateValue`
+  per axis, m5stack/StackChan-equivalent default spring, and
+  `duration_ms`-driven stiffness/damping mapping). The default
+  `CONFIG_STACKCHAN_SERVO_FEETECH=y` path now uses natural-spring
+  host-side interpolation; the
+  `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y` opt-in path is unchanged
+  from Phase 2 / PR #154.
+
 - Added a post-init `ReadPos` re-sync step ("Phase 0'") to
   `InitializeServo()` that re-reads the SCS0009 actual position after
   the boot-init `WriteHeadAngles` interpolation completes and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,14 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
-- #152 Phase 3 — replaced `HostInterpolationMotionDriver` linear
-  interpolation with `smooth_ui_toolkit` spring physics (`AnimateValue`
-  per axis, m5stack/StackChan-equivalent default spring, and
-  `duration_ms`-driven stiffness/damping mapping). The default
-  `CONFIG_STACKCHAN_SERVO_FEETECH=y` path now uses natural-spring
-  host-side interpolation; the
+- #152 Phase 3 — replaced normal-runtime `HostInterpolationMotionDriver`
+  linear interpolation with `smooth_ui_toolkit` spring physics
+  (`AnimateValue` per axis, m5stack/StackChan-equivalent default spring,
+  `duration_ms`-driven stiffness/damping mapping, and real-elapsed-time
+  spring ticks). The default `CONFIG_STACKCHAN_SERVO_FEETECH=y` path now
+  uses natural-spring host-side interpolation for MCP `move_head` and touch
+  wobble; boot-time `InitializeServo()` slow climb remains on
+  duration-bounded linear interpolation to avoid wake-up snap motion. The
   `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y` opt-in path is unchanged
   from Phase 2 / PR #154.
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -882,7 +882,8 @@ private:
         // WriteHeadAngles holds motion_mutex_ while calling this method; Tick()
         // and getters take the mutex internally for their own state access.
         virtual void StartMove(float yaw_deg, float pitch_deg,
-                               uint32_t duration_ms) = 0;
+                               uint32_t duration_ms,
+                               bool prefer_linear = false) = 0;
 
         // Last-known committed angle for each axis.
         virtual float GetYawDeg() const = 0;
@@ -916,9 +917,8 @@ private:
         }
 
         void StartMove(float yaw_deg, float pitch_deg,
-                       uint32_t duration_ms) override {
-            smooth_ui_toolkit::SpringOptions_t spring_options =
-                MapDurationToSpringOptions(duration_ms);
+                       uint32_t duration_ms,
+                       bool prefer_linear) override {
             uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
             int yaw = static_cast<int>(yaw_deg);
             int pitch = static_cast<int>(pitch_deg);
@@ -928,15 +928,27 @@ private:
             yaw_motion_.move_start_ms = now_ms;
             yaw_motion_.move_duration_ms = duration_ms;
             yaw_motion_.moving = (yaw_motion_.target_deg != yaw_motion_.current_deg);
-            StartAxisSpring(yaw_anim_, yaw_snap_on_rest_,
-                            yaw_motion_.current_deg, yaw,
-                            yaw_motion_.moving, spring_options);
+            yaw_linear_mode_ = prefer_linear;
 
             pitch_motion_.target_deg = pitch;
             pitch_motion_.start_deg = pitch_motion_.current_deg;
             pitch_motion_.move_start_ms = now_ms;
             pitch_motion_.move_duration_ms = duration_ms;
             pitch_motion_.moving = (pitch_motion_.target_deg != pitch_motion_.current_deg);
+            pitch_linear_mode_ = prefer_linear;
+            if (prefer_linear) {
+                yaw_anim_.teleport(static_cast<float>(yaw_motion_.current_deg));
+                yaw_snap_on_rest_ = false;
+                pitch_anim_.teleport(static_cast<float>(pitch_motion_.current_deg));
+                pitch_snap_on_rest_ = false;
+                return;
+            }
+
+            smooth_ui_toolkit::SpringOptions_t spring_options =
+                MapDurationToSpringOptions(duration_ms);
+            StartAxisSpring(yaw_anim_, yaw_snap_on_rest_,
+                            yaw_motion_.current_deg, yaw,
+                            yaw_motion_.moving, spring_options);
             StartAxisSpring(pitch_anim_, pitch_snap_on_rest_,
                             pitch_motion_.current_deg, pitch,
                             pitch_motion_.moving, spring_options);
@@ -974,21 +986,51 @@ private:
             bool new_yaw_moving;
             int new_pitch_current;
             bool new_pitch_moving;
+            bool yaw_linear_mode;
+            bool pitch_linear_mode;
+            uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
+            float dt_s;
+            // Spring mode follows real elapsed time so bus ACK latency or
+            // mutex contention does not stretch animation time indefinitely.
+            // Clamp deep preemption to avoid a single large lurch.
+            if (last_tick_us_ == 0) {
+                dt_s = static_cast<float>(MOTION_TICK_MS) / 1000.0f;
+            } else {
+                dt_s = static_cast<float>(now_us - last_tick_us_) / 1000000.0f;
+                if (dt_s > 0.1f) {
+                    dt_s = 0.1f;
+                }
+            }
+            last_tick_us_ = now_us;
+            uint32_t now_ms = static_cast<uint32_t>(now_us / 1000);
+
             xSemaphoreTake(motion_mutex_, portMAX_DELAY);
             yaw_local = yaw_motion_;
             pitch_local = pitch_motion_;
+            yaw_linear_mode = yaw_linear_mode_;
+            pitch_linear_mode = pitch_linear_mode_;
             if (!yaw_local.moving && !pitch_local.moving) {
                 xSemaphoreGive(motion_mutex_);
                 return;
             }
             new_yaw_current = yaw_local.current_deg;
             new_yaw_moving = yaw_local.moving;
-            AdvanceAxisSpring(yaw_local, yaw_anim_, yaw_snap_on_rest_,
-                              new_yaw_current, new_yaw_moving);
+            if (yaw_linear_mode) {
+                AdvanceAxisLinear(yaw_local, now_ms,
+                                  new_yaw_current, new_yaw_moving);
+            } else {
+                AdvanceAxisSpring(yaw_local, yaw_anim_, yaw_snap_on_rest_,
+                                  dt_s, new_yaw_current, new_yaw_moving);
+            }
             new_pitch_current = pitch_local.current_deg;
             new_pitch_moving = pitch_local.moving;
-            AdvanceAxisSpring(pitch_local, pitch_anim_, pitch_snap_on_rest_,
-                              new_pitch_current, new_pitch_moving);
+            if (pitch_linear_mode) {
+                AdvanceAxisLinear(pitch_local, now_ms,
+                                  new_pitch_current, new_pitch_moving);
+            } else {
+                AdvanceAxisSpring(pitch_local, pitch_anim_, pitch_snap_on_rest_,
+                                  dt_s, new_pitch_current, new_pitch_moving);
+            }
             xSemaphoreGive(motion_mutex_);
 
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
@@ -1053,14 +1095,14 @@ private:
             const AxisMotion& axis_local,
             smooth_ui_toolkit::AnimateValue& axis_anim,
             bool& snap_on_rest,
+            float dt_s,
             int& new_current_deg,
             bool& new_moving) {
             if (!axis_local.moving) {
                 return;
             }
 
-            axis_anim.updateWithDelta(
-                static_cast<float>(MOTION_TICK_MS) / 1000.0f);
+            axis_anim.updateWithDelta(dt_s);
             new_current_deg = static_cast<int>(axis_anim.directValue());
             if (axis_anim.done()) {
                 new_moving = false;
@@ -1068,6 +1110,32 @@ private:
                     new_current_deg = static_cast<int>(axis_anim.end);
                     snap_on_rest = false;
                 }
+            }
+        }
+
+        static void AdvanceAxisLinear(
+            const AxisMotion& axis_local,
+            uint32_t now_ms,
+            int& new_current_deg,
+            bool& new_moving) {
+            if (!axis_local.moving) {
+                return;
+            }
+
+            // Linear mode intentionally stays wall-clock based, matching the
+            // pre-spring interpolation path used for boot-init slow climbs;
+            // spring mode uses the real elapsed Tick delta instead.
+            uint32_t elapsed = now_ms - axis_local.move_start_ms;
+            if (axis_local.move_duration_ms == 0 ||
+                elapsed >= axis_local.move_duration_ms) {
+                new_current_deg = axis_local.target_deg;
+                new_moving = false;
+            } else {
+                int delta = axis_local.target_deg - axis_local.start_deg;
+                new_current_deg = axis_local.start_deg +
+                    static_cast<int>(
+                        static_cast<int64_t>(delta) * elapsed /
+                        axis_local.move_duration_ms);
             }
         }
 
@@ -1080,6 +1148,9 @@ private:
         smooth_ui_toolkit::AnimateValue pitch_anim_;
         bool yaw_snap_on_rest_ = false;
         bool pitch_snap_on_rest_ = false;
+        bool yaw_linear_mode_ = false;
+        bool pitch_linear_mode_ = false;
+        uint64_t last_tick_us_ = 0;
     };
 
     class ServoDelegatedMotionDriver final : public MotionDriver {
@@ -1111,7 +1182,12 @@ private:
         // "StartMove writes state; Tick drives the bus" split and keeps
         // timer-task latency bounded.
         void StartMove(float yaw_deg, float pitch_deg,
-                       uint32_t duration_ms) override {
+                       uint32_t duration_ms,
+                       bool prefer_linear) override {
+            // The delegated path is already duration-bounded by the SCS0009
+            // internal interpolation time argument; there is no host-side
+            // profile to switch.
+            (void)prefer_linear;
             uint16_t clamped = clamp_u16(duration_ms);
             if (duration_ms > clamped) {
                 static bool duration_overflow_warned = false;
@@ -2319,7 +2395,8 @@ private:
             }
             TickType_t boot_init_start_tick = xTaskGetTickCount();
             WriteHeadAngles(BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG,
-                            phase0_duration_ms);
+                            phase0_duration_ms,
+                            /* prefer_linear = */ true);
             // Two-phase boot-init wait:
             //
             // (1) Mandatory minimum: vTaskDelay until
@@ -2534,7 +2611,8 @@ private:
     // target — which would let a stale wobble step overwrite the new
     // command.
     void WriteHeadAngles(int yaw_deg, int pitch_deg,
-                         uint32_t duration_ms = MOTION_DEFAULT_DURATION_MS) {
+                         uint32_t duration_ms = MOTION_DEFAULT_DURATION_MS,
+                         bool prefer_linear = false) {
         if (!servo_ok_ || motion_driver_ == nullptr) {
             ESP_LOGW(TAG, "WriteHeadAngles skipped: servo not initialized");
             return;
@@ -2544,7 +2622,8 @@ private:
             servo_wobble_active_.store(false);
             servo_wobble_step_.store(0);
         }
-        motion_driver_->StartMove(yaw_deg, pitch_deg, duration_ms);
+        motion_driver_->StartMove(yaw_deg, pitch_deg, duration_ms,
+                                  prefer_linear);
         xSemaphoreGive(motion_mutex_);
     }
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -29,6 +29,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #endif
 #include "avatar_images.h"
 
+#include <smooth_ui_toolkit.hpp>
 #include <esp_log.h>
 #include <driver/i2c_master.h>
 #include <driver/gpio.h>
@@ -45,6 +46,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include <cJSON.h>
 #include <lvgl.h>
 #include <atomic>
+#include <cmath>
 #include <limits>
 #include <memory>
 #include <string>
@@ -833,6 +835,45 @@ private:
         return static_cast<uint16_t>(v);
     }
 
+    // Map the StartMove duration contract to spring options that approximate
+    // the requested timing. This is the stackchan-mcp side of
+    // m5stack/StackChan's map_speed_to_spring_options(speed): shorter
+    // duration -> higher stiffness/damping, longer duration -> lower
+    // stiffness/damping, with critical damping for no overshoot.
+    static smooth_ui_toolkit::SpringOptions_t MapDurationToSpringOptions(
+        uint32_t duration_ms) {
+        if (duration_ms == 0) {
+            duration_ms = 1;
+        }
+
+        float speed_f = 500.0f *
+            (static_cast<float>(MOTION_DEFAULT_DURATION_MS) /
+             static_cast<float>(duration_ms));
+        if (speed_f < 1.0f) speed_f = 1.0f;
+        if (speed_f > 1000.0f) speed_f = 1000.0f;
+        int speed = static_cast<int>(speed_f);
+
+        constexpr float kMin = 10.0f;
+        constexpr float kMax = 650.0f;
+        constexpr float kMass = 1.0f;
+        float normalized_speed = static_cast<float>(speed) / 1000.0f;
+        float stiffness =
+            kMin + (normalized_speed * normalized_speed) * (kMax - kMin);
+        float damping = 2.0f * std::sqrt(kMass * stiffness);
+
+        smooth_ui_toolkit::SpringOptions_t options;
+        options.stiffness = stiffness;
+        options.damping = damping;
+        options.mass = kMass;
+        options.velocity = 0.0f;
+        options.restDelta = speed > 800 ? 0.5f : 0.1f;
+        options.restSpeed = speed > 800 ? 0.5f : 0.1f;
+        options.duration = 0.0f;
+        options.bounce = 0.0f;
+        options.visualDuration = 0.0f;
+        return options;
+    }
+
     class MotionDriver {
     public:
         virtual ~MotionDriver() = default;
@@ -869,10 +910,15 @@ private:
               scs_bus_mutex_(scs_bus_mutex),
               motion_mutex_(motion_mutex),
               yaw_motion_(yaw_motion),
-              pitch_motion_(pitch_motion) {}
+              pitch_motion_(pitch_motion) {
+            yaw_anim_.teleport(static_cast<float>(yaw_motion_.current_deg));
+            pitch_anim_.teleport(static_cast<float>(pitch_motion_.current_deg));
+        }
 
         void StartMove(float yaw_deg, float pitch_deg,
                        uint32_t duration_ms) override {
+            smooth_ui_toolkit::SpringOptions_t spring_options =
+                MapDurationToSpringOptions(duration_ms);
             uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
             int yaw = static_cast<int>(yaw_deg);
             int pitch = static_cast<int>(pitch_deg);
@@ -882,12 +928,18 @@ private:
             yaw_motion_.move_start_ms = now_ms;
             yaw_motion_.move_duration_ms = duration_ms;
             yaw_motion_.moving = (yaw_motion_.target_deg != yaw_motion_.current_deg);
+            StartAxisSpring(yaw_anim_, yaw_snap_on_rest_,
+                            yaw_motion_.current_deg, yaw,
+                            yaw_motion_.moving, spring_options);
 
             pitch_motion_.target_deg = pitch;
             pitch_motion_.start_deg = pitch_motion_.current_deg;
             pitch_motion_.move_start_ms = now_ms;
             pitch_motion_.move_duration_ms = duration_ms;
             pitch_motion_.moving = (pitch_motion_.target_deg != pitch_motion_.current_deg);
+            StartAxisSpring(pitch_anim_, pitch_snap_on_rest_,
+                            pitch_motion_.current_deg, pitch,
+                            pitch_motion_.moving, spring_options);
         }
 
         float GetYawDeg() const override {
@@ -918,42 +970,26 @@ private:
 
             AxisMotion yaw_local;
             AxisMotion pitch_local;
+            int new_yaw_current;
+            bool new_yaw_moving;
+            int new_pitch_current;
+            bool new_pitch_moving;
             xSemaphoreTake(motion_mutex_, portMAX_DELAY);
             yaw_local = yaw_motion_;
             pitch_local = pitch_motion_;
+            if (!yaw_local.moving && !pitch_local.moving) {
+                xSemaphoreGive(motion_mutex_);
+                return;
+            }
+            new_yaw_current = yaw_local.current_deg;
+            new_yaw_moving = yaw_local.moving;
+            AdvanceAxisSpring(yaw_local, yaw_anim_, yaw_snap_on_rest_,
+                              new_yaw_current, new_yaw_moving);
+            new_pitch_current = pitch_local.current_deg;
+            new_pitch_moving = pitch_local.moving;
+            AdvanceAxisSpring(pitch_local, pitch_anim_, pitch_snap_on_rest_,
+                              new_pitch_current, new_pitch_moving);
             xSemaphoreGive(motion_mutex_);
-
-            if (!yaw_local.moving && !pitch_local.moving) return;
-
-            uint32_t now_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
-
-            int new_yaw_current = yaw_local.current_deg;
-            bool new_yaw_moving = yaw_local.moving;
-            if (yaw_local.moving) {
-                uint32_t elapsed = now_ms - yaw_local.move_start_ms;
-                if (elapsed >= yaw_local.move_duration_ms) {
-                    new_yaw_current = yaw_local.target_deg;
-                    new_yaw_moving = false;
-                } else {
-                    int delta = yaw_local.target_deg - yaw_local.start_deg;
-                    new_yaw_current = yaw_local.start_deg +
-                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / yaw_local.move_duration_ms);
-                }
-            }
-
-            int new_pitch_current = pitch_local.current_deg;
-            bool new_pitch_moving = pitch_local.moving;
-            if (pitch_local.moving) {
-                uint32_t elapsed = now_ms - pitch_local.move_start_ms;
-                if (elapsed >= pitch_local.move_duration_ms) {
-                    new_pitch_current = pitch_local.target_deg;
-                    new_pitch_moving = false;
-                } else {
-                    int delta = pitch_local.target_deg - pitch_local.start_deg;
-                    new_pitch_current = pitch_local.start_deg +
-                        static_cast<int>(static_cast<int64_t>(delta) * elapsed / pitch_local.move_duration_ms);
-                }
-            }
 
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
             if (yaw_local.moving) {
@@ -994,11 +1030,56 @@ private:
         }
 
     private:
+        static void StartAxisSpring(
+            smooth_ui_toolkit::AnimateValue& axis_anim,
+            bool& snap_on_rest,
+            int current_deg,
+            int target_deg,
+            bool moving,
+            const smooth_ui_toolkit::SpringOptions_t& spring_options) {
+            if (!moving) {
+                axis_anim.teleport(static_cast<float>(current_deg));
+                snap_on_rest = false;
+                return;
+            }
+
+            axis_anim.springOptions() = spring_options;
+            axis_anim.teleport(static_cast<float>(current_deg));
+            axis_anim = static_cast<float>(target_deg);
+            snap_on_rest = true;
+        }
+
+        static void AdvanceAxisSpring(
+            const AxisMotion& axis_local,
+            smooth_ui_toolkit::AnimateValue& axis_anim,
+            bool& snap_on_rest,
+            int& new_current_deg,
+            bool& new_moving) {
+            if (!axis_local.moving) {
+                return;
+            }
+
+            axis_anim.updateWithDelta(
+                static_cast<float>(MOTION_TICK_MS) / 1000.0f);
+            new_current_deg = static_cast<int>(axis_anim.directValue());
+            if (axis_anim.done()) {
+                new_moving = false;
+                if (snap_on_rest) {
+                    new_current_deg = static_cast<int>(axis_anim.end);
+                    snap_on_rest = false;
+                }
+            }
+        }
+
         ScsBus& scs_bus_;
         SemaphoreHandle_t& scs_bus_mutex_;
         SemaphoreHandle_t& motion_mutex_;
         AxisMotion& yaw_motion_;
         AxisMotion& pitch_motion_;
+        smooth_ui_toolkit::AnimateValue yaw_anim_;
+        smooth_ui_toolkit::AnimateValue pitch_anim_;
+        bool yaw_snap_on_rest_ = false;
+        bool pitch_snap_on_rest_ = false;
     };
 
     class ServoDelegatedMotionDriver final : public MotionDriver {


### PR DESCRIPTION
## Summary

Phase 3 of #152: replace the per-tick linear interpolation inside `HostInterpolationMotionDriver` with `smooth_ui_toolkit::AnimateValue`-driven spring physics, while preserving a linear preservation path for the boot-init slow climb to keep `InitializeServo()` wake-up motion duration-bounded.

This is the third Phase of the `hardware-from-StackChan-official` motion-subsystem migration (Phase 1 = `smooth_ui_toolkit` submodule integration via #153, Phase 2 = per-Servo independent `Update()` tick for `ServoDelegatedMotionDriver` via #154, Phase 3 = this PR).

## Background

`HostInterpolationMotionDriver` is the default Kconfig path (`CONFIG_STACKCHAN_SERVO_FEETECH=y`). Before this PR, its `Tick()` performed a `start_deg + (target_deg - start_deg) * elapsed / duration` linear interpolation per axis. m5stack/StackChan official motion uses `smooth_ui_toolkit` spring physics with a `speed (0-1000) -> stiffness/damping` quadratic mapping at the same role. Phase 3 brings the normal-runtime path closer to that official design while keeping `ServoDelegatedMotionDriver` (the opt-in `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y` path) untouched.

## Changes

### Spring physics for normal-runtime motion (commit 241acb7)

- `HostInterpolationMotionDriver` gains `smooth_ui_toolkit::AnimateValue yaw_anim_` and `pitch_anim_` private members and two static helpers `StartAxisSpring` / `AdvanceAxisSpring` for the spring lifecycle.
- A new file-scope helper `MapDurationToSpringOptions(duration_ms)` derives `SpringOptions_t` from the caller's `duration_ms` via the inverse of m5stack/StackChan's `speed -> stiffness` quadratic:
  - `speed = clamp(500 * (MOTION_DEFAULT_DURATION_MS / duration_ms), 1, 1000)`
  - `stiffness = 10 + (speed/1000)² * (650 - 10)`, mass = 1, damping = `2 * sqrt(stiffness * mass)` (critical damping, no overshoot)
  - `restSpeed` / `restDelta` = 0.5 for `speed > 800` else 0.1 (matches m5stack's high-speed micro-jitter suppression)
- `StartMove` updates `AxisMotion` state and primes `axis_anim_` (teleport to current, retarget to new target, `snap_on_rest = true`).
- `Tick` snapshots `AxisMotion` under `motion_mutex_`, advances each axis's spring, then dispatches to the SCS bus via the existing yaw → `kInterFrameGap` → pitch WritePos sequence under `scs_bus_mutex_`.

### Boot-init linear preservation + real elapsed time (commit 89bbdf6)

Applied after an adversarial review surfaced two findings against commit 241acb7:

- **Finding 1 (high)**: `MapDurationToSpringOptions` converted the 3000 ms boot-init move into a low-stiffness critical spring whose physics still peaked around 67 deg/s (front-loaded), defeating the duration-bounded velocity envelope that the prior linear path provided naturally. **Fix**: `MotionDriver::StartMove` gained an optional `bool prefer_linear = false` parameter. `HostInterpolationMotionDriver` keeps per-axis `linear_mode_` flags and a new `AdvanceAxisLinear` static helper that runs the pre-Phase-3 wall-clock `elapsed / duration` interpolation. Only `InitializeServo()`'s boot-init `WriteHeadAngles(BOOT_INIT_YAW_DEG, BOOT_INIT_PITCH_DEG, phase0_duration_ms)` call sets `prefer_linear=true`; MCP `move_head`, touch wobble, and all other callers remain on the spring path. `ServoDelegatedMotionDriver::StartMove` accepts the new argument but ignores it (the delegated path is already duration-bounded by the SCS0009 internal interpolation time).

- **Finding 2 (medium)**: `AdvanceAxisSpring` advanced the spring by `MOTION_TICK_MS/1000.0f` regardless of wall time, so WritePos ACK latency or `scs_bus_mutex_` contention stretched perceived animation duration. **Fix**: `HostInterpolationMotionDriver` tracks `last_tick_us_` via `esp_timer_get_time()` and passes the real elapsed `dt_s = (now_us - last_tick_us_) / 1e6` to the spring update. Pathological `dt_s > 100 ms` (deep preemption) is clamped to 0.1 s to avoid a single large lurch. The linear path remains wall-clock based via `esp_timer_get_time() - move_start_ms`, independent of `dt_s`; two time semantics coexist for two motion profiles by design.

### CHANGELOG

`[Unreleased]` > Firmware gains a single Phase 3 bullet covering both spring physics and the boot-init linear preservation.

## Validation

- **Pre-PR adversarial review**: two rounds. Round 1 raised Findings 1 and 2 against commit 241acb7; round 2 (against commits 241acb7 + 89bbdf6) found Findings 1 and 2 resolved. A `[medium]` ms-resolution `move_start_ms` race finding remained in round 2; that race is pre-existing (the linear-only path had it before Phase 3) and is being carved out into a follow-up Issue (see Known limitations below).
- **Local build verify**: ESP-IDF Docker `espressif/idf:v5.5.2` build via `python ./scripts/release.py stackchan` against this branch — `xiaozhi.bin` / `merged-binary.bin` artifacts produced successfully with the canonical `CONFIG_STACKCHAN_SERVO_FEETECH=y` default path enabled.
- **Real-device verification**: handed off to the repo owner after merge. Expected validation surface:
  - Boot-init `WriteHeadAngles(0, BOOT_INIT_PITCH_DEG, BOOT_INIT_MOVE_MS=3000)` produces a duration-bounded slow climb visually equivalent to the pre-PR behavior (no high-speed snap, no boot-time hang).
  - MCP `move_head` calls with `MOTION_DEFAULT_DURATION_MS=600` produce natural-feeling spring motion comparable to m5stack/StackChan official.
  - Touch wobble (`SERVO_WOBBLE_STEP_MS=350`) produces snappier spring steps than the previous linear pace.

## Known limitations

The pre-existing `HostInterpolationMotionDriver` write-back freshness guard uses ms-resolution `move_start_ms` and can collide on same-millisecond `StartMove` calls. Carved out as #158 for a follow-up PR that brings the host path's race protection in parity with `ServoDelegatedMotionDriver`'s `request_token` pattern (or moves `move_start_*` to µs resolution).

## License

- All changes confined to the MIT side (`firmware/main/boards/stackchan/stackchan.cc`, `CHANGELOG.md`).
- The 8 GPL-3.0 SCServo_lib files (`SC.{cc,h}`, `SCSCL.{cc,h}`, `SCSerial.{cc,h}`, `INST.h`, `SCServo.h`) are untouched.
- `smooth_ui_toolkit` (MIT) was integrated as a submodule in Phase 1 (#153); Phase 3 is the first PR to consume its API.

## Related

- Closes Phase 3 of #152
- Phase 2 / `ServoDelegatedMotionDriver` per-Servo refactor: #154
- Phase 1 / `smooth_ui_toolkit` submodule integration: #153
- `MotionDriver` abstraction + opt-in delegated motion path: #146
- Carved-out follow-up for ms-resolution race: #158
