### PR TITLE
feat(firmware/gateway): #163 add set_servo_torque MCP tool for Phase 4 idle-release probe

### DIFF
--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -3945,6 +3945,120 @@ private:
                 return result;
             });
 
+        mcp_server.AddTool(
+            "self.robot.set_servo_torque",
+            "Enable or disable SCS0009 servo torque on the yaw / pitch axes "
+            "independently. Disabling torque stops motor current on that axis; "
+            "the head holds via static friction (no motion is commanded). "
+            "On disable, the corresponding axis's MotionDriver state is reset "
+            "(moving=false, position_unknown=true, request token invalidated) "
+            "so a stale interpolation cannot resume on the bus and a "
+            "subsequent same-target set_head_angles is re-dispatched rather "
+            "than no-op-optimized. Re-enabling torque does NOT trigger a "
+            "move -- the next set_head_angles or wobble call will. Returns "
+            "the per-axis bus return codes. Diagnostic / power-management "
+            "primitive; auto release on idle is tracked separately under "
+            "#152 Phase 4.",
+            PropertyList({Property("yaw_enabled", kPropertyTypeBoolean),
+                          Property("pitch_enabled", kPropertyTypeBoolean)}),
+            [this](const PropertyList& properties) -> ReturnValue {
+                bool yaw_enabled = properties["yaw_enabled"].value<bool>();
+                bool pitch_enabled = properties["pitch_enabled"].value<bool>();
+
+                // Cancel MotionDriver state for any axis whose torque is
+                // being disabled BEFORE issuing the EnableTorque bus
+                // frame. Without this ordering, ServoTask could snapshot
+                // motion state while moving=true, wait on scs_bus_mutex_
+                // through our EnableTorque(OFF), then fire one stale
+                // WritePos on the freshly-disabled axis right after we
+                // release scs_bus_mutex_ (silently absorbed while torque
+                // is off, then resuming audibly when torque comes back).
+                // Performing the cancellation first lets the next Tick
+                // observe moving=false / a fresh request_token before it
+                // commits any WritePos. position_unknown forces the
+                // delegated path to re-dispatch the next move
+                // (HostInterpolation ignores the flag, but the
+                // moving=false + token bump already block resumption
+                // there). Re-enable is treated as a user-driven re-
+                // anchor: the caller is expected to use get_head_angles
+                // + set_head_angles to re-establish a verified position
+                // if needed.
+                //
+                // Known carve-out (#160): on the delegated path,
+                // ServoDelegatedMotionDriver does not override
+                // InvalidateAxisToken, and the per-axis AxisServo private
+                // pending_dispatch_ / retry-state is not cleared by this
+                // path. A subsequent Update() tick can therefore still
+                // re-stage a WritePos on the freshly-disabled axis from
+                // pending state captured before this call. Full
+                // delegated-path cancellation requires the same refactor
+                // tracked under #160 and is out of scope for this probe.
+                if (motion_driver_ != nullptr && motion_mutex_ != nullptr &&
+                    (!yaw_enabled || !pitch_enabled)) {
+                    xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                    if (!yaw_enabled) {
+                        yaw_motion_.moving = false;
+                        yaw_motion_.position_unknown = true;
+                        motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
+                    }
+                    if (!pitch_enabled) {
+                        pitch_motion_.moving = false;
+                        pitch_motion_.position_unknown = true;
+                        motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
+                    }
+                    // Also cancel any in-flight servo wobble sequence.
+                    // Wobble drives both axes through ServoTaskMain's
+                    // ServoWobbleStepAdvance after Tick; without
+                    // clearing the active flag here, the next tick
+                    // would observe moving==false and stage the next
+                    // wobble StartMove with torque off, enqueuing fresh
+                    // WritePos targets that would run on re-enable.
+                    // Mirrors the wobble-cancel sequence in
+                    // WriteHeadAngles.
+                    servo_wobble_active_.store(false);
+                    servo_wobble_step_.store(0);
+                    xSemaphoreGive(motion_mutex_);
+                }
+
+                int r_yaw = -1;
+                int r_pitch = -1;
+                if (servo_ok_ && scs_bus_mutex_ != nullptr) {
+                    xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+                    r_yaw = scs_bus_.EnableTorque(SERVO_YAW_ID,
+                                                  yaw_enabled ? 1 : 0);
+                    r_pitch = scs_bus_.EnableTorque(SERVO_PITCH_ID,
+                                                    pitch_enabled ? 1 : 0);
+                    xSemaphoreGive(scs_bus_mutex_);
+                }
+
+#if CONFIG_STACKCHAN_SERVO_FEETECH
+                bool yaw_ok = (r_yaw == 0);
+                bool pitch_ok = (r_pitch == 0);
+#else
+                bool yaw_ok = (r_yaw > 0);
+                bool pitch_ok = (r_pitch > 0);
+#endif
+
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "yaw_enabled", yaw_enabled);
+                cJSON_AddBoolToObject(root, "pitch_enabled", pitch_enabled);
+                cJSON_AddNumberToObject(root, "yaw_bus_return", r_yaw);
+                cJSON_AddNumberToObject(root, "pitch_bus_return", r_pitch);
+                cJSON_AddBoolToObject(root, "servo_ok", servo_ok_);
+                cJSON_AddBoolToObject(root, "ok", servo_ok_ && yaw_ok && pitch_ok);
+                if (!servo_ok_) {
+                    cJSON_AddStringToObject(root, "error",
+                                            "Servo bus not initialized.");
+                }
+                ESP_LOGI(TAG,
+                         "set_servo_torque: servo_ok=%d yaw_enabled=%d (r=%d) "
+                         "pitch_enabled=%d (r=%d)",
+                         servo_ok_ ? 1 : 0,
+                         (int)yaw_enabled, r_yaw,
+                         (int)pitch_enabled, r_pitch);
+                return root;
+            });
+
         // Diagnostic: toggle GPIO6 (servo TX) HIGH/LOW to verify physical signal
         mcp_server.AddTool(
             "self.robot.gpio_test",

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -297,6 +297,44 @@ def create_server() -> Server:
                 },
             ),
             Tool(
+                name="set_servo_torque",
+                description=(
+                    "Enable or disable SCS0009 servo torque on the yaw / "
+                    "pitch axes independently. Disabling torque stops motor "
+                    "current on that axis; the head holds via static "
+                    "friction (no motion is commanded). On disable, the "
+                    "firmware also cancels any in-flight MotionDriver "
+                    "interpolation and marks the axis position unknown so "
+                    "a subsequent same-target set_head_angles is re-"
+                    "dispatched rather than no-op-optimized. Re-enabling "
+                    "torque does NOT trigger a move; the next "
+                    "set_head_angles or wobble call will. Diagnostic / "
+                    "power-management primitive used to observe physical "
+                    "head behavior under torque-off (Issue #163; auto "
+                    "release on idle is Issue #152 Phase 4)."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "yaw_enabled": {
+                            "type": "boolean",
+                            "description": (
+                                "True to enable yaw axis torque, false to "
+                                "disable."
+                            ),
+                        },
+                        "pitch_enabled": {
+                            "type": "boolean",
+                            "description": (
+                                "True to enable pitch axis torque, false "
+                                "to disable."
+                            ),
+                        },
+                    },
+                    "required": ["yaw_enabled", "pitch_enabled"],
+                },
+            ),
+            Tool(
                 name="get_touch_state",
                 description=(
                     "Read the head-touch (Si12T) sensor state and the most recent "
@@ -675,6 +713,10 @@ def create_server() -> Server:
             ),
             "set_blink": (
                 "self.display.set_blink",
+                arguments,
+            ),
+            "set_servo_torque": (
+                "self.robot.set_servo_torque",
                 arguments,
             ),
             "get_touch_state": (


### PR DESCRIPTION
## Summary

Add a new MCP tool `self.robot.set_servo_torque(yaw_enabled,
pitch_enabled)` to firmware + gateway. The tool toggles SCS0009 torque
on each axis independently via `ScsBus::EnableTorque(id, enable)`. It
is a **diagnostic probe** for #152 Phase 4 (auto-torque-release on
idle): the maintainer can call it to physically observe whether the
head holds via static friction or drifts under gravity with torque off
on real hardware, before the auto-release timer is designed.

### What the firmware does on disable

When at least one axis is disabled, the handler runs (under the same
`motion_mutex_`-protected critical section, **before** the
`EnableTorque` bus frame):

1. `axis_motion_.moving = false` for the disabled axis.
2. `axis_motion_.position_unknown = true`.
3. `motion_driver_->InvalidateAxisToken(axis_id)` — bumps the freshness
   token (Issue #158 / PR #162 mechanism) so any in-flight Tick
   snapshot is invalidated.
4. `servo_wobble_active_.store(false)` and `servo_wobble_step_.store(0)`
   — cancels any in-flight wobble sequence (mirrors
   `WriteHeadAngles`'s wobble-cancel block).

Doing the state cancellation **before** the `EnableTorque` bus frame
narrows the window in which a stale Tick can emit one last `WritePos`
after `scs_bus_mutex_` is released.

### What the firmware does on enable

Nothing beyond the bus frame itself. The intended workflow is: the
caller reuses `get_head_angles` (which reads the SCS0009 raw position,
independent of torque state) plus a fresh `set_head_angles` to
re-anchor the firmware's internal `current_deg` if needed. `EnableTorque`
re-enable does not trigger any motion.

### Gateway exposure

`gateway/stackchan_mcp/stdio_server.py` adds the matching `Tool(...)`
entry in `list_tools()` (boolean inputSchema for each axis) and the
matching `tool_map` entry (`"set_servo_torque" → "self.robot.set_servo_torque"`).
The `mcp_router.py` subset path is unchanged; this probe is exposed on
the standard stdio MCP path.

## Test plan

### Code-level

- [x] firmware: `python ./scripts/release.py stackchan` (Docker
      `espressif/idf:v5.5.2`, canonical
      `CONFIG_STACKCHAN_SERVO_FEETECH=y` build). Builds clean; new tool
      symbol present in the linked binary.
- [ ] gateway: no automated test added — the new entry follows the same
      shape as `set_blink` (which has no dedicated test) and is dispatched
      through the same `tool_map` mechanism.

### Hardware

- [ ] Device boots without crash, existing MCP tools unaffected —
      handed to maintainer
- [ ] **Idle-state probe** (primary use case): `set_servo_torque(false,
      false)` from rest; observe whether the head holds (static
      friction) or drifts (gravity). `set_servo_torque(true, true)` to
      re-enable; verify subsequent `set_head_angles` resumes normal
      motion from the post-OFF physical position via the
      `get_head_angles` + `set_head_angles` re-anchor pattern — handed
      to maintainer
- [ ] **Mid-motion disable**: call `set_servo_torque(false, false)`
      during an active `set_head_angles` interpolation; verify the
      ServoTask stops emitting `WritePos` ticks (any leak is the
      carved-out `#161` pre-bus race) — handed to maintainer
- [ ] **Mid-wobble disable**: trigger a touch wobble, then disable
      torque mid-wobble; verify the wobble sequence does not resume
      after `set_servo_torque(true, true)` — handed to maintainer

## Pre-PR codex review

`review --base main`, four rounds. Findings addressed inline this PR:

- R1 P2: cancel `MotionDriver` state on disable → addressed (motion
  state cancellation block).
- R2 P2: expose the tool on the gateway side → addressed
  (`stdio_server.py` additions).
- R2 P2: stale `WritePos` ordering — disable bus frame fired before
  motion state cancel → addressed (reordered: cancel first, then bus
  frame).
- R2 P2: delegated path `pending_dispatch_` not cleared → carved out
  under **#160**, documented inline in the handler.
- R3 P2: in-flight wobble cancel → addressed (`servo_wobble_active_`
  cleared in the same critical section).
- R4 P2: pre-bus stale `WritePos` window in `Tick()` (the
  cancellation-before-bus-frame ordering narrows it but does not
  eliminate it on the host-interpolation path) → same pre-bus race
  surface as **#161** (pre-existing). Carved out; this probe does not
  introduce or widen it.
- R4 P2: `HostInterpolationMotionDriver::StartMove` does not consult
  `position_unknown`, so a same-target `set_head_angles` after a
  torque-off + hand-push can be no-op-optimized → carved out under
  **#160** (the broader `position_unknown` honoring across both drivers
  is part of the canonicalization).

## Known limitations

- **Pre-bus stale `WritePos` race** in
  `HostInterpolationMotionDriver::Tick()` when torque is disabled
  mid-interpolation: same race surface as
  [#161](https://github.com/kisaragi-mochi/stackchan-mcp/issues/161),
  pre-existing, not introduced by this PR. The cancellation-before-bus-
  frame ordering in this handler narrows the window; closing it
  requires the same pre-bus token gate tracked under #161.
- **Same-target re-dispatch after a torque-off hand-push**: the
  default host-interpolation path does not honor `position_unknown` in
  `StartMove`, so the documented "re-anchor with
  `get_head_angles` + `set_head_angles`" workflow is required after a
  manual reposition under torque-off. Honoring `position_unknown` in
  `HostInterpolationMotionDriver::StartMove` is part of the broader
  canonicalization tracked under
  [#160](https://github.com/kisaragi-mochi/stackchan-mcp/issues/160).
- **Delegated path `pending_dispatch_`** is not cleared by the
  cancellation block; the `AxisServo` private state machine refactor
  is tracked under #160.

## License

`firmware/main/boards/stackchan/SC*.{cc,h}`, `INST.h`, `SCServo.h`
(GPL-3.0) untouched. Firmware change is confined to MIT-licensed
`stackchan.cc`; `ScsBus::EnableTorque` is the MIT-canonical
FeetechScs-path abstraction. Gateway change is in
`gateway/stackchan_mcp/stdio_server.py` (MIT).

## Breaking changes

None. The new MCP tool is additive on both firmware and gateway sides;
existing tools and startup behavior are unchanged.

## Related issues

Closes #163
Refs #152 (Phase 4 auto-release follow-up that this probe informs)
Refs #160 (delegated-path / host-interpolation cancellation
canonicalization — covers F4/F6 carve-outs above)
Refs #161 (pre-bus stale-`WritePos` race — covers F5 carve-out above)
