### PR TITLE
fix(firmware): #158 port request_token guard to HostInterpolationMotionDriver

### DIFF
--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -898,6 +898,15 @@ private:
         // Optional hooks for drivers that need setup or shutdown.
         virtual bool Initialize() { return true; }
         virtual void Shutdown() {}
+
+        // Invalidate the freshness token for one axis. Used by board-
+        // level code that mutates AxisMotion fields directly outside
+        // StartMove (currently only InitializeServo's Phase 0' post-
+        // init ReadPos re-sync). Caller must hold motion_mutex_.
+        // Drivers without a token-based freshness guard treat this as
+        // a no-op (default implementation). Argument is SERVO_YAW_ID
+        // or SERVO_PITCH_ID; unknown values are ignored.
+        virtual void InvalidateAxisToken(int /*axis_id*/) {}
     };
 
     class HostInterpolationMotionDriver final : public MotionDriver {
@@ -911,7 +920,8 @@ private:
               scs_bus_mutex_(scs_bus_mutex),
               motion_mutex_(motion_mutex),
               yaw_motion_(yaw_motion),
-              pitch_motion_(pitch_motion) {
+              pitch_motion_(pitch_motion),
+              next_request_token_(0) {
             yaw_anim_.teleport(static_cast<float>(yaw_motion_.current_deg));
             pitch_anim_.teleport(static_cast<float>(pitch_motion_.current_deg));
         }
@@ -923,6 +933,7 @@ private:
             int yaw = static_cast<int>(yaw_deg);
             int pitch = static_cast<int>(pitch_deg);
 
+            yaw_motion_.request_token = ++next_request_token_;
             yaw_motion_.target_deg = yaw;
             yaw_motion_.start_deg = yaw_motion_.current_deg;
             yaw_motion_.move_start_ms = now_ms;
@@ -930,6 +941,7 @@ private:
             yaw_motion_.moving = (yaw_motion_.target_deg != yaw_motion_.current_deg);
             yaw_linear_mode_ = prefer_linear;
 
+            pitch_motion_.request_token = ++next_request_token_;
             pitch_motion_.target_deg = pitch;
             pitch_motion_.start_deg = pitch_motion_.current_deg;
             pitch_motion_.move_start_ms = now_ms;
@@ -1033,6 +1045,17 @@ private:
             }
             xSemaphoreGive(motion_mutex_);
 
+            // Known carve-out (#161): motion_mutex_ is released here
+            // and re-acquired after the WritePos block. If StartMove
+            // or InvalidateAxisToken (Phase 0') fires inside this
+            // release window, the WritePos calls below still send a
+            // stale interpolation step on the bus. The post-bus
+            // request_token guard below then correctly skips the
+            // current_deg / moving commit, but the physical
+            // intermediate position has already been issued. The
+            // pre-PR move_start_ms guard had the same surface; this
+            // PR does not regress that behavior. Closing the pre-bus
+            // gate is tracked separately under #161.
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
             if (yaw_local.moving) {
                 int yaw_pos = YawDegToPos(new_yaw_current);
@@ -1054,21 +1077,35 @@ private:
             xSemaphoreGive(scs_bus_mutex_);
 
             xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            if (yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
+            if (yaw_motion_.request_token == yaw_local.request_token) {
                 yaw_motion_.current_deg = new_yaw_current;
             }
             if (!new_yaw_moving && yaw_motion_.target_deg == yaw_local.target_deg
-                && yaw_motion_.move_start_ms == yaw_local.move_start_ms) {
+                && yaw_motion_.request_token == yaw_local.request_token) {
                 yaw_motion_.moving = false;
             }
-            if (pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
+            if (pitch_motion_.request_token == pitch_local.request_token) {
                 pitch_motion_.current_deg = new_pitch_current;
             }
             if (!new_pitch_moving && pitch_motion_.target_deg == pitch_local.target_deg
-                && pitch_motion_.move_start_ms == pitch_local.move_start_ms) {
+                && pitch_motion_.request_token == pitch_local.request_token) {
                 pitch_motion_.moving = false;
             }
             xSemaphoreGive(motion_mutex_);
+        }
+
+        // Bump the request token for the specified axis. Used by
+        // InitializeServo's Phase 0' re-sync so a Tick() snapshot
+        // taken before the re-sync no longer passes the post-bus
+        // freshness guard (which would otherwise overwrite the just-
+        // re-synced current_deg / moving state). Caller must hold
+        // motion_mutex_; this method does not take it.
+        void InvalidateAxisToken(int axis_id) override {
+            if (axis_id == SERVO_YAW_ID) {
+                yaw_motion_.request_token = ++next_request_token_;
+            } else if (axis_id == SERVO_PITCH_ID) {
+                pitch_motion_.request_token = ++next_request_token_;
+            }
         }
 
     private:
@@ -1144,6 +1181,29 @@ private:
         SemaphoreHandle_t& motion_mutex_;
         AxisMotion& yaw_motion_;
         AxisMotion& pitch_motion_;
+        // Monotonically increasing request id. Each StartMove increments
+        // this and writes the new value into yaw_motion_.request_token
+        // and pitch_motion_.request_token. Tick() snapshots both fields
+        // with the rest of AxisMotion and uses request_token equality
+        // (rather than move_start_ms, which only has ms resolution) to
+        // detect whether a snapshot is still the live request.
+        // InvalidateAxisToken() also bumps this counter for board-level
+        // direct AxisMotion resets that do not go through StartMove
+        // (currently only InitializeServo's Phase 0' post-init ReadPos
+        // re-sync); without that bump, a Tick() snapshot taken before
+        // such a reset would pass the post-bus freshness guard and
+        // overwrite the just-reset state. motion_mutex_ guards this
+        // counter. Canonicalizing the board ↔ driver token-invalidation
+        // boundary (e.g. moving the counter onto the board, or adding
+        // a dedicated MotionDriver override-position API) is tracked
+        // as a design improvement under #160. A separate carve-out
+        // (the pre-bus stale-WritePos race: Tick releases motion_mutex_
+        // before scs_bus_mutex_, so a StartMove / Phase 0' re-sync that
+        // lands in that release window still leaks one physical
+        // WritePos to the bus even though the post-bus commit guard
+        // here correctly rejects the AxisMotion write-back) is tracked
+        // under #161.
+        uint64_t next_request_token_ = 0;
         smooth_ui_toolkit::AnimateValue yaw_anim_;
         smooth_ui_toolkit::AnimateValue pitch_anim_;
         bool yaw_snap_on_rest_ = false;
@@ -1289,6 +1349,24 @@ private:
             yaw_axis_.Update();
             pitch_axis_.Update();
         }
+
+        // Intentionally does NOT override MotionDriver::InvalidateAxisToken.
+        // Bumping AxisMotion::request_token alone is not a sufficient
+        // cancellation boundary for the delegated path: AxisServo
+        // tracks per-axis dispatch state (pending_dispatch_, retry
+        // counters, ReadMove poll cursors) in driver-private fields
+        // that survive a Phase 0' direct AxisMotion reset, and a
+        // subsequent Update() tick could re-stage a WritePos for the
+        // freshly-reset axis even though the AxisMotion fields look
+        // clean. A full Phase 0' cancellation boundary (atomic token
+        // bump + pending_dispatch_ clear + retry-state reset) requires
+        // a larger refactor of the AxisServo state machine and is
+        // tracked separately as a design improvement under #160.
+        //
+        // Falling back to the MotionDriver base default no-op here is
+        // safe: the delegated path's Phase 0' race exists since
+        // PR #154 and this PR does not widen it. The previous behavior
+        // is preserved verbatim for this driver.
 
     private:
         static constexpr int kReadMoveFailureLimit = 5;
@@ -2534,6 +2612,16 @@ private:
                     yaw_motion_.moving = false;
                     yaw_motion_.move_start_ms =
                         (uint32_t)(boot_init_end_tick * portTICK_PERIOD_MS);
+                    // Bump the driver's request_token so any Tick()
+                    // snapshot taken before this re-sync no longer
+                    // passes the post-bus freshness guard and does
+                    // not overwrite the just-re-synced state. On the
+                    // HostInterpolation path this is a full
+                    // cancellation boundary. On the delegated path
+                    // this is a no-op (the override is intentionally
+                    // omitted; see ServoDelegatedMotionDriver and
+                    // #160 for the carved-out follow-up).
+                    motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
                     xSemaphoreGive(motion_mutex_);
                     ESP_LOGI(TAG,
                              "Phase 0' yaw re-sync: current_deg %d -> %d "
@@ -2553,6 +2641,10 @@ private:
                 // dispatches a fresh interpolation as before.
                 xSemaphoreTake(motion_mutex_, portMAX_DELAY);
                 yaw_motion_.position_unknown = true;
+                // Token bump covers the position_unknown mutation on
+                // the HostInterpolation path (same rationale as the
+                // success branch above); no-op on the delegated path.
+                motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
                 xSemaphoreGive(motion_mutex_);
                 ESP_LOGW(TAG,
                          "Phase 0' yaw re-sync skipped: ReadPos failed; "
@@ -2572,6 +2664,11 @@ private:
                     pitch_motion_.moving = false;
                     pitch_motion_.move_start_ms =
                         (uint32_t)(boot_init_end_tick * portTICK_PERIOD_MS);
+                    // Bump the driver's request_token (see the yaw
+                    // branch above for the rationale; HostInterpolation
+                    // full plug, delegated path no-op + carve-out
+                    // #160).
+                    motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
                     xSemaphoreGive(motion_mutex_);
                     ESP_LOGI(TAG,
                              "Phase 0' pitch re-sync: current_deg %d -> %d "
@@ -2584,6 +2681,10 @@ private:
             } else {
                 xSemaphoreTake(motion_mutex_, portMAX_DELAY);
                 pitch_motion_.position_unknown = true;
+                // Token bump covers the position_unknown mutation
+                // (HostInterpolation full plug, delegated no-op +
+                // carve-out #160; see the yaw fail branch above).
+                motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
                 xSemaphoreGive(motion_mutex_);
                 ESP_LOGW(TAG,
                          "Phase 0' pitch re-sync skipped: ReadPos failed; "


### PR DESCRIPTION
## Summary

Port the `request_token` write-back freshness guard from
`ServoDelegatedMotionDriver` to `HostInterpolationMotionDriver` so the
host-interpolation path shares the same protection against
same-millisecond `StartMove` races (Option A of #158), and extend the
freshness boundary to cover `InitializeServo`'s Phase 0' post-init
ReadPos re-sync on the same driver.

`HostInterpolationMotionDriver::Tick()` previously used
`move_start_ms` equality to decide whether to commit its post-bus
`current_deg` / `moving` write-back. `move_start_ms` is sourced from
`esp_timer_get_time() / 1000` (1 ms resolution), so two `StartMove`
calls landing inside the same millisecond shared the guard value and
a stale `Tick` snapshot could overwrite the newer move's state. The
fix is structurally the same pattern already in
`ServoDelegatedMotionDriver`: the per-driver monotonic
`next_request_token_` counter is incremented in `StartMove` and
written into `AxisMotion::request_token` (the struct field has
existed since PR #154 / Phase 2; only `ServoDelegatedMotionDriver`
had been consuming it).

To preserve the freshness invariant across Phase 0' direct
`AxisMotion` mutations (which do not go through `StartMove`), this PR
adds a new `MotionDriver::InvalidateAxisToken(axis_id)` hook with a
base-class no-op default. `HostInterpolationMotionDriver` overrides
it to bump the per-driver counter for the named axis (caller holds
`motion_mutex_`; the hook does not retake it). Phase 0' calls the
hook inside its existing `motion_mutex_` critical section after every
direct `AxisMotion` mutation, on both the success and the
ReadPos-failed branches for yaw and pitch.

`move_start_ms` is retained for its arithmetic role in
`AdvanceAxisLinear` (`elapsed = now_ms - move_start_ms`); only its
identity / freshness role is replaced.

Carved out from PR #159's adversarial-review round 2 (Phase 3); the
bug predates Phase 3 (the ms-resolution guard was the linear-only
era's design) but Phase 3 broadened the observable impact because the
new `smooth_ui_toolkit::AnimateValue` spring state can also diverge
from `AxisMotion` under the same race.

## Test plan

### Code-level

- [x] firmware: `python ./scripts/release.py stackchan` (Docker
      `espressif/idf:v5.5.2`, canonical
      `CONFIG_STACKCHAN_SERVO_FEETECH=y` build). Local build verify
      passes; the configuration used by `firmware-release.yml` is the
      same canonical path.
- [ ] gateway: not applicable (firmware-only change)

### Hardware

- [ ] Device boots without crash — handed to maintainer
- [ ] Existing MCP tools still work where affected: `move_head`,
      `get_head_angles` — handed to maintainer
- [ ] Existing touch/servo behavior still works where affected: tap,
      stroke, wobble — handed to maintainer
- [x] Same-millisecond `StartMove` race window is theoretical and
      self-correcting within one `MOTION_TICK_MS` (20 ms) cycle.
      Real-device behavior under normal command rate is unchanged;
      this PR raises the floor for the rare same-ms race under
      rapid MCP commands or wobble interleaving.

## Pre-PR codex review

- `review --base main` round 1: P2 finding — Phase 0' direct re-sync
  bypasses the new token guard. Addressed via the
  `InvalidateAxisToken` hook and four Phase 0' call sites.
- `adversarial-review --base main` round 2: high finding — bumping
  the token alone on `ServoDelegatedMotionDriver` does not cancel
  `AxisServo::pending_dispatch_`, so a partial override there would
  be misleading. Addressed by intentionally **not** overriding
  `InvalidateAxisToken` on the delegated driver; the delegated path
  retains its pre-PR Phase 0' behavior verbatim (no new race
  introduced). Full cancellation boundary on the delegated path is
  carved out under #160.
- `adversarial-review --base main` round 3: high finding — `Tick()`
  releases `motion_mutex_` between snapshot and `scs_bus_mutex_`, so
  a `StartMove` / Phase 0' that lands inside that release window
  still leaks one stale physical `WritePos`. This race surface
  predates this PR (the prior `move_start_ms` guard had the same
  pre-bus gap); fixing it requires either a pre-bus token re-check
  or a structural change to `Tick()`'s mutex discipline. Carved out
  under #161; this PR remains focused on Issue #158's stated scope
  (post-bus commit-guard race).

## Known limitations

- Pre-bus stale-`WritePos` race in `HostInterpolationMotionDriver::Tick()`
  (motion_mutex release window) — tracked under
  [#161](https://github.com/kisaragi-mochi/stackchan-mcp/issues/161).
  Pre-existing; not introduced or widened by this PR.
- `ServoDelegatedMotionDriver` Phase 0' cancellation boundary
  (token bump + `pending_dispatch_` clear + retry-state reset, as a
  unified `OverridePosition` API or equivalent) — tracked under
  [#160](https://github.com/kisaragi-mochi/stackchan-mcp/issues/160).
  Pre-existing since PR #154; not introduced or widened by this PR.

## License

`firmware/main/boards/stackchan/SC*.{cc,h}`, `INST.h`, `SCServo.h`
(GPL-3.0, 8 files) untouched. Change is confined to MIT-licensed
`firmware/main/boards/stackchan/stackchan.cc`. No license boundary
shift.

## Breaking changes

None. `MotionDriver` public interface gains one new optional virtual
method (`InvalidateAxisToken(int axis_id)`) with a no-op default, so
existing driver implementations continue to compile and behave
identically. `AxisMotion::request_token` field already existed
(PR #154 / Phase 2); only its consumer set widens to include
`HostInterpolationMotionDriver` and Phase 0'. `move_start_ms`
remains in `AxisMotion` for `AdvanceAxisLinear`'s elapsed
computation.

## Related issues

Closes #158
Refs #160 (delegated-path Phase 0' cancellation boundary follow-up)
Refs #161 (pre-bus stale-WritePos race carve-out)
Refs #152 (Phase 3 carve-out from adversarial-review round 2)
Refs PR #154 (Phase 2 origin of the `request_token` pattern)
