### PR TITLE
feat(firmware/gateway): #168 Phase 4 — auto torque release on motion idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Added `set_auto_torque_release(enabled, timeout_ms)` and automatic
+  SCS0009 torque release after motion idle timeout for #152 Phase 4.
+
+- Fixed: mitigated #165 cumulative WritePos protection-mode exposure by
+  reducing session-wide WritePos accumulation during idle periods.
+
 - #152 Phase 3 — replaced normal-runtime `HostInterpolationMotionDriver`
   linear interpolation with `smooth_ui_toolkit` spring physics
   (`AnimateValue` per axis, m5stack/StackChan-equivalent default spring,

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1104,6 +1104,25 @@ config STACKCHAN_SERVO_DELEGATED_MOTION
         per requested move and polls ReadMove for completion. When disabled,
         the firmware keeps the existing host-side interpolation loop.
 
+config STACKCHAN_AUTO_TORQUE_RELEASE_ENABLED
+    bool "Auto release SCS0009 torque on motion idle"
+    default y
+    help
+        Releases servo torque after motion idle timeout to mitigate
+        SCS0009 cumulative WritePos protection mode (#165) and reduce
+        motor heat. Re-engages automatically on the next motion command
+        via explicit EnableTorque(ON) at the motion entry point.
+
+config STACKCHAN_AUTO_TORQUE_RELEASE_MS
+    int "Idle timeout before torque release (ms)"
+    default 5000
+    range 500 600000
+    depends on STACKCHAN_AUTO_TORQUE_RELEASE_ENABLED
+    help
+        Time in milliseconds with no motion before torque auto-releases.
+        Runtime-overridable via the set_auto_torque_release MCP tool
+        (session override, not persisted across reboot).
+
 endif # BOARD_TYPE_STACKCHAN
 
 endmenu

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -682,9 +682,9 @@ private:
     uint32_t last_motion_end_ms_ = 0;              // ServoTask-private
     bool last_motion_end_valid_ = false;           // ServoTask-private
     std::atomic<bool> torque_currently_released_{false};
+    std::atomic<bool> torque_fully_engaged_{true};
     // Per-axis commanded torque state is only used to avoid suppressing a
-    // real mixed-axis re-enable; torque_currently_released_ remains the
-    // cross-task summary of "both axes released".
+    // real mixed-axis re-enable; the atomics publish cross-task summaries.
     bool yaw_torque_enabled_ = true;               // protected by scs_bus_mutex_
     bool pitch_torque_enabled_ = true;             // protected by scs_bus_mutex_
     std::atomic<bool> boot_init_done_{false};
@@ -699,6 +699,7 @@ private:
     static constexpr uint32_t MOTION_POLL_INTERVAL_MS = 50;
     static constexpr uint32_t AUTO_TORQUE_RELEASE_MIN_MS = 500;
     static constexpr uint32_t AUTO_TORQUE_RELEASE_MAX_MS = 600000;
+    static constexpr int kMaxReengageRetries = 3;
 #ifdef CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_MS
     static constexpr uint32_t AUTO_TORQUE_RELEASE_DEFAULT_MS =
         CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_MS;
@@ -2831,6 +2832,15 @@ private:
             return result;
         };
 
+        auto publish_torque_state = [&]() {
+            torque_currently_released_.store(
+                !yaw_torque_enabled_ && !pitch_torque_enabled_,
+                std::memory_order_release);
+            torque_fully_engaged_.store(
+                yaw_torque_enabled_ && pitch_torque_enabled_,
+                std::memory_order_release);
+        };
+
         if (!servo_ok_ || scs_bus_mutex_ == nullptr) {
             return finish(false);
         }
@@ -2843,6 +2853,7 @@ private:
             bool already_engaged =
                 yaw_torque_enabled_ && pitch_torque_enabled_;
             if (already_engaged) {
+                publish_torque_state();
                 log_result(true);
                 xSemaphoreGive(scs_bus_mutex_);
                 return result;
@@ -2850,10 +2861,14 @@ private:
             result.yaw_bus_return = scs_bus_.EnableTorque(SERVO_YAW_ID, 1);
             result.pitch_bus_return =
                 scs_bus_.EnableTorque(SERVO_PITCH_ID, 1);
-            yaw_torque_enabled_ = true;
-            pitch_torque_enabled_ = true;
-            torque_currently_released_.store(false, std::memory_order_release);
             update_bus_ok();
+            if (result.yaw_ok) {
+                yaw_torque_enabled_ = true;
+            }
+            if (result.pitch_ok) {
+                pitch_torque_enabled_ = true;
+            }
+            publish_torque_state();
             log_result(false);
             xSemaphoreGive(scs_bus_mutex_);
             return result;
@@ -2863,6 +2878,7 @@ private:
                 bool still_released =
                     !yaw_torque_enabled_ && !pitch_torque_enabled_;
                 if (still_released) {
+                    publish_torque_state();
                     log_result(true);
                     xSemaphoreGive(scs_bus_mutex_);
                     return result;
@@ -2902,11 +2918,14 @@ private:
                 SERVO_YAW_ID, yaw_enabled ? 1 : 0);
             result.pitch_bus_return = scs_bus_.EnableTorque(
                 SERVO_PITCH_ID, pitch_enabled ? 1 : 0);
-            yaw_torque_enabled_ = yaw_enabled;
-            pitch_torque_enabled_ = pitch_enabled;
-            torque_currently_released_.store(!yaw_enabled && !pitch_enabled,
-                                             std::memory_order_release);
             update_bus_ok();
+            if (result.yaw_ok) {
+                yaw_torque_enabled_ = yaw_enabled;
+            }
+            if (result.pitch_ok) {
+                pitch_torque_enabled_ = pitch_enabled;
+            }
+            publish_torque_state();
             log_result(false);
             xSemaphoreGive(scs_bus_mutex_);
             return result;
@@ -2914,24 +2933,39 @@ private:
     }
 
     void EnsureTorqueEngagedBeforeMove() {
-        if (!torque_currently_released_.load(std::memory_order_acquire)) {
+        if (torque_fully_engaged_.load(std::memory_order_acquire)) {
             return;
         }
         if (!servo_ok_) {
             return;
         }
-        InternalSetServoTorque(true, true, ReleaseReason::kReengagement);
+        ServoTorqueResult r = InternalSetServoTorque(
+            true, true, ReleaseReason::kReengagement);
+        if (!torque_fully_engaged_.load(std::memory_order_acquire)) {
+            ESP_LOGW(TAG,
+                     "servo torque re-engagement bus write failed: "
+                     "yaw_ok=%d (r=%d) pitch_ok=%d (r=%d)",
+                     r.yaw_ok ? 1 : 0, r.yaw_bus_return,
+                     r.pitch_ok ? 1 : 0, r.pitch_bus_return);
+        }
     }
 
-    void TakeMotionMutexAfterTorqueEngaged() {
-        while (true) {
+    bool TakeMotionMutexAfterTorqueEngaged() {
+        for (int attempt = 0; attempt < kMaxReengageRetries; ++attempt) {
             EnsureTorqueEngagedBeforeMove();
             xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            if (!torque_currently_released_.load(std::memory_order_acquire)) {
-                return;
+            if (torque_fully_engaged_.load(std::memory_order_acquire)) {
+                return true;
             }
             xSemaphoreGive(motion_mutex_);
+            vTaskDelay(pdMS_TO_TICKS(MOTION_TICK_MS));
         }
+        ESP_LOGW(TAG,
+                 "EnsureTorqueEngagedBeforeMove: re-engagement failed after "
+                 "%d attempts; skipping motion entry to avoid silent "
+                 "torque-off WritePos.",
+                 kMaxReengageRetries);
+        return false;
     }
 
     void MaybeAutoReleaseTorque() {
@@ -2969,8 +3003,22 @@ private:
             auto_release_timeout_ms_.load(std::memory_order_acquire);
         if (!torque_currently_released_.load(std::memory_order_acquire) &&
             idle_ms >= timeout_ms) {
-            InternalSetServoTorque(false, false, ReleaseReason::kAutoIdle);
-            last_motion_end_valid_ = false;
+            ServoTorqueResult r = InternalSetServoTorque(
+                false, false, ReleaseReason::kAutoIdle);
+            if (torque_currently_released_.load(
+                    std::memory_order_acquire)) {
+                last_motion_end_valid_ = false;
+            } else if (r.short_circuited) {
+                last_motion_end_valid_ = false;
+            } else {
+                last_motion_end_ms_ = now_ms;
+                ESP_LOGW(TAG,
+                         "auto-release OFF bus write failed: yaw_ok=%d "
+                         "(r=%d) pitch_ok=%d (r=%d). Retrying after one "
+                         "idle window.",
+                         r.yaw_ok ? 1 : 0, r.yaw_bus_return,
+                         r.pitch_ok ? 1 : 0, r.pitch_bus_return);
+            }
         }
     }
 
@@ -2998,7 +3046,9 @@ private:
             ESP_LOGW(TAG, "WriteHeadAngles skipped: servo not initialized");
             return;
         }
-        TakeMotionMutexAfterTorqueEngaged();
+        if (!TakeMotionMutexAfterTorqueEngaged()) {
+            return;
+        }
         if (servo_wobble_active_.load()) {
             servo_wobble_active_.store(false);
             servo_wobble_step_.store(0);
@@ -3027,7 +3077,9 @@ private:
         if (!servo_wobble_active_.load(std::memory_order_acquire)) {
             return;
         }
-        TakeMotionMutexAfterTorqueEngaged();
+        if (!TakeMotionMutexAfterTorqueEngaged()) {
+            return;
+        }
         if (!servo_wobble_active_.load()) {
             xSemaphoreGive(motion_mutex_);
             return;

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -682,6 +682,7 @@ private:
     TaskHandle_t servo_task_handle_ = nullptr;
     uint32_t last_motion_end_ms_ = 0;              // ServoTask-private
     bool last_motion_end_valid_ = false;           // ServoTask-private
+    std::atomic<bool> idle_timer_reset_pending_{false};
     enum class TorqueState : uint8_t {
         kEngaged = 0,
         kPartial = 1,
@@ -689,6 +690,7 @@ private:
         kReleasing = 3,
     };
     std::atomic<TorqueState> torque_state_{TorqueState::kEngaged};
+    std::atomic<uint32_t> torque_release_epoch_{0};
     // Per-axis commanded torque state is protected by scs_bus_mutex_;
     // torque_state_ publishes the derived cross-task summary.
     bool yaw_torque_enabled_ = true;               // protected by scs_bus_mutex_
@@ -934,13 +936,28 @@ private:
         } else {
             state = TorqueState::kPartial;
         }
+        TorqueState old_state =
+            torque_state_.load(std::memory_order_acquire);
+        if (state == TorqueState::kEngaged &&
+            old_state != TorqueState::kEngaged) {
+            // Reset the ServoTask-owned idle window even when OFF->ON
+            // happens between ServoTask ticks.
+            idle_timer_reset_pending_.store(true,
+                                            std::memory_order_release);
+        }
         torque_state_.store(state, std::memory_order_release);
     }
 
     // Marks a fully-OFF transition while the bus write is still pending.
-    void MarkReleasing() {
+    // Returns this call's release epoch so auto-idle rollback can detect
+    // another release publisher that interleaved after it.
+    uint32_t MarkReleasing() {
+        uint32_t epoch =
+            torque_release_epoch_.fetch_add(1, std::memory_order_acq_rel) +
+            1;
         torque_state_.store(TorqueState::kReleasing,
                             std::memory_order_release);
+        return epoch;
     }
 
     // Block until torque_state_ leaves kReleasing or the elapsed-time
@@ -3020,7 +3037,7 @@ private:
                 // motion_mutex_ so concurrent motion entries do not observe
                 // the old engaged state while the OFF bus write is pending.
                 if (!yaw_enabled && !pitch_enabled) {
-                    MarkReleasing();
+                    (void)MarkReleasing();
                 }
                 xSemaphoreGive(motion_mutex_);
             }
@@ -3100,6 +3117,12 @@ private:
         if (!boot_init_done_.load(std::memory_order_acquire)) {
             return;
         }
+        // PublishTorqueState() raises this when torque re-engages between
+        // ServoTask ticks, so a stale idle timer cannot immediately re-OFF.
+        if (idle_timer_reset_pending_.exchange(
+                false, std::memory_order_acq_rel)) {
+            last_motion_end_valid_ = false;
+        }
         // Keep the idle window scoped to the currently engaged interval.
         // Released/partial/releasing states must not age a stale timer into
         // the next re-engage.
@@ -3136,7 +3159,7 @@ private:
             // block on motion_mutex_, so a concurrent manual ON is routed
             // through the kReleasing wait/retry path instead of treating the
             // already-expired engaged state as a successful no-op.
-            MarkReleasing();
+            uint32_t my_epoch = MarkReleasing();
             ServoTorqueResult r = InternalSetServoTorque(
                 false, false, ReleaseReason::kAutoIdle);
             auto state_after =
@@ -3144,16 +3167,30 @@ private:
             if (state_after == TorqueState::kReleased) {
                 last_motion_end_valid_ = false;
             } else if (state_after == TorqueState::kReleasing) {
-                // Auto-idle re-observed motion or wobble under motion_mutex_
-                // and returned before any bus frame went out, so the per-axis
-                // torque state is still fully engaged.
-                torque_state_.store(TorqueState::kEngaged,
-                                    std::memory_order_release);
+                uint32_t current_epoch =
+                    torque_release_epoch_.load(std::memory_order_acquire);
+                if (current_epoch == my_epoch) {
+                    // Auto-idle re-observed motion or wobble under
+                    // motion_mutex_ and returned before any bus frame went
+                    // out, so the per-axis torque state is still fully
+                    // engaged.
+                    torque_state_.store(TorqueState::kEngaged,
+                                        std::memory_order_release);
+                    ESP_LOGW(TAG,
+                             "auto-release OFF aborted by motion/wobble "
+                             "re-check; rolled back torque_state_ to "
+                             "kEngaged (epoch=%u), retry after "
+                             "one idle window.",
+                             (unsigned)my_epoch);
+                } else {
+                    ESP_LOGW(TAG,
+                             "auto-release OFF aborted, but release epoch "
+                             "advanced from %u to %u "
+                             "(another release publisher in flight); leaving "
+                             "torque_state_ for them.",
+                             (unsigned)my_epoch, (unsigned)current_epoch);
+                }
                 last_motion_end_ms_ = now_ms;
-                ESP_LOGW(TAG,
-                         "auto-release OFF aborted by motion/wobble "
-                         "re-check; rolled back torque_state_ to kEngaged, "
-                         "retry after one idle window.");
             } else {
                 last_motion_end_ms_ = now_ms;
                 ESP_LOGW(TAG,

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -679,10 +679,34 @@ private:
     SemaphoreHandle_t scs_bus_mutex_ = nullptr;    // serializes UART access (WritePos/ReadPos)
     std::unique_ptr<MotionDriver> motion_driver_;
     TaskHandle_t servo_task_handle_ = nullptr;
+    uint32_t last_motion_end_ms_ = 0;              // ServoTask-private
+    bool last_motion_end_valid_ = false;           // ServoTask-private
+    std::atomic<bool> torque_currently_released_{false};
+    // Per-axis commanded torque state is only used to avoid suppressing a
+    // real mixed-axis re-enable; torque_currently_released_ remains the
+    // cross-task summary of "both axes released".
+    bool yaw_torque_enabled_ = true;               // protected by scs_bus_mutex_
+    bool pitch_torque_enabled_ = true;             // protected by scs_bus_mutex_
+    std::atomic<bool> boot_init_done_{false};
+#if CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_ENABLED
+    std::atomic<bool> auto_release_enabled_{true};
+#else
+    std::atomic<bool> auto_release_enabled_{false};
+#endif
     static constexpr uint32_t MOTION_TICK_MS = 20;
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
     static constexpr uint32_t MOTION_POLL_INTERVAL_MS = 50;
+    static constexpr uint32_t AUTO_TORQUE_RELEASE_MIN_MS = 500;
+    static constexpr uint32_t AUTO_TORQUE_RELEASE_MAX_MS = 600000;
+#ifdef CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_MS
+    static constexpr uint32_t AUTO_TORQUE_RELEASE_DEFAULT_MS =
+        CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_MS;
+#else
+    static constexpr uint32_t AUTO_TORQUE_RELEASE_DEFAULT_MS = 5000;
+#endif
+    std::atomic<uint32_t> auto_release_timeout_ms_{
+        AUTO_TORQUE_RELEASE_DEFAULT_MS};
 
     // Issue #80 / #98: pitch is guarded by two complementary tiers.
     //
@@ -873,6 +897,32 @@ private:
         options.visualDuration = 0.0f;
         return options;
     }
+
+    enum class ReleaseReason : uint8_t {
+        kManual = 0,
+        kAutoIdle,
+        kReengagement,
+    };
+
+    static const char* ReleaseReasonName(ReleaseReason reason) {
+        switch (reason) {
+            case ReleaseReason::kManual:
+                return "manual";
+            case ReleaseReason::kAutoIdle:
+                return "auto_idle";
+            case ReleaseReason::kReengagement:
+                return "reengagement";
+        }
+        return "unknown";
+    }
+
+    struct ServoTorqueResult {
+        int yaw_bus_return = -1;
+        int pitch_bus_return = -1;
+        bool yaw_ok = false;
+        bool pitch_ok = false;
+        bool short_circuited = false;
+    };
 
     class MotionDriver {
     public:
@@ -2742,6 +2792,185 @@ private:
                          "leaving current_deg at restored-or-seeded value "
                          "and marking position unknown for delegated no-op gate");
             }
+            boot_init_done_.store(true, std::memory_order_release);
+        }
+    }
+
+    ServoTorqueResult InternalSetServoTorque(bool yaw_enabled,
+                                             bool pitch_enabled,
+                                             ReleaseReason reason) {
+        ServoTorqueResult result;
+        const bool mixed_axes = yaw_enabled != pitch_enabled;
+        const bool disables_axis = !yaw_enabled || !pitch_enabled;
+
+        auto update_bus_ok = [&]() {
+#if CONFIG_STACKCHAN_SERVO_FEETECH
+            result.yaw_ok = (result.yaw_bus_return == 0);
+            result.pitch_ok = (result.pitch_bus_return == 0);
+#else
+            result.yaw_ok = (result.yaw_bus_return > 0);
+            result.pitch_ok = (result.pitch_bus_return > 0);
+#endif
+        };
+
+        auto log_result = [&](bool short_circuited) {
+            result.short_circuited = short_circuited;
+            ESP_LOGI(TAG,
+                     "set_servo_torque (reason=%s): servo_ok=%d "
+                     "yaw_enabled=%d (r=%d) pitch_enabled=%d (r=%d) "
+                     "short_circuited=%d",
+                     ReleaseReasonName(reason),
+                     servo_ok_ ? 1 : 0,
+                     yaw_enabled ? 1 : 0, result.yaw_bus_return,
+                     pitch_enabled ? 1 : 0, result.pitch_bus_return,
+                     short_circuited ? 1 : 0);
+        };
+
+        auto finish = [&](bool short_circuited) -> ServoTorqueResult {
+            log_result(short_circuited);
+            return result;
+        };
+
+        if (!servo_ok_ || scs_bus_mutex_ == nullptr) {
+            return finish(false);
+        }
+
+        // Fully-symmetric re-engage is mutex-ordered even when it becomes
+        // a no-op, so a manual ON racing an auto-idle OFF is determined by
+        // scs_bus_mutex_ acquisition order.
+        if (yaw_enabled && pitch_enabled) {
+            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            bool already_engaged =
+                yaw_torque_enabled_ && pitch_torque_enabled_;
+            if (already_engaged) {
+                log_result(true);
+                xSemaphoreGive(scs_bus_mutex_);
+                return result;
+            }
+            result.yaw_bus_return = scs_bus_.EnableTorque(SERVO_YAW_ID, 1);
+            result.pitch_bus_return =
+                scs_bus_.EnableTorque(SERVO_PITCH_ID, 1);
+            yaw_torque_enabled_ = true;
+            pitch_torque_enabled_ = true;
+            torque_currently_released_.store(false, std::memory_order_release);
+            update_bus_ok();
+            log_result(false);
+            xSemaphoreGive(scs_bus_mutex_);
+            return result;
+        } else {
+            if (!mixed_axes) {
+                xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+                bool still_released =
+                    !yaw_torque_enabled_ && !pitch_torque_enabled_;
+                if (still_released) {
+                    log_result(true);
+                    xSemaphoreGive(scs_bus_mutex_);
+                    return result;
+                }
+                xSemaphoreGive(scs_bus_mutex_);
+            }
+
+            // Preserve the existing cancellation-first disable path exactly:
+            // reset MotionDriver state for axes being disabled before the
+            // EnableTorque(OFF) bus frames can race with ServoTask writes.
+            if (motion_driver_ != nullptr && motion_mutex_ != nullptr &&
+                disables_axis) {
+                xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+                if (reason == ReleaseReason::kAutoIdle &&
+                    (yaw_motion_.moving || pitch_motion_.moving ||
+                     servo_wobble_active_.load(std::memory_order_acquire))) {
+                    xSemaphoreGive(motion_mutex_);
+                    return finish(true);
+                }
+                if (!yaw_enabled) {
+                    yaw_motion_.moving = false;
+                    yaw_motion_.position_unknown = true;
+                    motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
+                }
+                if (!pitch_enabled) {
+                    pitch_motion_.moving = false;
+                    pitch_motion_.position_unknown = true;
+                    motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
+                }
+                servo_wobble_active_.store(false, std::memory_order_release);
+                servo_wobble_step_.store(0, std::memory_order_release);
+                xSemaphoreGive(motion_mutex_);
+            }
+
+            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            result.yaw_bus_return = scs_bus_.EnableTorque(
+                SERVO_YAW_ID, yaw_enabled ? 1 : 0);
+            result.pitch_bus_return = scs_bus_.EnableTorque(
+                SERVO_PITCH_ID, pitch_enabled ? 1 : 0);
+            yaw_torque_enabled_ = yaw_enabled;
+            pitch_torque_enabled_ = pitch_enabled;
+            torque_currently_released_.store(!yaw_enabled && !pitch_enabled,
+                                             std::memory_order_release);
+            update_bus_ok();
+            log_result(false);
+            xSemaphoreGive(scs_bus_mutex_);
+            return result;
+        }
+    }
+
+    void EnsureTorqueEngagedBeforeMove() {
+        if (!torque_currently_released_.load(std::memory_order_acquire)) {
+            return;
+        }
+        if (!servo_ok_) {
+            return;
+        }
+        InternalSetServoTorque(true, true, ReleaseReason::kReengagement);
+    }
+
+    void TakeMotionMutexAfterTorqueEngaged() {
+        while (true) {
+            EnsureTorqueEngagedBeforeMove();
+            xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+            if (!torque_currently_released_.load(std::memory_order_acquire)) {
+                return;
+            }
+            xSemaphoreGive(motion_mutex_);
+        }
+    }
+
+    void MaybeAutoReleaseTorque() {
+        if (!auto_release_enabled_.load(std::memory_order_acquire)) {
+            return;
+        }
+        if (!servo_ok_) {
+            return;
+        }
+        if (!boot_init_done_.load(std::memory_order_acquire)) {
+            return;
+        }
+        if (servo_wobble_active_.load(std::memory_order_acquire)) {
+            last_motion_end_valid_ = false;
+            return;
+        }
+
+        bool moving = motion_driver_->IsMoving();
+        uint32_t now_ms =
+            static_cast<uint32_t>(esp_timer_get_time() / 1000);
+
+        if (moving) {
+            last_motion_end_valid_ = false;
+            return;
+        }
+
+        if (!last_motion_end_valid_) {
+            last_motion_end_ms_ = now_ms;
+            last_motion_end_valid_ = true;
+            return;
+        }
+
+        uint32_t idle_ms = now_ms - last_motion_end_ms_;
+        uint32_t timeout_ms =
+            auto_release_timeout_ms_.load(std::memory_order_acquire);
+        if (!torque_currently_released_.load(std::memory_order_acquire) &&
+            idle_ms >= timeout_ms) {
+            InternalSetServoTorque(false, false, ReleaseReason::kAutoIdle);
+            last_motion_end_valid_ = false;
         }
     }
 
@@ -2769,7 +2998,7 @@ private:
             ESP_LOGW(TAG, "WriteHeadAngles skipped: servo not initialized");
             return;
         }
-        xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+        TakeMotionMutexAfterTorqueEngaged();
         if (servo_wobble_active_.load()) {
             servo_wobble_active_.store(false);
             servo_wobble_step_.store(0);
@@ -2783,18 +3012,22 @@ private:
     // after the active MotionDriver reports idle, so the delegated path never
     // overwrites an in-flight SCS0009 internal motion.
     //
-    // Entire body runs under motion_mutex_. Without that hold, a concurrent
-    // non-wobble WriteHeadAngles() could clear servo_wobble_active_ AFTER
-    // this function has passed the active-load + IsMoving gate but BEFORE
-    // the switch reaches dispatch, which would let a wobble step
-    // overwrite the user's freshly-staged target. Holding the mutex makes
-    // "wobble-active check → idle check → step dispatch" atomic w.r.t.
-    // any external StartMove() request.
+    // The initial active check stays outside motion_mutex_ so idle ServoTask
+    // ticks do not run the torque re-engagement path. The dispatch body runs
+    // under motion_mutex_; without that hold, a concurrent non-wobble
+    // WriteHeadAngles() could clear servo_wobble_active_ AFTER this function
+    // has passed the active-load + IsMoving gate but BEFORE the switch reaches
+    // dispatch, which would let a wobble step overwrite the user's freshly-
+    // staged target. Holding the mutex makes "wobble-active check → idle check
+    // → step dispatch" atomic w.r.t. any external StartMove() request.
     void ServoWobbleStepAdvance() {
         if (!servo_ok_ || motion_driver_ == nullptr) {
             return;
         }
-        xSemaphoreTake(motion_mutex_, portMAX_DELAY);
+        if (!servo_wobble_active_.load(std::memory_order_acquire)) {
+            return;
+        }
+        TakeMotionMutexAfterTorqueEngaged();
         if (!servo_wobble_active_.load()) {
             xSemaphoreGive(motion_mutex_);
             return;
@@ -2874,6 +3107,7 @@ private:
                 continue;
             }
             motion_driver_->Tick();
+            MaybeAutoReleaseTorque();
             ServoWobbleStepAdvance();
             taskYIELD();
         }
@@ -4015,98 +4249,91 @@ private:
             [this](const PropertyList& properties) -> ReturnValue {
                 bool yaw_enabled = properties["yaw_enabled"].value<bool>();
                 bool pitch_enabled = properties["pitch_enabled"].value<bool>();
-
-                // Cancel MotionDriver state for any axis whose torque is
-                // being disabled BEFORE issuing the EnableTorque bus
-                // frame. Without this ordering, ServoTask could snapshot
-                // motion state while moving=true, wait on scs_bus_mutex_
-                // through our EnableTorque(OFF), then fire one stale
-                // WritePos on the freshly-disabled axis right after we
-                // release scs_bus_mutex_ (silently absorbed while torque
-                // is off, then resuming audibly when torque comes back).
-                // Performing the cancellation first lets the next Tick
-                // observe moving=false / a fresh request_token before it
-                // commits any WritePos. position_unknown forces the
-                // delegated path to re-dispatch the next move
-                // (HostInterpolation ignores the flag, but the
-                // moving=false + token bump already block resumption
-                // there). Re-enable is treated as a user-driven re-
-                // anchor: the caller is expected to use get_head_angles
-                // + set_head_angles to re-establish a verified position
-                // if needed.
-                //
-                // Known carve-out (#160): on the delegated path,
-                // ServoDelegatedMotionDriver does not override
-                // InvalidateAxisToken, and the per-axis AxisServo private
-                // pending_dispatch_ / retry-state is not cleared by this
-                // path. A subsequent Update() tick can therefore still
-                // re-stage a WritePos on the freshly-disabled axis from
-                // pending state captured before this call. Full
-                // delegated-path cancellation requires the same refactor
-                // tracked under #160 and is out of scope for this probe.
-                if (motion_driver_ != nullptr && motion_mutex_ != nullptr &&
-                    (!yaw_enabled || !pitch_enabled)) {
-                    xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-                    if (!yaw_enabled) {
-                        yaw_motion_.moving = false;
-                        yaw_motion_.position_unknown = true;
-                        motion_driver_->InvalidateAxisToken(SERVO_YAW_ID);
-                    }
-                    if (!pitch_enabled) {
-                        pitch_motion_.moving = false;
-                        pitch_motion_.position_unknown = true;
-                        motion_driver_->InvalidateAxisToken(SERVO_PITCH_ID);
-                    }
-                    // Also cancel any in-flight servo wobble sequence.
-                    // Wobble drives both axes through ServoTaskMain's
-                    // ServoWobbleStepAdvance after Tick; without
-                    // clearing the active flag here, the next tick
-                    // would observe moving==false and stage the next
-                    // wobble StartMove with torque off, enqueuing fresh
-                    // WritePos targets that would run on re-enable.
-                    // Mirrors the wobble-cancel sequence in
-                    // WriteHeadAngles.
-                    servo_wobble_active_.store(false);
-                    servo_wobble_step_.store(0);
-                    xSemaphoreGive(motion_mutex_);
-                }
-
-                int r_yaw = -1;
-                int r_pitch = -1;
-                if (servo_ok_ && scs_bus_mutex_ != nullptr) {
-                    xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-                    r_yaw = scs_bus_.EnableTorque(SERVO_YAW_ID,
-                                                  yaw_enabled ? 1 : 0);
-                    r_pitch = scs_bus_.EnableTorque(SERVO_PITCH_ID,
-                                                    pitch_enabled ? 1 : 0);
-                    xSemaphoreGive(scs_bus_mutex_);
-                }
-
-#if CONFIG_STACKCHAN_SERVO_FEETECH
-                bool yaw_ok = (r_yaw == 0);
-                bool pitch_ok = (r_pitch == 0);
-#else
-                bool yaw_ok = (r_yaw > 0);
-                bool pitch_ok = (r_pitch > 0);
-#endif
+                ServoTorqueResult torque_result = InternalSetServoTorque(
+                    yaw_enabled, pitch_enabled, ReleaseReason::kManual);
 
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddBoolToObject(root, "yaw_enabled", yaw_enabled);
                 cJSON_AddBoolToObject(root, "pitch_enabled", pitch_enabled);
-                cJSON_AddNumberToObject(root, "yaw_bus_return", r_yaw);
-                cJSON_AddNumberToObject(root, "pitch_bus_return", r_pitch);
+                cJSON_AddNumberToObject(root, "yaw_bus_return",
+                                        torque_result.yaw_bus_return);
+                cJSON_AddNumberToObject(root, "pitch_bus_return",
+                                        torque_result.pitch_bus_return);
                 cJSON_AddBoolToObject(root, "servo_ok", servo_ok_);
-                cJSON_AddBoolToObject(root, "ok", servo_ok_ && yaw_ok && pitch_ok);
+                cJSON_AddBoolToObject(
+                    root, "ok",
+                    servo_ok_ && (torque_result.short_circuited ||
+                                  (torque_result.yaw_ok &&
+                                   torque_result.pitch_ok)));
+                cJSON_AddBoolToObject(root, "short_circuited",
+                                      torque_result.short_circuited);
                 if (!servo_ok_) {
                     cJSON_AddStringToObject(root, "error",
                                             "Servo bus not initialized.");
                 }
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.robot.set_auto_torque_release",
+            "Enable or disable automatic SCS0009 torque release after "
+            "motion idle timeout. timeout_ms is clamped by the firmware "
+            "to 500..600000 ms. Disabling this setting does not re-enable "
+            "torque if it is already released; the next set_head_angles, "
+            "wobble, or explicit set_servo_torque(true, true) call "
+            "re-engages torque.",
+            PropertyList({Property("enabled", kPropertyTypeBoolean),
+                          Property("timeout_ms", kPropertyTypeInteger,
+                                   (int)AUTO_TORQUE_RELEASE_DEFAULT_MS)}),
+            [this](const PropertyList& properties) -> ReturnValue {
+                bool enabled = properties["enabled"].value<bool>();
+                int requested_timeout_ms = properties["timeout_ms"].value<int>();
+                bool clamped = false;
+                uint32_t timeout_ms = 0;
+
+                if (requested_timeout_ms <
+                    static_cast<int>(AUTO_TORQUE_RELEASE_MIN_MS)) {
+                    timeout_ms = AUTO_TORQUE_RELEASE_MIN_MS;
+                    clamped = true;
+                    ESP_LOGW(TAG,
+                             "set_auto_torque_release: timeout_ms=%d below "
+                             "minimum %u, clamping",
+                             requested_timeout_ms,
+                             (unsigned)AUTO_TORQUE_RELEASE_MIN_MS);
+                } else if (requested_timeout_ms >
+                           static_cast<int>(AUTO_TORQUE_RELEASE_MAX_MS)) {
+                    timeout_ms = AUTO_TORQUE_RELEASE_MAX_MS;
+                    clamped = true;
+                    ESP_LOGW(TAG,
+                             "set_auto_torque_release: timeout_ms=%d above "
+                             "maximum %u, clamping",
+                             requested_timeout_ms,
+                             (unsigned)AUTO_TORQUE_RELEASE_MAX_MS);
+                } else {
+                    timeout_ms = static_cast<uint32_t>(requested_timeout_ms);
+                }
+
+                bool torque_released_at_call =
+                    torque_currently_released_.load(std::memory_order_acquire);
+                auto_release_timeout_ms_.store(timeout_ms,
+                                               std::memory_order_release);
+                auto_release_enabled_.store(enabled,
+                                            std::memory_order_release);
+
                 ESP_LOGI(TAG,
-                         "set_servo_torque: servo_ok=%d yaw_enabled=%d (r=%d) "
-                         "pitch_enabled=%d (r=%d)",
-                         servo_ok_ ? 1 : 0,
-                         (int)yaw_enabled, r_yaw,
-                         (int)pitch_enabled, r_pitch);
+                         "set_auto_torque_release: enabled=%d "
+                         "timeout_ms=%u clamped=%d "
+                         "torque_released_at_call=%d",
+                         enabled ? 1 : 0, (unsigned)timeout_ms,
+                         clamped ? 1 : 0,
+                         torque_released_at_call ? 1 : 0);
+
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "enabled", enabled);
+                cJSON_AddNumberToObject(root, "timeout_ms", timeout_ms);
+                cJSON_AddBoolToObject(root, "clamped", clamped);
+                cJSON_AddBoolToObject(root, "torque_released_at_call",
+                                      torque_released_at_call);
                 return root;
             });
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -45,6 +45,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include "esp_video.h"
 #include <cJSON.h>
 #include <lvgl.h>
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <limits>
@@ -2969,18 +2970,27 @@ private:
             return;
         }
 
