### PR TITLE
fix(firmware): #160 close ServoDelegatedMotionDriver Phase 0' / set_servo_torque cancellation boundary

### DIFF
--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -901,8 +901,20 @@ private:
 
         // Invalidate the freshness token for one axis. Used by board-
         // level code that mutates AxisMotion fields directly outside
-        // StartMove (currently only InitializeServo's Phase 0' post-
-        // init ReadPos re-sync). Caller must hold motion_mutex_.
+        // StartMove (currently InitializeServo's Phase 0' post-init
+        // ReadPos re-sync, and the set_servo_torque MCP tool's
+        // disable path). Caller must hold motion_mutex_.
+        //
+        // HostInterpolationMotionDriver: bumps the per-axis
+        // request_token, defeating any post-bus freshness check from a
+        // Tick() snapshot taken before the external mutation.
+        //
+        // ServoDelegatedMotionDriver: bumps the per-axis request_token
+        // AND clears the corresponding AxisServo's per-axis private
+        // cancellation state (pending_dispatch_, dispatch_failures_,
+        // readmove_failures_), atomically with the caller's motion_mutex_
+        // hold.
+        //
         // Drivers without a token-based freshness guard treat this as
         // a no-op (default implementation). Argument is SERVO_YAW_ID
         // or SERVO_PITCH_ID; unknown values are ignored.
@@ -1047,15 +1059,15 @@ private:
 
             // Known carve-out (#161): motion_mutex_ is released here
             // and re-acquired after the WritePos block. If StartMove
-            // or InvalidateAxisToken (Phase 0') fires inside this
-            // release window, the WritePos calls below still send a
-            // stale interpolation step on the bus. The post-bus
-            // request_token guard below then correctly skips the
-            // current_deg / moving commit, but the physical
+            // or InvalidateAxisToken (Phase 0' / torque disable) fires
+            // inside this release window, the WritePos calls below
+            // still send a stale interpolation step on the bus. The
+            // post-bus request_token guard below then correctly skips
+            // the current_deg / moving commit, but the physical
             // intermediate position has already been issued. The
-            // pre-PR move_start_ms guard had the same surface; this
-            // PR does not regress that behavior. Closing the pre-bus
-            // gate is tracked separately under #161.
+            // pre-PR move_start_ms guard had the same surface; this PR
+            // does not regress that behavior. Closing the pre-bus gate
+            // is tracked separately under #161.
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
             if (yaw_local.moving) {
                 int yaw_pos = YawDegToPos(new_yaw_current);
@@ -1189,19 +1201,13 @@ private:
         // detect whether a snapshot is still the live request.
         // InvalidateAxisToken() also bumps this counter for board-level
         // direct AxisMotion resets that do not go through StartMove
-        // (currently only InitializeServo's Phase 0' post-init ReadPos
-        // re-sync); without that bump, a Tick() snapshot taken before
-        // such a reset would pass the post-bus freshness guard and
-        // overwrite the just-reset state. motion_mutex_ guards this
-        // counter. Canonicalizing the board ↔ driver token-invalidation
-        // boundary (e.g. moving the counter onto the board, or adding
-        // a dedicated MotionDriver override-position API) is tracked
-        // as a design improvement under #160. A separate carve-out
-        // (the pre-bus stale-WritePos race: Tick releases motion_mutex_
-        // before scs_bus_mutex_, so a StartMove / Phase 0' re-sync that
-        // lands in that release window still leaks one physical
-        // WritePos to the bus even though the post-bus commit guard
-        // here correctly rejects the AxisMotion write-back) is tracked
+        // (currently InitializeServo's Phase 0' post-init ReadPos
+        // re-sync and the set_servo_torque disable path); without that
+        // bump, a Tick() snapshot taken before such a reset would pass
+        // the post-bus freshness guard and overwrite the just-reset
+        // state. motion_mutex_ guards this counter. The pre-bus
+        // stale-WritePos race, where an external reset lands after the
+        // snapshot but before the bus frame, is tracked separately
         // under #161.
         uint64_t next_request_token_ = 0;
         smooth_ui_toolkit::AnimateValue yaw_anim_;
@@ -1350,23 +1356,47 @@ private:
             pitch_axis_.Update();
         }
 
