### PR TITLE
docs(changelog): backfill #175 / PR #176 wobble pitch preserve entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Fixed: STROKE-triggered touch wobble previously commanded
+  `target_pitch = 0` per step, forcing the SCS0009 pitch axis toward
+  the lower mechanical end-stop (raw `pos ≈ 620`) on every touch. The
+  wobble now preserves the pre-wobble pitch by reading
+  `pitch_motion_.current_deg` (already protected by the active
+  `motion_mutex_` hold at this point in `ServoWobbleStepAdvance()`);
+  yaw continues to oscillate `±SERVO_WOBBLE_AMPLITUDE_DEG`. This
+  eliminates the single-STROKE `#165` onset path that
+  [#146](https://github.com/kisaragi-mochi/stackchan-mcp/pull/146)
+  introduced by hardcoding the pitch target, which subsequently became
+  reachable on every touch once
+  [PR #173](https://github.com/kisaragi-mochi/stackchan-mcp/pull/173)
+  made `auto_idle → reengagement → wobble` a routine cycle. On-device
+  verification: single STROKE shows `target_deg=44` (pre-wobble pitch)
+  across all four wobble steps; eight strokes in 60 s and a 60-min
+  representative motion load each report zero `WritePos retries
+  exhausted` events. Closes
+  [#175](https://github.com/kisaragi-mochi/stackchan-mcp/issues/175).
+
 - Added `set_auto_torque_release(enabled, timeout_ms)` and automatic
   SCS0009 torque release after motion idle timeout for #152 Phase 4.
 


### PR DESCRIPTION
## Summary

Backfill the missing `[Unreleased] Firmware` CHANGELOG entry for #175 / PR #176 (wobble pitch-preserve hotfix). The accumulating `[Unreleased] Firmware` section is the source the next `firmware-vX.Y.Z` release notes are extracted from, and PR #176 merged without updating it.

## Why

PR #176 fixed the `ServoWobbleStepAdvance()` hardcoded `target_pitch = 0` bug tracked in #175. At merge time the CHANGELOG entry was not added, leaving the change absent from `[Unreleased] Firmware`. Without this backfill, the next firmware release notes would silently omit a user-facing fix.

## Validation

- `git diff main..HEAD --stat`: `CHANGELOG.md` only, no source files touched
- Entry text cross-checked against PR #176 description, Issue #175 root-cause analysis, and the on-device verification summary recorded on Issue #174
- No personal config / IPs / paths in the diff

## Test plan

- [ ] CI passes (no new code paths, but the workflow runs firmware build + gateway tests on every push as a sanity check)
- [ ] Reviewer confirms the entry text matches what landed in PR #176 and the verification reported on Issue #174

Refs #175, PR #176.