-        // Serialize against any pending OFF write. Without this wait, a
-        // re-engage call could win scs_bus_mutex_ ahead of the pending
-        // EnableTorque(OFF) on the auto-release path, publish kEngaged, let
-        // motion start, and then have the OFF write disable torque after
-        // motion has already been staged (round-3 adversarial finding).
-        constexpr int kMaxKReleasingWaitMs = 200;
-        constexpr int kKReleasingPollIntervalMs = 5;
-        int waited_ms = 0;
-        while (state == TorqueState::kReleasing &&
-               waited_ms < kMaxKReleasingWaitMs) {
-            vTaskDelay(pdMS_TO_TICKS(kKReleasingPollIntervalMs));
-            waited_ms += kKReleasingPollIntervalMs;
+        // Serialize against any pending OFF write before deciding whether to
+        // re-engage. Measure real elapsed time instead of advancing by the
+        // nominal poll interval: at CONFIG_FREERTOS_HZ=100, pdMS_TO_TICKS(5)
+        // floors to 0 ticks, so a nominal-ms loop would burn the 200 ms budget
+        // in a yield-only spin. Round the delay up to at least one tick so the
+        // budget is bounded by elapsed time, not loop scheduling.
+        constexpr uint32_t kMaxKReleasingWaitMs = 200;
+        constexpr uint32_t kKReleasingPollIntervalMs = 5;
+        const TickType_t kDelayTicks =
+            std::max<TickType_t>(1,
+                                 pdMS_TO_TICKS(kKReleasingPollIntervalMs));
+        const uint32_t start_us =
+            static_cast<uint32_t>(esp_timer_get_time());
+        while (state == TorqueState::kReleasing) {
+            const uint32_t elapsed_ms =
+                (static_cast<uint32_t>(esp_timer_get_time()) - start_us) /
+                1000;
+            if (elapsed_ms >= kMaxKReleasingWaitMs) {
+                break;
+            }
+            vTaskDelay(kDelayTicks);
             state = torque_state_.load(std::memory_order_acquire);
         }
 
@@ -2995,8 +3005,8 @@ private:
             // retry decide whether to skip the motion entirely.
             ESP_LOGW(TAG,
                      "EnsureTorqueEngagedBeforeMove: kReleasing not "
-                     "completing within %d ms, deferring to caller retry.",
-                     kMaxKReleasingWaitMs);
+                     "completing within %u ms, deferring to caller retry.",
+                     static_cast<unsigned>(kMaxKReleasingWaitMs));
             return;
         }
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -942,6 +942,37 @@ private:
                             std::memory_order_release);
     }
 