-        // Intentionally does NOT override MotionDriver::InvalidateAxisToken.
-        // Bumping AxisMotion::request_token alone is not a sufficient
-        // cancellation boundary for the delegated path: AxisServo
-        // tracks per-axis dispatch state (pending_dispatch_, retry
-        // counters, ReadMove poll cursors) in driver-private fields
-        // that survive a Phase 0' direct AxisMotion reset, and a
-        // subsequent Update() tick could re-stage a WritePos for the
-        // freshly-reset axis even though the AxisMotion fields look
-        // clean. A full Phase 0' cancellation boundary (atomic token
-        // bump + pending_dispatch_ clear + retry-state reset) requires
-        // a larger refactor of the AxisServo state machine and is
-        // tracked separately as a design improvement under #160.
+        // Caller holds motion_mutex_. Bumps next_request_token_ for the
+        // specified axis (mirrors HostInterpolationMotionDriver's
+        // implementation) AND clears the per-AxisServo private
+        // cancellation state via OnExternalReset(), so that a Stage()
+        // call that preceded the external mutation does not leak a stale
+        // WritePos onto the bus from the next Update() tick.
         //
-        // Falling back to the MotionDriver base default no-op here is
-        // safe: the delegated path's Phase 0' race exists since
-        // PR #154 and this PR does not widen it. The previous behavior
-        // is preserved verbatim for this driver.
+        // Used by InitializeServo's Phase 0' post-init ReadPos re-sync
+        // and by the set_servo_torque MCP tool's disable path.
+        //
+        // Closing this cancellation boundary required a paired AxisMotion
+        // (visible) + AxisServo (driver-private) atomic reset: bumping
+        // the visible request_token alone (the default no-op fallback
+        // this driver used to inherit) was insufficient because
+        // pending_dispatch_ / dispatch_failures_ / readmove_failures_
+        // survived a Phase 0' direct AxisMotion mutation and the next
+        // Update() tick would re-issue a WritePos for the stale staged
+        // target. Issue #160 tracks the design discussion and the
+        // adversarial review that converged on this Option A design.
+        //
+        // Scope note: this closes the post-Update / next-tick race only.
+        // A snapshot taken by Update() BEFORE the external reset still
+        // carries a local `dispatch = true` boolean (Update()'s local
+        // variable, not the member field) that survives this member-
+        // state clear. The in-flight Dispatch() then passes the
+        // request_token freshness gate at the pre-WritePos check (which
+        // now sees a bumped token) and skips the WritePos itself, so
+        // the bus is not touched with a stale frame — but the call
+        // still acquires scs_bus_mutex_ once before returning. The
+        // pre-bus stale-command race (Issue #161) is the remaining
+        // cancellation-boundary layer and is intentionally NOT closed
+        // by this PR.
+        void InvalidateAxisToken(int axis_id) override {
+            if (axis_id == SERVO_YAW_ID) {
+                yaw_motion_.request_token = ++next_request_token_;
+                yaw_axis_.OnExternalReset();
+            } else if (axis_id == SERVO_PITCH_ID) {
+                pitch_motion_.request_token = ++next_request_token_;
+                pitch_axis_.OnExternalReset();
+            }
+        }
 
     private:
         static constexpr int kReadMoveFailureLimit = 5;
@@ -1485,6 +1515,31 @@ private:
                     PollReadMove(snapshot);
                 }
                 return false;
