### PR TITLE
fix(firmware): #175 preserve current pitch during touch wobble to avoid SCS0009 end-stop excursion

### DIFF
--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -3306,12 +3306,20 @@ private:
         const int A = SERVO_WOBBLE_AMPLITUDE_DEG;
         int step = servo_wobble_step_.load();
         int target_yaw = 0;
-        int target_pitch = 0;
+        // Preserve the current pitch through the wobble sequence; only the
+        // yaw axis is animated. A hardcoded `target_pitch = 0` on every
+        // step would command the SCS0009 pitch axis toward the lower
+        // end-stop (raw pos ~620 ≈ pitch 0°) on a device whose standard
+        // rest pose is BOOT_INIT_PITCH_DEG=45°, accelerating #165
+        // cumulative WritePos protection-mode onset within a single
+        // STROKE gesture. Direct field read is safe here because
+        // motion_mutex_ is already held (see contract above). #175.
+        int target_pitch = pitch_motion_.current_deg;
         switch (step) {
-            case 0: target_yaw = -A; target_pitch = 0; break;
-            case 1: target_yaw = +A; target_pitch = 0; break;
-            case 2: target_yaw = -A; target_pitch = 0; break;
-            case 3: target_yaw =  0; target_pitch = 0; break;
+            case 0: target_yaw = -A; break;
+            case 1: target_yaw = +A; break;
+            case 2: target_yaw = -A; break;
+            case 3: target_yaw =  0; break;
             default:
                 servo_wobble_active_.store(false);
                 xSemaphoreGive(motion_mutex_);


### PR DESCRIPTION
## Summary

Preserve the current pitch through the touch-triggered servo wobble
sequence. Only the yaw axis is animated; the pitch axis stays at its
pre-wobble angle.

## Why

`ServoWobbleStepAdvance()` previously hardcoded `target_pitch = 0` on
every wobble step, which commanded the SCS0009 pitch axis toward the
lower mechanical end-stop (raw pos ~620 ≈ pitch 0°) on a device whose
standard rest pose is `BOOT_INIT_PITCH_DEG = 45°`. The resulting
`45° → 0°` pitch excursion on top of the intended `±20°` yaw oscillation
drives the SCS0009 into #165 cumulative WritePos protection mode within
a single STROKE gesture, observed during real-device verification for
PR #173 / Issue #174.

Captured serial log excerpt (post-PR-#173 firmware, boot standard
pitch=45°):

```
I (29075) touch event: STROKE (zones=000 duration=...ms raw=0x258)
I (29105) set_servo_torque (reason=reengagement): yaw=1 pitch=1 r=0
W (29965) Motion pitch ReadMove failed: current_deg=0 target_deg=0; 5 consecutive failures
W (30145) Motion yaw  WritePos failed: r=-1 (deg=20,  pos=524)
W (30165) Motion pitch WritePos failed: r=-1 (deg=0,  pos=620)
... ~25 consecutive WritePos failures across both axes ...
W (30555) Motion yaw  WritePos retries exhausted: abandoning request
W (30585) Motion pitch WritePos retries exhausted: abandoning request
```

The Phase 4 (#173) `auto_idle → torque OFF → reengagement → wobble` cycle
itself behaves correctly. The hang originates one step earlier — at the
wobble step targets themselves — and the fix is contained to that
function.

### Introduced by

`2236d00 feat(firmware): #143 introduce MotionDriver abstraction +
opt-in servo-delegated motion path (#146)` (merged 2026-05-17).

### Exposure increased by

PR #173 (Phase 4 auto torque release) added a routine
`auto_idle → torque OFF → reengagement → wobble` cycle that brings the
wobble pitch hardcode into the critical path on every STROKE-on-released
device interaction.

## Change

`firmware/main/boards/stackchan/stackchan.cc`,
`ServoWobbleStepAdvance()`:

```diff
 const int A = SERVO_WOBBLE_AMPLITUDE_DEG;
 int step = servo_wobble_step_.load();
 int target_yaw = 0;
-int target_pitch = 0;
+// Preserve the current pitch through the wobble sequence; only the
+// yaw axis is animated. A hardcoded `target_pitch = 0` on every
+// step would command the SCS0009 pitch axis toward the lower
+// end-stop (raw pos ~620 ≈ pitch 0°) on a device whose standard
+// rest pose is BOOT_INIT_PITCH_DEG=45°, accelerating #165
+// cumulative WritePos protection-mode onset within a single
+// STROKE gesture. Direct field read is safe here because
+// motion_mutex_ is already held (see contract above). #175.
+int target_pitch = pitch_motion_.current_deg;
 switch (step) {
-    case 0: target_yaw = -A; target_pitch = 0; break;
-    case 1: target_yaw = +A; target_pitch = 0; break;
-    case 2: target_yaw = -A; target_pitch = 0; break;
-    case 3: target_yaw =  0; target_pitch = 0; break;
+    case 0: target_yaw = -A; break;
+    case 1: target_yaw = +A; break;
+    case 2: target_yaw = -A; break;
+    case 3: target_yaw =  0; break;
     default:
         servo_wobble_active_.store(false);
         xSemaphoreGive(motion_mutex_);
         return;
 }
 motion_driver_->StartMove(target_yaw, target_pitch, SERVO_WOBBLE_STEP_MS);
```

`pitch_motion_.current_deg` is a plain `int` protected by
`motion_mutex_`. The mutex is already held at the read site (see the
function's contract documentation above the affected block), so the
direct field read is correct without additional synchronization.

## Validation

### Code-verifiable (self-confirmed)

- [x] License boundary unchanged (no edits under GPL-3.0 `SC*.{cc,h}` / `INST.h` / `SCServo.h`)
- [x] `motion_mutex_` ordering and hold contract preserved (the read happens at the existing hold site)
- [x] No new dependencies, no public surface change, no Kconfig changes
- [x] No personal info / hostnames / absolute paths in the diff
- [x] Wobble cancel-on-concurrent-StartMove path unchanged
       (`servo_wobble_active_ = false` clear in `WriteHeadAngles()` still applies)
- [x] Boot-init Phase 0 climb path unaffected (wobble is touch-driven; boot path does not invoke `ServoWobbleStepAdvance`)
- [x] Phase 4 auto-release / reengagement (#173) entry points unaffected

### Real-device verification (PENDING — see #174)

The following must be confirmed on M5Stack CoreS3 + SCS0009 hardware
before the next firmware release tag:

- [ ] PMIC OFF / ON → fresh boot → STROKE gesture executes wobble
      (yaw `±20° → 0°` oscillation) without `Motion pitch WritePos`
      events showing `deg=0`
- [ ] Same gesture does NOT trigger `WritePos retries exhausted ... abandoning request`
- [ ] 5+ repeated STROKE gestures over 60 s do not trigger #165 onset
      on the reference hardware
- [ ] Pre-existing wobble cancellation behavior preserved:
      a concurrent `WriteHeadAngles()` during a wobble still cleanly
      overrides the staged angles without a stray wobble step
- [ ] No regression to PR #173 / Issue #174 acceptance criteria

## Release implication

Release blocker for the next firmware tag in combination with PR #173.
Without this fix, real-device verification for #174 cannot reach
completion (any STROKE gesture during Item 5 verification hangs the
device before the idle-counter restart can be observed). Real-device
acceptance for both this PR and PR #173 is tracked in #174.

## Out of scope

- Re-architecting wobble to be a general `current_deg`-relative
  oscillation; this minimal-diff fix only substitutes the pitch target
- Pitch-range clamping inside `ServoWobbleStepAdvance()` (already
  covered by the motion-driver `StartMove` contract / `WriteHeadAngles`)
- Reverting #146 (the MotionDriver abstraction itself is correct; only
  the wobble's pitch-target literal is wrong)
- #150 boot pre-init safe-seed pitch desync (separate Issue; not
  closed by this fix)

## Refs

- Closes #175
- Real-device verification for this PR + #173 tracked in: #174
- Introduced by: #146 (PR for #143)
- Exposure surfaced by: #173 (PR for #168, Phase 4 auto torque release)
- Root onset mechanism: #165 (SCS0009 cumulative WritePos protection mode)
- Recovery scenario: #100 (bus hang requiring PMIC OFF / ON)