+    // Block until torque_state_ leaves kReleasing or the elapsed-time
+    // budget expires. Caller must NOT hold motion_mutex_ or scs_bus_mutex_.
+    // Uses esp_timer_get_time() so the budget is honored at real time
+    // regardless of CONFIG_FREERTOS_HZ.
+    //
+    // Returns true if the state is no longer kReleasing (proceed safely),
+    // false if the wait budget was exhausted while still kReleasing
+    // (caller decides how to handle: either skip with ESP_LOGW or defer to
+    // its own bounded retry).
+    bool WaitForKReleasingToClear() {
+        constexpr uint32_t kMaxKReleasingWaitMs = 200;
+        constexpr uint32_t kKReleasingPollIntervalMs = 5;
+        const TickType_t kDelayTicks =
+            std::max<TickType_t>(1,
+                                 pdMS_TO_TICKS(kKReleasingPollIntervalMs));
+        const uint32_t start_us =
+            static_cast<uint32_t>(esp_timer_get_time());
+        auto state = torque_state_.load(std::memory_order_acquire);
+        while (state == TorqueState::kReleasing) {
+            const uint32_t elapsed_ms =
+                (static_cast<uint32_t>(esp_timer_get_time()) - start_us) /
+                1000;
+            if (elapsed_ms >= kMaxKReleasingWaitMs) {
+                return false;
+            }
+            vTaskDelay(kDelayTicks);
+            state = torque_state_.load(std::memory_order_acquire);
+        }
+        return true;
+    }
+
     struct ServoTorqueResult {
         int yaw_bus_return = -1;
         int pitch_bus_return = -1;
@@ -2860,10 +2891,44 @@ private:
             return finish(false);
         }
 