+            }
+
+            // Caller must hold motion_mutex_. Clears the per-axis private
+            // cancellation state so that a subsequent Update() tick observes
+            // a clean slate after the board-level code directly mutates
+            // AxisMotion outside the Stage() path (currently
+            // InitializeServo's Phase 0' post-init ReadPos re-sync and the
+            // set_servo_torque MCP tool's disable path).
+            //
+            // Does NOT take any semaphore (motion_mutex_ is already held by
+            // the caller; double-take of the non-recursive FreeRTOS
+            // semaphore would deadlock). Does NOT touch the SCS bus. Does
+            // NOT touch motion_ (AxisMotion); the caller has already mutated
+            // it before invoking this method through
+            // ServoDelegatedMotionDriver::InvalidateAxisToken.
+            //
+            // INVARIANT: every new AxisServo private cancellation-state
+            // field added in the future MUST be added to this reset.
+            // Otherwise external resets (Phase 0' / torque disable / any
+            // future cancellation caller) will leave stale state that the
+            // next Update() may act on, regressing the Issue #160 fix.
+            void OnExternalReset() {
+                pending_dispatch_ = false;
+                dispatch_failures_ = 0;
+                readmove_failures_ = 0;
             }
 
         private:
@@ -2615,12 +2670,10 @@ private:
                     // Bump the driver's request_token so any Tick()
                     // snapshot taken before this re-sync no longer
                     // passes the post-bus freshness guard and does
