### PR TITLE
release: gateway v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,6 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ## [Unreleased]
 
-### Gateway
-
-- Added hardware-lane aware dispatch for ESP32 tool calls. Independent
-  hardware lanes (servo, LED, avatar/display, screen, audio, camera,
-  touch, status) now pipeline concurrently on the gateway side, while
-  ordering within the same lane is preserved. The existing
-  `ESP32Manager.call_tool()` API remains compatible. `tools/call`
-  send-failure handling is also hardened: WebSocket send failures now
-  mark the ESP32 connection disconnected and no longer leave
-  unobserved pending future exceptions. Refs
-  [#73](https://github.com/kisaragi-mochi/stackchan-mcp/issues/73)
-  (firmware-side `tools/call` execution remains serialized by
-  `Application::Schedule()`, so Issue #73 stays open as the
-  firmware-side follow-up).
-
 ### Firmware
 
 - Fixed: STROKE-triggered touch wobble previously commanded
@@ -340,6 +325,42 @@ change is called out under a `Firmware` subsection of the release entry.
   Refs
   [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
   Problem 1.
+
+## [0.8.0] - 2026-05-19
+
+### Gateway
+
+- Added the `set_auto_torque_release(enabled, timeout_ms)` MCP tool
+  exposure on the gateway, the runtime configuration surface for the
+  firmware-side Phase 4 auto-torque-release feature
+  ([#152](https://github.com/kisaragi-mochi/stackchan-mcp/issues/152)
+  Phase 4). `timeout_ms` is clamped by the firmware to `500..600000`
+  ms; the gateway forwards the request and returns the firmware's
+  response including the `clamped` flag and the
+  `torque_released_at_call` state. Refs
+  [#168](https://github.com/kisaragi-mochi/stackchan-mcp/issues/168).
+
+- Added the `set_servo_torque(yaw_enabled, pitch_enabled)` MCP tool
+  exposure on the gateway. The tool is a per-axis SCS0009 torque
+  toggle primitive originally introduced as a diagnostic probe for the
+  Phase 4 design work but also useful as a standalone power-management
+  primitive. The gateway forwards the request and returns the
+  firmware's response including the `short_circuited` flag indicating
+  whether the bus call was actually issued. Closes
+  [#163](https://github.com/kisaragi-mochi/stackchan-mcp/issues/163).
+
+- Added hardware-lane aware dispatch for ESP32 tool calls. Independent
+  hardware lanes (servo, LED, avatar/display, screen, audio, camera,
+  touch, status) now pipeline concurrently on the gateway side, while
+  ordering within the same lane is preserved. The existing
+  `ESP32Manager.call_tool()` API remains compatible. `tools/call`
+  send-failure handling is also hardened: WebSocket send failures now
+  mark the ESP32 connection disconnected and no longer leave
+  unobserved pending future exceptions. Refs
+  [#73](https://github.com/kisaragi-mochi/stackchan-mcp/issues/73)
+  (firmware-side `tools/call` execution remains serialized by
+  `Application::Schedule()`, so Issue #73 stays open as the
+  firmware-side follow-up).
 
 ## [0.7.0] - 2026-05-14
 
@@ -762,7 +783,9 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.6.0
 [0.5.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.5.0
 [0.4.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.4.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.7.0"
+version = "0.8.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Promote `[Unreleased] Gateway` to `[0.8.0] - 2026-05-19` and bump `gateway/pyproject.toml` to `0.8.0`. The release covers three PRs landed since `v0.7.0`:

- **`set_auto_torque_release(enabled, timeout_ms)` MCP tool exposure** (PR #173, #168 Phase 4)
- **`set_servo_torque(yaw_enabled, pitch_enabled)` MCP tool exposure** (PR #167, #163)
- **Hardware-lane aware dispatch for ESP32 tool calls** (PR #130, #73)

Also backfills the missing `v0.7.0` comparison link in `CHANGELOG.md`, which went unupdated at v0.7.0 release time — the same class of promotion debt tracked in #157 for firmware tags.

## Why now

These three PRs each added new user-visible gateway behavior (two new MCP tools and a parallel-dispatch infrastructure change). Cutting a paired gateway release alongside `firmware-v1.7.0` lets users `pipx install --force stackchan-mcp` and flash the new firmware in one upgrade cycle, since the new firmware-side features (`#152` Phase 4, `#163` torque probe) are only reachable from clients via the gateway-side MCP tool exposure added in PRs #173 and #167.

## Changes

- `CHANGELOG.md`:
  - `[Unreleased] Gateway` content (PR #130 entry only) moved into a new `[0.8.0] - 2026-05-19` section
  - Two new entries added to `[0.8.0] Gateway` for PR #173 and PR #167 (the gateway-side tool exposures that were missed at their respective merge times)
  - `[Unreleased] Firmware` content left in place (firmware tags use the accumulating-`[Unreleased]`-Firmware flow; the unmerged Firmware content is the source for the next `firmware-vX.Y.Z` release notes)
  - Comparison links updated: `[Unreleased]: compare/v0.8.0...HEAD`, `[0.8.0]: compare/v0.7.0...v0.8.0`, new `[0.7.0]: compare/v0.6.0...v0.7.0` link added (previously missing)
- `gateway/pyproject.toml`: `version = "0.8.0"`

## Validation

- `git diff main..HEAD --stat`: 2 files, `CHANGELOG.md` + `gateway/pyproject.toml`
- No source files touched on the gateway Python side; the actual behavior changes shipped in PRs #130, #167, #173
- No personal config / IPs / paths in the diff

## Test plan

- [ ] CI passes (firmware build + gateway pytest both run on every push)
- [ ] After merge, `git tag v0.8.0 && git push origin v0.8.0` will trigger the Trusted Publishing path to PyPI
- [ ] `gh release create v0.8.0` (via the documented sed-based extraction from CHANGELOG) for the GitHub Release page

Refs #157 (firmware-side promotion debt — same class of issue, this PR addresses the gateway-side instance for `[0.7.0]` and `[0.8.0]`).