-        // Fully-symmetric re-engage is mutex-ordered even when it becomes
-        // a no-op, so a manual ON racing an auto-idle OFF is determined by
-        // scs_bus_mutex_ acquisition order.
+        // Fully-symmetric re-engage remains bus-ordered even when it becomes
+        // a no-op. If an auto-idle OFF has already published kReleasing, the
+        // manual path waits for that pending transition before entering the
+        // bus section.
         if (yaw_enabled && pitch_enabled) {
+            // Serialize manual re-engage against a pending OFF transition on
+            // the auto-release path. Without this wait, a manual
+            // set_servo_torque(true, true) could win scs_bus_mutex_ ahead of
+            // the pending EnableTorque(OFF), publish kEngaged, and then have
+            // the OFF write silently disable torque after the MCP call
+            // returned "ok" -- violating the explicit-ON contract.
+            //
+            // kReengagement is exempt: EnsureTorqueEngagedBeforeMove() has
+            // already waited out kReleasing before reaching here.
+            //
+            // kAutoIdle does not enter this branch (it requests
+            // (false, false)); included in the guard for completeness /
+            // future-proofing.
+            if (reason == ReleaseReason::kManual) {
+                auto state_pre =
+                    torque_state_.load(std::memory_order_acquire);
+                if (state_pre == TorqueState::kReleasing) {
+                    if (!WaitForKReleasingToClear()) {
+                        ESP_LOGW(TAG,
+                                 "set_servo_torque (reason=%s): kReleasing "
+                                 "not clearing within wait budget; skipping "
+                                 "bus frames, caller may retry.",
+                                 ReleaseReasonName(reason));
+                        log_result(true);
+                        return result;
+                    }
+                    // After the wait, state may be kEngaged (OFF failed and
+                    // rolled back) or kReleased (OFF succeeded). Fall through
+                    // to the existing (true, true) logic, which short-circuits
+                    // on kEngaged and proceeds normally on kReleased/kPartial.
+                }
+            }
+
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
             if (torque_state_.load(std::memory_order_acquire) ==
                 TorqueState::kEngaged) {
@@ -2951,16 +3016,6 @@ private:
         }
     }
 