-                    // not overwrite the just-re-synced state. On the
-                    // HostInterpolation path this is a full
-                    // cancellation boundary. On the delegated path
-                    // this is a no-op (the override is intentionally
-                    // omitted; see ServoDelegatedMotionDriver and
-                    // #160 for the carved-out follow-up).
+                    // not overwrite the just-re-synced state. The
+                    // delegated driver also clears its per-axis
+                    // private cancellation state under the same
+                    // motion_mutex_ hold.
                     motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
                     xSemaphoreGive(motion_mutex_);
                     ESP_LOGI(TAG,
@@ -2641,9 +2694,9 @@ private:
                 // dispatches a fresh interpolation as before.
                 xSemaphoreTake(motion_mutex_, portMAX_DELAY);
                 yaw_motion_.position_unknown = true;
-                // Token bump covers the position_unknown mutation on
-                // the HostInterpolation path (same rationale as the
-                // success branch above); no-op on the delegated path.
+                // Token/state invalidation covers the position_unknown
+                // mutation using the same external-reset boundary as
+                // the success branch above.
                 motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
                 xSemaphoreGive(motion_mutex_);
                 ESP_LOGW(TAG,
@@ -2664,10 +2717,8 @@ private:
                     pitch_motion_.moving = false;
                     pitch_motion_.move_start_ms =
                         (uint32_t)(boot_init_end_tick * portTICK_PERIOD_MS);
-                    // Bump the driver's request_token (see the yaw
-                    // branch above for the rationale; HostInterpolation
-                    // full plug, delegated path no-op + carve-out
-                    // #160).
+                    // Invalidate the driver's token/state boundary
+                    // (see the yaw branch above for the rationale).
                     motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
                     xSemaphoreGive(motion_mutex_);
                     ESP_LOGI(TAG,
@@ -2681,9 +2732,9 @@ private:
             } else {
                 xSemaphoreTake(motion_mutex_, portMAX_DELAY);
                 pitch_motion_.position_unknown = true;
-                // Token bump covers the position_unknown mutation
-                // (HostInterpolation full plug, delegated no-op +
-                // carve-out #160; see the yaw fail branch above).
+                // Invalidate the driver's token/state boundary for the
+                // position_unknown mutation (see the yaw fail branch
+                // above).
                 motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
                 xSemaphoreGive(motion_mutex_);
                 ESP_LOGW(TAG,


### PR DESCRIPTION
## Summary

Close the `ServoDelegatedMotionDriver` Phase 0' / `set_servo_torque`
cancellation boundary by providing a complete `InvalidateAxisToken(axis_id)`
override that both bumps the per-axis `request_token` AND clears the
per-`AxisServo` private dispatch/retry state (`pending_dispatch_`,
`dispatch_failures_`, `readmove_failures_`) atomically under the caller-held
`motion_mutex_`.

Implements **Option A** from the Issue #160 design review (independent
adversarial review pre-converged on Option A; implementation adversarial
review converged in 1 round with no material findings).

Closes #160.

## Why

After #158 / #162 ported the `request_token` guard from
`ServoDelegatedMotionDriver` to `HostInterpolationMotionDriver` and added the
`InvalidateAxisToken(axis_id)` interface, the Host path's Phase 0' cancellation
boundary became complete. The ServoDelegated driver was carved out as
"intentionally does NOT override" because bumping `request_token` alone did
not cover the AxisServo private state — `pending_dispatch_=true` from a
pre-reset `Stage()` would still cause the next `Update()` tick to issue a
WritePos for the stale staged target even though the visible AxisMotion
fields had been reset by Phase 0' or by the `set_servo_torque` disable path.

This PR finishes that carve-out by adding `AxisServo::OnExternalReset()` and
the corresponding `InvalidateAxisToken(axis_id)` override.

## What changed

**Single file**: `firmware/main/boards/stackchan/stackchan.cc` (+106 / −55,
net +51 lines). The deletions are stale carve-out comments that the new
implementation supersedes; no code logic is removed.

1. **`AxisServo::OnExternalReset()`** — new public method on the
   `ServoDelegatedMotionDriver::AxisServo` nested class. Clears
   `pending_dispatch_`, `dispatch_failures_`, `readmove_failures_`. Caller
   must hold `motion_mutex_`. Does not take any semaphore, does not touch the
   SCS bus, does not mutate `motion_` (AxisMotion). An `INVARIANT` comment
   marks the method as the required reset surface for every new AxisServo
   private cancellation-state field added in the future.

2. **`ServoDelegatedMotionDriver::InvalidateAxisToken(int axis_id)`
   override** — replaces the old "Intentionally does NOT override" comment
   block. Bumps the per-axis `request_token` (mirrors
   `HostInterpolationMotionDriver`'s implementation) and calls the
   corresponding `AxisServo::OnExternalReset()` under the caller's
   `motion_mutex_` hold.

3. **`MotionDriver::InvalidateAxisToken()` base comment** — updated to list
   both callers (Phase 0' post-init ReadPos re-sync AND
   `set_servo_torque` disable path) and to spell out the
   per-driver behavior contract (`HostInterpolation` = token-only;
   `ServoDelegated` = token + AxisServo private-state reset).

4. **Stale comment touch-ups** — Host driver's `Tick()` carve-out comment
   (mentions `set_servo_torque` now alongside Phase 0'), Host driver's
   `next_request_token_` member comment (drops obsolete "design improvement
   under #160" wording), and the four `InitializeServo` Phase 0' callers'
   helper comments (drop obsolete "delegated no-op + carve-out #160"
   wording). All updates are factual corrections; no behavioral changes.

**No existing callers are modified**: `InitializeServo` Phase 0' (4 sites)
and `set_servo_torque` (2 sites) already invoke
`motion_driver_->InvalidateAxisToken(SERVO_*_ID)` and pick up the new
delegated-path semantics automatically.

## What is NOT in scope

The **pre-bus stale-command race (#161)** — Tick releases `motion_mutex_`
before `scs_bus_mutex_`, so an external reset that lands in the release
window still leaks one physical WritePos to the bus even though the post-bus
commit guard correctly rejects the write-back — is **intentionally NOT
closed by this PR**. The new override's scope-note comment block documents
this carve-out explicitly. The remaining cancellation-boundary layer is
tracked under #161.

A snapshot taken by `Update()` BEFORE the external reset still carries a
local `dispatch = true` boolean (Update()'s local variable, not the member
field) that survives this member-state clear. The in-flight `Dispatch()`
then passes the `request_token` freshness gate at the pre-WritePos check
(which now sees a bumped token) and skips the WritePos itself, so the bus
is **not** touched with a stale frame — but the call still acquires
`scs_bus_mutex_` once before returning. This is acceptable and is the
intended cancellation boundary for Option A.

## Validation

### Build verify

```
cd firmware
docker run --rm --cpus=4 -v "$PWD":/project -w /project espressif/idf:v5.5.2 \
  python ./scripts/release.py stackchan
```

Result: incremental build PASSED in 3 m 27 s. `build/xiaozhi.bin` 3.3 M,
`build/merged-binary.bin` 9.5 M. Partition: 17 % free.

### Adversarial review

`codex adversarial-review --base main` converged in **1 round**, verdict:
**approve / no material findings**, against the five focus areas:

1. Lock-order/contract correctness of `OnExternalReset` (caller-held
   `motion_mutex_`, no semaphore taken, no SCS bus touched, no AxisMotion
   write).
2. `InvalidateAxisToken` atomicity between token bump and `OnExternalReset`
   under the caller's `motion_mutex_` hold.
3. Preservation of the #161 pre-bus stale-command race carve-out.
4. `AxisServo` INVARIANT comment completeness (all existing per-axis
   private cancellation fields listed).
5. Consistency of the updated stale-comment touch-ups.

### Real-device verification (M5Stack CoreS3 + SCS0009 × 2 hardware)

**ESP32 soft reset path** (esptool hard_reset; servo power maintained):

- Boot log captured the snap-suppress hold (PR #137), boot pre-init ReadPos
  retry success on both axes (PR #139 retry budget), and the Phase 0' pitch
  re-sync `current_deg 45 → 44` event that fires
  `motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID)` on the success
  branch.
- MCP regression: `move_head(0, 45) → get_head_angles → move_head(20, 30)
  → get_head_angles → move_head(0, 45) → get_head_angles` returned
  command-aligned positions on every call (post-quantization within ±1°).
  No bus hang, no ReadPos failure.

**PMIC long-press OFF / short-press ON fresh boot path** (servo power
cycled — exercises Issue #138 / PR #139 paths and the cumulative-WritePos
state in Issue #165 hypothesis terms):

- Boot pre-init ReadPos: yaw `attempts=2`, pitch `attempts=5` → **pitch
  ReadPos exhausted**, triggering PR #139's `safe_seed` path
  (`current_deg = 45 = BOOT_INIT_PITCH_DEG`).
- Phase 0' executed both branches: yaw on the success branch
  (`yaw_motion_.current_deg = 0` commit), pitch on the
  `position_unknown = true` fail branch (ReadPos still failed on the
  re-sync attempt for the seeded pitch path) — both branches invoke
  `motion_driver_->InvalidateAxisToken(SERVO_*_ID)` and exercise the new
  ServoDelegated override.
- Boot log line:
  `Phase 0' pitch re-sync: current_deg 45 -> 44 (actual ReadPos=763,
  clamped to safe range 0..88)` confirms the success-branch re-sync also
  ran on the post-init ReadPos retry.
- No regression in `get_head_angles` post-boot (returned
  `{yaw:0, pitch:44}` consistently in matching session conditions).

The cancellation boundary is now closed on both motion drivers under both
boot paths.

## License boundary

Unchanged. Only `firmware/main/boards/stackchan/stackchan.cc` (MIT) is
touched. The eight GPL-3.0 files (`SCS.{cc,h}`, `SCSCL.{cc,h}`,
`SCSerial.{cc,h}`, `INST.h`, `SCServo.h`) are not touched and their license
headers remain intact.

## Related

- Closes #160 (delegated-path Phase 0' cancellation boundary follow-up)
- Refs #158 / PR #162 (predecessor — `request_token` guard parity on Host)
- Refs #161 (pre-bus stale-command race — carve-out preserved verbatim)
- Refs #163 / PR #164 (paused `set_servo_torque` probe — also depends on
  this PR to function correctly on the ServoDelegated path; revisit after
  this PR lands)
- Refs #152 Phase 4 (idle auto-release — will consume this cancellation
  primitive, not redefine it)