-    // Wait budget for an in-progress OFF transition before deciding whether
-    // to re-engage. The auto-release path holds scs_bus_mutex_ for two
-    // EnableTorque bus frames (typically <5 ms total) between MarkReleasing()
-    // and the final PublishTorqueState() call. 200 ms is a generous safety
-    // margin that still keeps motion-entry latency human-imperceptible.
-    //
-    // If this budget is exhausted while torque_state_ is still kReleasing,
-    // the caller's bounded retry (kMaxReengageRetries = 3 in
-    // TakeMotionMutexAfterTorqueEngaged) will issue at most 3 such waits
-    // before declaring re-engage failure and skipping the motion entry.
     void EnsureTorqueEngagedBeforeMove() {
         auto state = torque_state_.load(std::memory_order_acquire);
         if (state == TorqueState::kEngaged) {
@@ -2970,44 +3025,18 @@ private:
             return;
         }
 
-        // Serialize against any pending OFF write before deciding whether to
-        // re-engage. Measure real elapsed time instead of advancing by the
-        // nominal poll interval: at CONFIG_FREERTOS_HZ=100, pdMS_TO_TICKS(5)
-        // floors to 0 ticks, so a nominal-ms loop would burn the 200 ms budget
-        // in a yield-only spin. Round the delay up to at least one tick so the
-        // budget is bounded by elapsed time, not loop scheduling.
-        constexpr uint32_t kMaxKReleasingWaitMs = 200;
-        constexpr uint32_t kKReleasingPollIntervalMs = 5;
-        const TickType_t kDelayTicks =
-            std::max<TickType_t>(1,
-                                 pdMS_TO_TICKS(kKReleasingPollIntervalMs));
-        const uint32_t start_us =
-            static_cast<uint32_t>(esp_timer_get_time());
-        while (state == TorqueState::kReleasing) {
-            const uint32_t elapsed_ms =
-                (static_cast<uint32_t>(esp_timer_get_time()) - start_us) /
-                1000;
-            if (elapsed_ms >= kMaxKReleasingWaitMs) {
-                break;
-            }
-            vTaskDelay(kDelayTicks);
-            state = torque_state_.load(std::memory_order_acquire);
-        }
-
-        if (state == TorqueState::kEngaged) {
-            // The OFF write failed during our wait and the state was
-            // recomputed back to kEngaged. No re-engage needed.
-            return;
-        }
         if (state == TorqueState::kReleasing) {
-            // Wait budget exhausted without the OFF transition completing.
-            // Bail out and let TakeMotionMutexAfterTorqueEngaged's bounded
-            // retry decide whether to skip the motion entirely.
-            ESP_LOGW(TAG,
-                     "EnsureTorqueEngagedBeforeMove: kReleasing not "
-                     "completing within %u ms, deferring to caller retry.",
-                     static_cast<unsigned>(kMaxKReleasingWaitMs));
-            return;
+            if (!WaitForKReleasingToClear()) {
+                ESP_LOGW(TAG,
+                         "EnsureTorqueEngagedBeforeMove: kReleasing not "
+                         "clearing within wait budget, deferring to caller "
+                         "retry.");
+                return;
+            }
+            state = torque_state_.load(std::memory_order_acquire);
+            if (state == TorqueState::kEngaged) {
+                return;  // OFF rolled back to kEngaged
+            }
         }
 
         // state is kPartial or kReleased -- safe to re-engage now.

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -2873,7 +2873,9 @@ private:
 
     ServoTorqueResult InternalSetServoTorque(bool yaw_enabled,
                                              bool pitch_enabled,
-                                             ReleaseReason reason) {
+                                             ReleaseReason reason,
+                                             uint32_t expected_release_epoch =
+                                                 0) {
         ServoTorqueResult result;
         const bool disables_axis = !yaw_enabled || !pitch_enabled;
 
@@ -3043,6 +3045,26 @@ private:
             }
 
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+            if (reason == ReleaseReason::kAutoIdle &&
+                expected_release_epoch != 0) {
+                uint32_t current_epoch =
+                    torque_release_epoch_.load(std::memory_order_acquire);
+                auto current_state =
+                    torque_state_.load(std::memory_order_acquire);
+                if (current_epoch != expected_release_epoch ||
+                    current_state != TorqueState::kReleasing) {
+                    ESP_LOGW(TAG,
+                             "auto-release OFF aborted at bus check: epoch=%u "
+                             "(expected %u), state=%d (expected kReleasing); "
+                             "skipping EnableTorque(0,0) frames.",
+                             (unsigned)current_epoch,
+                             (unsigned)expected_release_epoch,
+                             (int)current_state);
+                    xSemaphoreGive(scs_bus_mutex_);
+                    log_result(true);
+                    return result;
+                }
+            }
             result.yaw_bus_return = scs_bus_.EnableTorque(
                 SERVO_YAW_ID, yaw_enabled ? 1 : 0);
             result.pitch_bus_return = scs_bus_.EnableTorque(
@@ -3159,17 +3181,18 @@ private:
             // block on motion_mutex_, so a concurrent manual ON is routed
             // through the kReleasing wait/retry path instead of treating the
             // already-expired engaged state as a successful no-op.
-            uint32_t my_epoch = MarkReleasing();
+            uint32_t my_pre_epoch = MarkReleasing();
             ServoTorqueResult r = InternalSetServoTorque(
-                false, false, ReleaseReason::kAutoIdle);
+                false, false, ReleaseReason::kAutoIdle,
+                /*expected_release_epoch=*/my_pre_epoch + 1);
             auto state_after =
                 torque_state_.load(std::memory_order_acquire);
             if (state_after == TorqueState::kReleased) {
                 last_motion_end_valid_ = false;
-            } else if (state_after == TorqueState::kReleasing) {
+            } else if (r.short_circuited) {
                 uint32_t current_epoch =
                     torque_release_epoch_.load(std::memory_order_acquire);
-                if (current_epoch == my_epoch) {
+                if (current_epoch == my_pre_epoch) {
                     // Auto-idle re-observed motion or wobble under
                     // motion_mutex_ and returned before any bus frame went
                     // out, so the per-axis torque state is still fully
@@ -3181,14 +3204,21 @@ private:
                              "re-check; rolled back torque_state_ to "
                              "kEngaged (epoch=%u), retry after "
                              "one idle window.",
-                             (unsigned)my_epoch);
+                             (unsigned)my_pre_epoch);
+                } else if (current_epoch == my_pre_epoch + 1) {
+                    ESP_LOGW(TAG,
+                             "auto-release OFF aborted at bus check; leaving "
+                             "torque_state_ for concurrent publisher "
+                             "(my_pre_epoch=%u current_epoch=%u).",
+                             (unsigned)my_pre_epoch,
+                             (unsigned)current_epoch);
                 } else {
                     ESP_LOGW(TAG,
-                             "auto-release OFF aborted, but release epoch "
-                             "advanced from %u to %u "
-                             "(another release publisher in flight); leaving "
-                             "torque_state_ for them.",
-                             (unsigned)my_epoch, (unsigned)current_epoch);
+                             "auto-release OFF: release epoch advanced past "
+                             "ours (my_pre_epoch=%u current_epoch=%u); "
+                             "leaving torque_state_ for concurrent publisher.",
+                             (unsigned)my_pre_epoch,
+                             (unsigned)current_epoch);
                 }
                 last_motion_end_ms_ = now_ms;
             } else {

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -3100,6 +3100,14 @@ private:
         if (!boot_init_done_.load(std::memory_order_acquire)) {
             return;
         }
+        // Keep the idle window scoped to the currently engaged interval.
+        // Released/partial/releasing states must not age a stale timer into
+        // the next re-engage.
+        if (torque_state_.load(std::memory_order_acquire) !=
+            TorqueState::kEngaged) {
+            last_motion_end_valid_ = false;
+            return;
+        }
         if (servo_wobble_active_.load(std::memory_order_acquire)) {
             last_motion_end_valid_ = false;
             return;
@@ -3123,14 +3131,29 @@ private:
         uint32_t idle_ms = now_ms - last_motion_end_ms_;
         uint32_t timeout_ms =
             auto_release_timeout_ms_.load(std::memory_order_acquire);
-        if (torque_state_.load(std::memory_order_acquire) ==
-            TorqueState::kEngaged &&
-            idle_ms >= timeout_ms) {
+        if (idle_ms >= timeout_ms) {
+            // Publish the pending OFF before InternalSetServoTorque() can
+            // block on motion_mutex_, so a concurrent manual ON is routed
+            // through the kReleasing wait/retry path instead of treating the
+            // already-expired engaged state as a successful no-op.
+            MarkReleasing();
             ServoTorqueResult r = InternalSetServoTorque(
                 false, false, ReleaseReason::kAutoIdle);
-            if (torque_state_.load(std::memory_order_acquire) ==
-                TorqueState::kReleased) {
+            auto state_after =
+                torque_state_.load(std::memory_order_acquire);
+            if (state_after == TorqueState::kReleased) {
                 last_motion_end_valid_ = false;
+            } else if (state_after == TorqueState::kReleasing) {
+                // Auto-idle re-observed motion or wobble under motion_mutex_
+                // and returned before any bus frame went out, so the per-axis
+                // torque state is still fully engaged.
+                torque_state_.store(TorqueState::kEngaged,
+                                    std::memory_order_release);
+                last_motion_end_ms_ = now_ms;
+                ESP_LOGW(TAG,
+                         "auto-release OFF aborted by motion/wobble "
+                         "re-check; rolled back torque_state_ to kEngaged, "
+                         "retry after one idle window.");
             } else {
                 last_motion_end_ms_ = now_ms;
                 ESP_LOGW(TAG,

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -681,10 +681,15 @@ private:
     TaskHandle_t servo_task_handle_ = nullptr;
     uint32_t last_motion_end_ms_ = 0;              // ServoTask-private
     bool last_motion_end_valid_ = false;           // ServoTask-private
-    std::atomic<bool> torque_currently_released_{false};
-    std::atomic<bool> torque_fully_engaged_{true};
-    // Per-axis commanded torque state is only used to avoid suppressing a
-    // real mixed-axis re-enable; the atomics publish cross-task summaries.
+    enum class TorqueState : uint8_t {
+        kEngaged = 0,
+        kPartial = 1,
+        kReleased = 2,
+        kReleasing = 3,
+    };
+    std::atomic<TorqueState> torque_state_{TorqueState::kEngaged};
+    // Per-axis commanded torque state is protected by scs_bus_mutex_;
+    // torque_state_ publishes the derived cross-task summary.
     bool yaw_torque_enabled_ = true;               // protected by scs_bus_mutex_
     bool pitch_torque_enabled_ = true;             // protected by scs_bus_mutex_
     std::atomic<bool> boot_init_done_{false};
@@ -915,6 +920,25 @@ private:
                 return "reengagement";
         }
         return "unknown";
+    }
+
+    // Caller must hold scs_bus_mutex_.
+    void PublishTorqueState() {
+        TorqueState state;
+        if (yaw_torque_enabled_ && pitch_torque_enabled_) {
+            state = TorqueState::kEngaged;
+        } else if (!yaw_torque_enabled_ && !pitch_torque_enabled_) {
+            state = TorqueState::kReleased;
+        } else {
+            state = TorqueState::kPartial;
+        }
+        torque_state_.store(state, std::memory_order_release);
+    }
+
+    // Marks a fully-OFF transition while the bus write is still pending.
+    void MarkReleasing() {
+        torque_state_.store(TorqueState::kReleasing,
+                            std::memory_order_release);
     }
 
     struct ServoTorqueResult {
@@ -2801,7 +2825,6 @@ private:
                                              bool pitch_enabled,
                                              ReleaseReason reason) {
         ServoTorqueResult result;
-        const bool mixed_axes = yaw_enabled != pitch_enabled;
         const bool disables_axis = !yaw_enabled || !pitch_enabled;
 
         auto update_bus_ok = [&]() {
@@ -2832,15 +2855,6 @@ private:
             return result;
         };
 
-        auto publish_torque_state = [&]() {
-            torque_currently_released_.store(
-                !yaw_torque_enabled_ && !pitch_torque_enabled_,
-                std::memory_order_release);
-            torque_fully_engaged_.store(
-                yaw_torque_enabled_ && pitch_torque_enabled_,
-                std::memory_order_release);
-        };
-
         if (!servo_ok_ || scs_bus_mutex_ == nullptr) {
             return finish(false);
         }
@@ -2850,10 +2864,8 @@ private:
         // scs_bus_mutex_ acquisition order.
         if (yaw_enabled && pitch_enabled) {
             xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-            bool already_engaged =
-                yaw_torque_enabled_ && pitch_torque_enabled_;
-            if (already_engaged) {
-                publish_torque_state();
+            if (torque_state_.load(std::memory_order_acquire) ==
+                TorqueState::kEngaged) {
                 log_result(true);
                 xSemaphoreGive(scs_bus_mutex_);
                 return result;
@@ -2868,17 +2880,17 @@ private:
             if (result.pitch_ok) {
                 pitch_torque_enabled_ = true;
             }
-            publish_torque_state();
+            PublishTorqueState();
             log_result(false);
             xSemaphoreGive(scs_bus_mutex_);
             return result;
         } else {
-            if (!mixed_axes) {
+            if (!yaw_enabled && !pitch_enabled) {
                 xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-                bool still_released =
-                    !yaw_torque_enabled_ && !pitch_torque_enabled_;
-                if (still_released) {
-                    publish_torque_state();
+                bool already_released =
+                    torque_state_.load(std::memory_order_acquire) ==
+                    TorqueState::kReleased;
+                if (already_released) {
                     log_result(true);
                     xSemaphoreGive(scs_bus_mutex_);
                     return result;
@@ -2910,6 +2922,12 @@ private:
                 }
                 servo_wobble_active_.store(false, std::memory_order_release);
                 servo_wobble_step_.store(0, std::memory_order_release);
+                // Mark the fully-OFF transition before releasing
+                // motion_mutex_ so concurrent motion entries do not observe
+                // the old engaged state while the OFF bus write is pending.
+                if (!yaw_enabled && !pitch_enabled) {
+                    MarkReleasing();
+                }
                 xSemaphoreGive(motion_mutex_);
             }
 
@@ -2925,7 +2943,7 @@ private:
             if (result.pitch_ok) {
                 pitch_torque_enabled_ = pitch_enabled;
             }
-            publish_torque_state();
+            PublishTorqueState();
             log_result(false);
             xSemaphoreGive(scs_bus_mutex_);
             return result;
@@ -2933,7 +2951,8 @@ private:
     }
 
     void EnsureTorqueEngagedBeforeMove() {
-        if (torque_fully_engaged_.load(std::memory_order_acquire)) {
+        if (torque_state_.load(std::memory_order_acquire) ==
+            TorqueState::kEngaged) {
             return;
         }
         if (!servo_ok_) {
@@ -2941,7 +2960,8 @@ private:
         }
         ServoTorqueResult r = InternalSetServoTorque(
             true, true, ReleaseReason::kReengagement);
-        if (!torque_fully_engaged_.load(std::memory_order_acquire)) {
+        if (torque_state_.load(std::memory_order_acquire) !=
+            TorqueState::kEngaged) {
             ESP_LOGW(TAG,
                      "servo torque re-engagement bus write failed: "
                      "yaw_ok=%d (r=%d) pitch_ok=%d (r=%d)",
@@ -2954,7 +2974,8 @@ private:
         for (int attempt = 0; attempt < kMaxReengageRetries; ++attempt) {
             EnsureTorqueEngagedBeforeMove();
             xSemaphoreTake(motion_mutex_, portMAX_DELAY);
-            if (torque_fully_engaged_.load(std::memory_order_acquire)) {
+            if (torque_state_.load(std::memory_order_acquire) ==
+                TorqueState::kEngaged) {
                 return true;
             }
             xSemaphoreGive(motion_mutex_);
@@ -3001,14 +3022,13 @@ private:
         uint32_t idle_ms = now_ms - last_motion_end_ms_;
         uint32_t timeout_ms =
             auto_release_timeout_ms_.load(std::memory_order_acquire);
-        if (!torque_currently_released_.load(std::memory_order_acquire) &&
+        if (torque_state_.load(std::memory_order_acquire) ==
+            TorqueState::kEngaged &&
             idle_ms >= timeout_ms) {
             ServoTorqueResult r = InternalSetServoTorque(
                 false, false, ReleaseReason::kAutoIdle);
-            if (torque_currently_released_.load(
-                    std::memory_order_acquire)) {
-                last_motion_end_valid_ = false;
-            } else if (r.short_circuited) {
+            if (torque_state_.load(std::memory_order_acquire) ==
+                TorqueState::kReleased) {
                 last_motion_end_valid_ = false;
             } else {
                 last_motion_end_ms_ = now_ms;
@@ -4366,7 +4386,8 @@ private:
                 }
 
                 bool torque_released_at_call =
-                    torque_currently_released_.load(std::memory_order_acquire);
+                    torque_state_.load(std::memory_order_acquire) ==
+                    TorqueState::kReleased;
                 auto_release_timeout_ms_.store(timeout_ms,
                                                std::memory_order_release);
                 auto_release_enabled_.store(enabled,

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -2950,24 +2950,58 @@ private:
         }
     }
 
+    // Wait budget for an in-progress OFF transition before deciding whether
+    // to re-engage. The auto-release path holds scs_bus_mutex_ for two
+    // EnableTorque bus frames (typically <5 ms total) between MarkReleasing()
+    // and the final PublishTorqueState() call. 200 ms is a generous safety
+    // margin that still keeps motion-entry latency human-imperceptible.
+    //
+    // If this budget is exhausted while torque_state_ is still kReleasing,
+    // the caller's bounded retry (kMaxReengageRetries = 3 in
+    // TakeMotionMutexAfterTorqueEngaged) will issue at most 3 such waits
+    // before declaring re-engage failure and skipping the motion entry.
     void EnsureTorqueEngagedBeforeMove() {
-        if (torque_state_.load(std::memory_order_acquire) ==
-            TorqueState::kEngaged) {
+        auto state = torque_state_.load(std::memory_order_acquire);
+        if (state == TorqueState::kEngaged) {
             return;
         }
         if (!servo_ok_) {
             return;
         }
-        ServoTorqueResult r = InternalSetServoTorque(
-            true, true, ReleaseReason::kReengagement);
-        if (torque_state_.load(std::memory_order_acquire) !=
-            TorqueState::kEngaged) {
-            ESP_LOGW(TAG,
-                     "servo torque re-engagement bus write failed: "
-                     "yaw_ok=%d (r=%d) pitch_ok=%d (r=%d)",
-                     r.yaw_ok ? 1 : 0, r.yaw_bus_return,
-                     r.pitch_ok ? 1 : 0, r.pitch_bus_return);
+
+        // Serialize against any pending OFF write. Without this wait, a
+        // re-engage call could win scs_bus_mutex_ ahead of the pending
+        // EnableTorque(OFF) on the auto-release path, publish kEngaged, let
+        // motion start, and then have the OFF write disable torque after
+        // motion has already been staged (round-3 adversarial finding).
+        constexpr int kMaxKReleasingWaitMs = 200;
+        constexpr int kKReleasingPollIntervalMs = 5;
+        int waited_ms = 0;
+        while (state == TorqueState::kReleasing &&
+               waited_ms < kMaxKReleasingWaitMs) {
+            vTaskDelay(pdMS_TO_TICKS(kKReleasingPollIntervalMs));
+            waited_ms += kKReleasingPollIntervalMs;
+            state = torque_state_.load(std::memory_order_acquire);
         }
+
+        if (state == TorqueState::kEngaged) {
+            // The OFF write failed during our wait and the state was
+            // recomputed back to kEngaged. No re-engage needed.
+            return;
+        }
+        if (state == TorqueState::kReleasing) {
+            // Wait budget exhausted without the OFF transition completing.
+            // Bail out and let TakeMotionMutexAfterTorqueEngaged's bounded
+            // retry decide whether to skip the motion entirely.
+            ESP_LOGW(TAG,
+                     "EnsureTorqueEngagedBeforeMove: kReleasing not "
+                     "completing within %d ms, deferring to caller retry.",
+                     kMaxKReleasingWaitMs);
+            return;
+        }
+
+        // state is kPartial or kReleased -- safe to re-engage now.
+        InternalSetServoTorque(true, true, ReleaseReason::kReengagement);
     }
 
     bool TakeMotionMutexAfterTorqueEngaged() {

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -706,6 +706,7 @@ private:
     static constexpr uint32_t AUTO_TORQUE_RELEASE_MIN_MS = 500;
     static constexpr uint32_t AUTO_TORQUE_RELEASE_MAX_MS = 600000;
     static constexpr int kMaxReengageRetries = 3;
+    static constexpr int kMaxManualReengageRetries = 3;
 #ifdef CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_MS
     static constexpr uint32_t AUTO_TORQUE_RELEASE_DEFAULT_MS =
         CONFIG_STACKCHAN_AUTO_TORQUE_RELEASE_MS;
@@ -2896,19 +2897,9 @@ private:
         // manual path waits for that pending transition before entering the
         // bus section.
         if (yaw_enabled && pitch_enabled) {
-            // Serialize manual re-engage against a pending OFF transition on
-            // the auto-release path. Without this wait, a manual
-            // set_servo_torque(true, true) could win scs_bus_mutex_ ahead of
-            // the pending EnableTorque(OFF), publish kEngaged, and then have
-            // the OFF write silently disable torque after the MCP call
-            // returned "ok" -- violating the explicit-ON contract.
-            //
-            // kReengagement is exempt: EnsureTorqueEngagedBeforeMove() has
-            // already waited out kReleasing before reaching here.
-            //
-            // kAutoIdle does not enter this branch (it requests
-            // (false, false)); included in the guard for completeness /
-            // future-proofing.
+            // Pre-mutex wait: this reduces obvious contention before
+            // attempting scs_bus_mutex_. The post-mutex re-check below closes
+            // the pre-check-to-mutex TOCTOU window.
             if (reason == ReleaseReason::kManual) {
                 auto state_pre =
                     torque_state_.load(std::memory_order_acquire);
@@ -2929,26 +2920,63 @@ private:
                 }
             }
 
-            xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
-            if (torque_state_.load(std::memory_order_acquire) ==
-                TorqueState::kEngaged) {
-                log_result(true);
+            // Bounded retry for the remaining TOCTOU window: torque_state_
+            // can flip to kReleasing between the pre-mutex check and
+            // xSemaphoreTake(). Once the bus mutex is held, re-check; if an
+            // auto-release OFF was published in that gap, release the mutex,
+            // wait, and retry. kReengagement is exempt because
+            // EnsureTorqueEngagedBeforeMove() already waited; kAutoIdle does
+            // not enter this (true, true) branch.
+            for (int attempt = 0; attempt < kMaxManualReengageRetries;
+                 ++attempt) {
+                xSemaphoreTake(scs_bus_mutex_, portMAX_DELAY);
+
+                if (reason == ReleaseReason::kManual &&
+                    torque_state_.load(std::memory_order_acquire) ==
+                        TorqueState::kReleasing) {
+                    xSemaphoreGive(scs_bus_mutex_);
+                    if (!WaitForKReleasingToClear()) {
+                        ESP_LOGW(TAG,
+                                 "set_servo_torque (reason=%s): kReleasing "
+                                 "persists after attempt %d; skipping bus "
+                                 "frames, caller may retry.",
+                                 ReleaseReasonName(reason),
+                                 attempt);
+                        log_result(true);
+                        return result;
+                    }
+                    continue;
+                }
+
+                if (torque_state_.load(std::memory_order_acquire) ==
+                    TorqueState::kEngaged) {
+                    log_result(true);
+                    xSemaphoreGive(scs_bus_mutex_);
+                    return result;
+                }
+                result.yaw_bus_return =
+                    scs_bus_.EnableTorque(SERVO_YAW_ID, 1);
+                result.pitch_bus_return =
+                    scs_bus_.EnableTorque(SERVO_PITCH_ID, 1);
+                update_bus_ok();
+                if (result.yaw_ok) {
+                    yaw_torque_enabled_ = true;
+                }
+                if (result.pitch_ok) {
+                    pitch_torque_enabled_ = true;
+                }
+                PublishTorqueState();
+                log_result(false);
                 xSemaphoreGive(scs_bus_mutex_);
                 return result;
             }
-            result.yaw_bus_return = scs_bus_.EnableTorque(SERVO_YAW_ID, 1);
-            result.pitch_bus_return =
-                scs_bus_.EnableTorque(SERVO_PITCH_ID, 1);
-            update_bus_ok();
-            if (result.yaw_ok) {
-                yaw_torque_enabled_ = true;
-            }
-            if (result.pitch_ok) {
-                pitch_torque_enabled_ = true;
-            }
-            PublishTorqueState();
-            log_result(false);
-            xSemaphoreGive(scs_bus_mutex_);
+
+            ESP_LOGW(TAG,
+                     "set_servo_torque (reason=%s): kReleasing observed in "
+                     "all %d post-mutex retries; skipping bus frames.",
+                     ReleaseReasonName(reason),
+                     kMaxManualReengageRetries);
+            log_result(true);
             return result;
         } else {
             if (!yaw_enabled && !pitch_enabled) {

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -335,6 +335,39 @@ def create_server() -> Server:
                 },
             ),
             Tool(
+                name="set_auto_torque_release",
+                description=(
+                    "Enable or disable firmware-side automatic SCS0009 "
+                    "torque release after motion idle timeout. timeout_ms "
+                    "is clamped by the firmware to 500..600000 ms. "
+                    "Disabling this setting does not re-enable torque if "
+                    "it is already released; the next set_head_angles, "
+                    "wobble, or explicit set_servo_torque(true, true) call "
+                    "re-engages torque."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": (
+                                "True to enable idle auto-release, false "
+                                "to disable it."
+                            ),
+                        },
+                        "timeout_ms": {
+                            "type": "integer",
+                            "description": (
+                                "Idle timeout in milliseconds. Values "
+                                "outside 500..600000 are clamped by the "
+                                "firmware handler."
+                            ),
+                        },
+                    },
+                    "required": ["enabled", "timeout_ms"],
+                },
+            ),
+            Tool(
                 name="get_touch_state",
                 description=(
                     "Read the head-touch (Si12T) sensor state and the most recent "
@@ -717,6 +750,10 @@ def create_server() -> Server:
             ),
             "set_servo_torque": (
                 "self.robot.set_servo_torque",
+                arguments,
+            ),
+            "set_auto_torque_release": (
+                "self.robot.set_auto_torque_release",
                 arguments,
             ),
             "get_touch_state": (


### PR DESCRIPTION
## Summary

Phase 4 of #152 — implements automatic SCS0009 torque release after motion
idle timeout to mitigate #165 cumulative-WritePos protection mode and
reduce motor heat. Re-engagement is **explicit** (`EnableTorque(ON)`
injection at motion entry points), not relying on SCS0009 implicit re-arm.

## Why

- #165 root cause: long uninterrupted WritePos traffic eventually drives
  SCS0009 into a ReadPos-blind state recoverable only by PMIC OFF/ON
- Phase 1–3 (#153 / #154 / #159) restructured motion architecture; Phase 4
  reduces session-wide WritePos accumulation during idle
- Builds on the probe in #167 (`set_servo_torque` MCP tool) and the
  cancellation refactor in #166 (`ServoDelegatedMotionDriver::InvalidateAxisToken`)

## Design highlights

- **Board-level idle timer**: `MaybeAutoReleaseTorque()` called from
  `ServoTaskMain` after `motion_driver_->Tick()` (no `MotionDriver`
  interface change).
- **Single `TorqueState` atomic enum**: `kEngaged` / `kPartial` /
  `kReleased` / `kReleasing` (the last is a transitioning state used to
  serialize the fully-OFF path against concurrent re-engage).
- **Explicit re-engagement**: `EnsureTorqueEngagedBeforeMove()` is invoked
  at the head of `WriteHeadAngles` and `ServoWobbleStepAdvance`
  (`servo_motion` task only, not on the ESP_TIMER_TASK `StartServoWobble`
  path).
- **Result-driven state update**: per-axis torque state is committed only
  for axes whose `EnableTorque` bus write returned success. The unified
  `torque_state_` is recomputed from actual per-axis state, never from
  requested state.
- **Backoff on bus failure**:
  - Auto-release OFF failure → `ESP_LOGW` + one-idle-window backoff
    (`last_motion_end_ms_ = now_ms`); next idle window retries.
  - Re-engage ON failure → bounded retry (`kMaxReengageRetries = 3`) in
    `TakeMotionMutexAfterTorqueEngaged`; on exhaustion, `ESP_LOGW` and
    motion-skip (mirrors the existing `servo_ok_` early-return).
- **`kReleasing` serialization**: `MarkReleasing()` is set inside the
  `motion_mutex_` critical section before its release;
  `EnsureTorqueEngagedBeforeMove()` poll-waits (200 ms budget, 5 ms
  interval) while `torque_state_ == kReleasing` before re-engaging, so
  pending `EnableTorque(OFF)` always wins bus ordering over any concurrent
  re-engage attempt.

### New public surface

- **MCP tool**: `set_auto_torque_release(enabled, timeout_ms)` — firmware
  clamps `timeout_ms` to `[500, 600000]`, returns
  `{enabled, timeout_ms, clamped, torque_released_at_call}`. Disabling
  does **not** re-engage torque; explicit `set_servo_torque(true, true)`
  or any motion-entry call re-engages.
- **Kconfig**:
  - `STACKCHAN_AUTO_TORQUE_RELEASE_ENABLED` (bool, default `y`)
  - `STACKCHAN_AUTO_TORQUE_RELEASE_MS` (int, default `5000`, range `500..600000`,
    depends on the bool)

## Review trail (10 commits)

The design was refined in #168 via three rounds of design-level
adversarial review (initial draft v1 → final design comment v4). After
implementation, the following adversarial findings drove ten iteration
rounds:

| Commit | What it does | Triggered by |
|---|---|---|
| `89bda83` | Initial Phase 4 implementation per the v4 final design. | — |
| `5a5ab77` | Make the torque state machine bus-return-driven (only commit per-axis state on confirmed bus success). | Round-1 adversarial: state was committed even when `EnableTorque` failed → mitigation defeated itself under degraded bus. |
| `6c8b1f0` | Unify torque state into a single `std::atomic<TorqueState>` enum; introduce `MarkReleasing()` for the fully-OFF transition. | Round-2 adversarial: torn state observation between two atomic stores; OFF transition race let concurrent motion entries skip re-engage. |
| `d182866` | Serialize `kReleasing` against re-engage (poll-wait in `EnsureTorqueEngagedBeforeMove`, 200 ms budget). | Round-3 adversarial: `MarkReleasing()` alone could not stop a re-engage from winning bus ordering ahead of the pending OFF write. |
| `0b26381` | Use `esp_timer_get_time()`-based real elapsed-time deadline for the `kReleasing` wait, and round each `vTaskDelay` up to at least one tick. | Round-4 adversarial: at `CONFIG_FREERTOS_HZ=100`, `pdMS_TO_TICKS(5)` floors to 0 ticks, collapsing the 200 ms wait into a yield-only spin and invalidating the forward-progress guarantee. |
| `2bae2d4` | Extract `WaitForKReleasingToClear()` helper and apply it to the manual `set_servo_torque(true,true)` path (gated on `reason == kManual`) so explicit ON cannot race a pending auto-release OFF. | Round-5 adversarial: manual ON bypassed the round-4 wait, could win `scs_bus_mutex_` ahead of pending OFF and return ok before being silently overwritten. |
| `b4ab2b1` | Wrap the manual `(true,true)` bus section in a bounded retry loop (`kMaxManualReengageRetries = 3`) with a **post-mutex** `kReleasing` re-check; on observation, release `scs_bus_mutex_`, `WaitForKReleasingToClear()`, retry. Mirrors `TakeMotionMutexAfterTorqueEngaged`'s pattern. | Round-6 adversarial: the round-5 pre-mutex wait still had a TOCTOU window — `kReleasing` could be published between the pre-check and `scs_bus_mutex_` acquisition. |
| `d77320f` | Pre-call `MarkReleasing()` from `MaybeAutoReleaseTorque` BEFORE invoking `InternalSetServoTorque` (so concurrent manual ON sees `kReleasing` at the OFF-decide point, not later); rollback to `kEngaged` on bail-out. Also gate idle-timer maintenance on `torque_state_ == kEngaged` so released-period stale aging cannot trigger an immediate re-OFF after re-engage. | Round-7 adversarial: (a) manual ON could still lose to auto-idle OFF before `MarkReleasing()` ran inside `InternalSetServoTorque`'s motion-cancel block; (b) re-engaged after long-released idle could be immediately re-OFFed by a stale `last_motion_end_ms_`. |
| `e9de865` | Make `MarkReleasing()` owned by a `std::atomic<uint32_t> torque_release_epoch_`; the auto-idle bail-out rollback only fires when the current epoch still equals the auto-idle's own epoch (otherwise another release publisher is in flight and we must not stomp their `kReleasing`). Add `std::atomic<bool> idle_timer_reset_pending_` set by `PublishTorqueState()` on transitions into `kEngaged` and consumed by `MaybeAutoReleaseTorque` via `exchange(false, ...)`, so a fast manual OFF → manual ON between ServoTask ticks still resets the idle window. | Round-8 adversarial: (a) the round-8 rollback was an unowned atomic store — a concurrent `set_servo_torque(false, false)` (realistic LLM operator pattern) could publish its own `kReleasing` and have it erased by the auto-idle rollback; (b) the round-8 polling-based reset missed quick release→engage cycles that ServoTask never observed in the intermediate state. |
| `91bff00` | Add `expected_release_epoch` parameter to `InternalSetServoTorque()`; on the auto-idle disable path, after acquiring `scs_bus_mutex_` verify both that the release epoch still equals our auto-idle attempt AND that `torque_state_` is still `kReleasing`. If either fails, abort without writing `EnableTorque(0, 0)` so a concurrent publisher's state (including pure-mixed `kPartial` from `set_servo_torque(false, true)` / `(true, false)`) is preserved. `MaybeAutoReleaseTorque` rollback expanded to three-way (`current_epoch == my_pre_epoch` rolls back, `+1` doesn't, `> +1` doesn't). | Round-9 adversarial: between `MarkReleasing()` and `scs_bus_mutex_` acquisition on the auto-idle disable path, a concurrent manual partial-torque write (`(false, true)` / `(true, false)`) could land `kPartial` on the bus first, and the auto-idle would then send `EnableTorque(0, 0)` anyway and clobber the partial state — no ACK loss / wait-budget exhaustion required. |

## Known limitations

This PR addresses the cumulative-WritePos race conditions on the
auto-release / re-engage path with best-effort coverage of the
common Phase-4 cases (auto-release → re-engage on next motion;
manual ON/OFF in serial sequence; partial torque in serial sequence).
Three classes of follow-up are intentionally carved out:

- **#170 SCS0009 EnableTorque ACK loss recovery** — when an
  `EnableTorque(OFF)` bus frame reaches the servo but the ACK is lost on
  the UART return path, `torque_state_` can publish `kEngaged` from the
  cached per-axis state, stranding the device torque-off without a
  recovery path through `EnsureTorqueEngagedBeforeMove` or manual
  `set_servo_torque(true, true)`. Consistent with the firmware-wide
  stance on ACK loss today (`WritePos` retries-exhausted → "abandoning
  request and marking position unknown" at `stackchan.cc:1768`) and
  with the upstream m5stack/StackChan reference behavior (which relies
  on implicit SCS0009 re-arm and does not encounter this scenario).
  Recovery design (`kUncertain` state vs `REG_TORQUE_ENABLE` readback
  vs hybrid) requires its own design pass.

- **#171 `set_servo_torque(true, true)` wait-budget exhaustion
  reported as `ok=true`** — when the pending `EnableTorque(OFF)` bus
  write takes >200 ms (i.e. the bus is degraded, consistent with #165
  / #170), the manual ON path returns `short_circuited=true` and the
  MCP response computes `ok=true` because `short_circuited` is treated
  the same as `already_engaged`. An LLM operator relying on the `ok`
  field may proceed under a stale "torque is ON" belief. Only fires
  under bus-degradation conditions; healthy bus clears the wait in
  <5 ms. Response-JSON semantic distinction (`wait_exhausted` vs
  `already_engaged`) is being designed in the follow-up issue.

- **#172 Phase 4.1 atomic state ownership rework** — the fine-grained
  lock-free design composed of `torque_state_`, `torque_release_epoch_`,
  and the per-axis `scs_bus_mutex_`-protected booleans does not give
  an atomic compare-and-swap on the combined `{epoch, state, per-axis}`
  ownership tuple. Two specific interleaving corner cases were
  identified by adversarial review:
  - Auto-release's inner `MarkReleasing()` can overwrite a `kPartial`
    state published by a concurrent `set_servo_torque(false, true)` /
    `(true, false)` partial-torque write.
  - `MaybeAutoReleaseTorque` rollback's `load + store` is non-atomic
    and can overwrite a concurrent publisher's `kReleasing` / `kPartial`.

  Both require a partial-torque write AND a coincident auto-release
  bail-out / rollback within a μs-scale window — the realistic LLM
  operator behavior is to issue partial-torque writes serially
  (not concurrent with motion-staging tool_use), so the corner cases
  do not affect normal operation. Both have recovery paths (next
  motion or next MCP call re-establishes the intended state). The
  follow-up issue tracks a Phase 4.1 design pass to bring the
  ownership tuple under a single CAS-able primitive or a
  `scs_bus_mutex_`-protected check-and-store.

## Test plan

### Code-verifiable (self-confirmed, included)

- [x] License boundary unchanged (no edits to GPL-3.0 SCServo_lib files: `firmware/main/boards/stackchan/SC*.{cc,h}`, `INST.h`, `SCServo.h`)
- [x] `MotionDriver` virtual interface unchanged
- [x] No personal info / hostnames / absolute paths in the diff
- [x] Mutex ordering preserved (`motion_mutex_ → scs_bus_mutex_`)
- [x] Boot-init Phase 0 climb invariant: `torque_state_` initial value is `kEngaged` so `EnsureTorqueEngagedBeforeMove` at `InitializeServo()` (Phase 0 climb `WriteHeadAngles`) short-circuits and emits no bus frame
- [x] Manual `set_servo_torque(true, true)` regression: the `(true,true)` branch in `InternalSetServoTorque` takes only `scs_bus_mutex_`, never touches `motion_mutex_` / `yaw_motion_.moving` / `pitch_motion_.moving` / `servo_wobble_active_`
- [x] Atomic memory ordering (`acquire` on reads, `release` on writes) on all cross-task flags
- [x] `git diff --check` passes
- [x] `python3 -m py_compile gateway/stackchan_mcp/stdio_server.py` passes

### Real-device verification (PENDING — see follow-up issue)

The following scenarios require physical M5Stack CoreS3 + SCS0009 hardware
and are deferred to a real-device verification session before the next
firmware release tag is cut:

- [ ] Happy path: PMIC fresh boot → idle 5 s → auto-release fires; serial log shows `set_servo_torque (reason=auto_idle): ...`
- [ ] Hand-push recovery: while torque-off, push head ±30°, then `set_head_angles(0, 45)` re-engages; serial log shows `set_servo_torque (reason=reengagement): ...`
- [ ] Boot-init Phase 0 climb: serial log shows no `EnableTorque(ON)` frame between Phase 1a/1b hold and Phase 0 climb completion (`#121` snap-suppress ordering preserved)
- [ ] Constraint 11 on hardware: `set_servo_torque(true, true)` during an active `set_head_angles` interpolation does not cancel the motion
- [ ] Touch wobble during idle countdown: wobble ends → idle counter restarts from wobble end
- [ ] Manual + auto race: invoke `set_servo_torque(true, true)` near the 5 s auto-release deadline; final state matches the last log `reason=...` line
- [ ] `set_auto_torque_release(false)` preserves released state (no re-engage)
- [ ] Runtime clamp: `(true, 100)` → clamped to 500 with `clamped: true`; `(true, 700000)` → clamped to 600000 with `clamped: true`
- [ ] #165 onset extension: `[Phase 4 ON]` extended-session test (≥ 60 min uptime without #165 onset)

A follow-up issue will track real-device acceptance and gate the next
firmware release tag on its completion.

## Refs

- Parent: #152 (motion subsystem migration epic — Phase 4)
- Root cause: #165 (cumulative-WritePos protection mode — primary mitigation target)
- Probe: #167 (`set_servo_torque` MCP tool, "Known limitations" for HostInterpolation `position_unknown`)
- Cancellation refactor: #166 (ServoDelegated `InvalidateAxisToken`)
- Final design: #168 ([comment](https://github.com/kisaragi-mochi/stackchan-mcp/issues/168#issuecomment-4475317251))
- Carve-out follow-ups: #170 (SCS0009 EnableTorque ACK loss recovery), #171 (manual ON wait-budget exhaustion `ok=true` semantics), #172 (Phase 4.1 lock-free / mutex-protected ownership-tuple rework)

Closes #168 (subject to real-device verification gating before release).


Real-device verification tracked in: #174 (release blocker for next firmware release tag).
