### PR TITLE
docs: #184 correct stack-chan project attribution to Shinya Ishikawa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,23 @@ change is called out under a `Firmware` subsection of the release entry.
   [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
   Problem 1.
 
+### Docs
+
+- Corrected the stack-chan project attribution in `README.md` and
+  `README.ja.md`. The hero blurb, the self-built-stack-chan note,
+  and the "Related projects" entry previously credited the project
+  to "Takawo-san" (mongonta0716 / Takao Akaki) and linked to a
+  personal fork; the project originator is **Shinya Ishikawa**
+  (ししかわ / 石川真也), with public release in 2021, and the
+  canonical upstream is `stack-chan/stack-chan`. The "Related
+  projects" section now also separately credits Takao Akaki
+  (mongonta0716) via the `stack-chan/stackchan-arduino` entry,
+  which is the implementation lineage actually referenced by this
+  firmware. A new `Trademarks` / `商標` section is appended to
+  both READMEs acknowledging that "StackChan" / "スタックチャン"
+  is a registered trademark of Shinya Ishikawa. Closes
+  [#184](https://github.com/kisaragi-mochi/stackchan-mcp/issues/184).
+
 ## [0.8.0] - 2026-05-19
 
 ### Gateway

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 **M5Stack 公式 [StackChan](https://docs.m5stack.com/ja/StackChan)** (2025年 Kickstarter 出荷キット) を任意の LLM クライアントから操作するための MCP (Model Context Protocol) ブリッジ。
 
-> オリジナルの [stack-chan プロジェクト (タカヲさん)](https://github.com/mongonta0716/stack-chan) のコミュニティから生まれ、M5Stack 公式が製品化した StackChan キットを対象としています。
+> [stack-chan プロジェクト](https://github.com/stack-chan/stack-chan)（ししかわ／石川真也 さんが 2021 年に公開）のコミュニティから生まれ、M5Stack 公式が製品化した StackChan キットを対象としています。
 
 ```
 ┌─────────────┐     stdio MCP      ┌──────────────┐    WebSocket MCP    ┌──────────────┐
@@ -39,7 +39,7 @@
 | **タッチ** | FT6336 / Si12T |
 | **ディスプレイ** | ILI9342 (SPI, 320×240) |
 
-> 自作の stack-chan (タカヲさん版オリジナル設計) でも、上記のピンアサイン・I2C アドレスが一致していれば動く可能性があります。動作報告・修正 PR 歓迎です。
+> 自作の stack-chan（[stack-chan プロジェクト](https://github.com/stack-chan/stack-chan)のオリジナル設計に準拠）でも、上記のピンアサイン・I2C アドレスが一致していれば動く可能性があります。動作報告・修正 PR 歓迎です。
 
 ## ツール一覧 (gateway 経由で MCP クライアントが呼べる)
 
@@ -519,7 +519,9 @@ X 軸 (yaw、`-90..+90°`) には同等のハードウェア制限はなく — 
 
 - [M5Stack 公式 StackChan ドキュメント](https://docs.m5stack.com/ja/StackChan) — 想定ハードウェアの公式ドキュメント (出荷時ファーム / 配線図 / API リファレンス等)
 - [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) — ベースとなる ESP32 LLM クライアントファームウェア
-- [stack-chan](https://github.com/mongonta0716/stack-chan) — オリジナルの StackChan プロジェクト (タカヲさん)
+- [stack-chan](https://github.com/stack-chan/stack-chan) — オリジナルの StackChan プロジェクト（ししかわ／石川真也 さん）
+- [stackchan-arduino](https://github.com/stack-chan/stackchan-arduino) — Arduino 系の servo 制御 library（タカオ さん／mongonta0716）。本ファームウェアの SCS0009 positioning timing はこちらを参考にしています
+- [m5stack-avatar](https://github.com/stack-chan/m5stack-avatar) — StackChan 系 firmware で広く使われている avatar 描画 library
 - [Model Context Protocol](https://modelcontextprotocol.io) — MCP プロトコル仕様
 
 ## コントリビューション
@@ -527,3 +529,7 @@ X 軸 (yaw、`-90..+90°`) には同等のハードウェア制限はなく — 
 Issue / PR 歓迎です。StackChan コミュニティで使える形を目指しています。
 
 開発手順は [`CONTRIBUTING.md`](CONTRIBUTING.md) を参照してください。
+
+## 商標
+
+「StackChan」および「スタックチャン」は、stack-chan プロジェクトを発足したししかわ（石川真也）さんの登録商標です。本リポジトリでは、対象ハードウェアである M5Stack 公式 StackChan キットを指す用語としてこれらの名称を使用しています。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An MCP (Model Context Protocol) bridge for the **M5Stack official [StackChan](https://docs.m5stack.com/ja/StackChan)** (2025 Kickstarter shipping kit), letting any LLM client drive the device.
 
-> Born out of the [stack-chan project](https://github.com/mongonta0716/stack-chan) community (originated by Takawo-san). This repository targets the M5Stack official StackChan kit that grew out of that lineage.
+> Born out of the [stack-chan project](https://github.com/stack-chan/stack-chan) community (originated by Shinya Ishikawa in 2021). This repository targets the M5Stack official StackChan kit that grew out of that lineage.
 
 ```
 ┌─────────────┐     stdio MCP      ┌──────────────┐    WebSocket MCP    ┌──────────────┐
@@ -39,7 +39,7 @@ This repository is a monorepo.
 | **Touch** | FT6336 / Si12T |
 | **Display** | ILI9342 (SPI, 320×240) |
 
-> A self-built stack-chan (Takawo-san's original design) may also work as long as the pin assignments and I2C addresses match. Reports and PRs welcome.
+> A self-built stack-chan (following the original [stack-chan project](https://github.com/stack-chan/stack-chan) design) may also work as long as the pin assignments and I2C addresses match. Reports and PRs welcome.
 
 ## Tools (callable by MCP clients via the gateway)
 
@@ -569,7 +569,9 @@ The `gateway/` runs as an independent Python process and only talks to the ESP32
 
 - [M5Stack official StackChan documentation](https://docs.m5stack.com/ja/StackChan) — official documentation for the target hardware (factory firmware / wiring / API reference / etc.)
 - [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) — the base ESP32 LLM client firmware
-- [stack-chan](https://github.com/mongonta0716/stack-chan) — the original StackChan project (Takawo-san)
+- [stack-chan](https://github.com/stack-chan/stack-chan) — the original StackChan project (Shinya Ishikawa)
+- [stackchan-arduino](https://github.com/stack-chan/stackchan-arduino) — Arduino-side servo control library (Takao Akaki / mongonta0716); this firmware references the SCS0009 positioning timing established there
+- [m5stack-avatar](https://github.com/stack-chan/m5stack-avatar) — Avatar rendering library widely used by StackChan firmware
 - [Model Context Protocol](https://modelcontextprotocol.io) — the MCP protocol specification
 
 ## Contributing
@@ -577,3 +579,7 @@ The `gateway/` runs as an independent Python process and only talks to the ESP32
 Issues and PRs are welcome. We aim to provide something the StackChan community can use as-is.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the development flow.
+
+## Trademarks
+
+"StackChan" and "スタックチャン" are registered trademarks of Shinya Ishikawa, the originator of the stack-chan project. This repository uses these names in reference to the M5Stack official StackChan kit it targets.


### PR DESCRIPTION
## Summary

Correct the stack-chan project attribution in `README.md` and `README.ja.md`. The previous wording credited the project to "Takawo-san" (mongonta0716 / Takao Akaki) and linked to a personal fork; as flagged by a community comment on X, the project originator is **Shinya Ishikawa** (ししかわ / 石川真也), who publicly released stack-chan in 2021, and the canonical upstream is `stack-chan/stack-chan` in the official `stack-chan` GitHub organization.

Changes:

- Switch the upstream links at L7 / L42 / Related projects from `mongonta0716/stack-chan` (personal fork) to `stack-chan/stack-chan` (official org repo), in both READMEs.
- Attribute the project origin to Shinya Ishikawa with the 2021 release year in the hero blurb (L7).
- Neutralize the self-built-stack-chan note at L42 to reference the original stack-chan project design rather than an individual.
- In the "Related projects" section, split into separate entries so the Arduino-side servo-control implementation credit for Takao Akaki (mongonta0716) is preserved alongside the project-origin credit. The firmware references the SCS0009 positioning timing established in `stack-chan/stackchan-arduino`; that credit is retained as its own entry. Also list `stack-chan/m5stack-avatar` as it is widely used by StackChan firmware in the ecosystem.
- Append a new `Trademarks` / `商標` section to both READMEs acknowledging that "StackChan" / "スタックチャン" is a registered trademark of Shinya Ishikawa (per the PR TIMES reference linked in the Issue).
- `CHANGELOG.md` `[Unreleased]` gets a `### Docs` subsection summarizing the above.

Per-language naming convention:

| Audience | Originator | Arduino contributor |
|---|---|---|
| `README.md` (EN) | "Shinya Ishikawa" | "Takao Akaki / mongonta0716" |
| `README.ja.md` (JA) | "ししかわ／石川真也" | "タカオ さん／mongonta0716" |

Code-internal `mongonta0716/stackchan-arduino` references in `firmware/main/boards/stackchan/stackchan.cc` (L779 / L2614) and the prior `CHANGELOG.md` entry at L208 are unchanged: they credit the actual implementation source the firmware draws timing from, and the org-URL equivalent is now reachable via the README "Related projects" entry above. An opportunistic in-code URL refresh can be done in a separate task if desired.

References:
- Upstream BibTeX citation in `stack-chan/stack-chan`: "Shinya Ishikawa and the Stack-chan community"
- `stack-chan` org profile contact: `ishikawa.s.1027@gmail.com`
- PR TIMES article confirming originator, 2021 release, and registered-trademark status: https://prtimes.jp/main/html/rd/p/000000244.000064534.html

## Test plan

### Code-level

- [ ] gateway: `uv run pytest`
- [ ] gateway: `uv run ruff check .`
- [ ] firmware: `python ./scripts/release.py stackchan`
- [x] Not applicable / not run: docs-only diff (README.md / README.ja.md / CHANGELOG.md); pre-PR `codex review --base main` reported clean with no material findings ("README/README.ja と CHANGELOG の文書更新のみで、既存のビルドや実行経路に影響する問題は見当たりませんでした。リンクや日英同期の範囲も差分内では整合しています。")

### Hardware

- [ ] Device boots without crash
- [ ] Existing MCP tools still work where affected: `move_head`, `take_photo`, `set_volume`, `get_head_angles`
- [ ] Existing touch/servo behavior still works where affected: tap, stroke, wobble
- [ ] New behavior verified on real hardware: <!-- details -->
- [x] Not applicable / hardware not available: docs-only diff, no firmware or gateway code paths touched.

## Breaking changes

None. Documentation and attribution wording only; no API / NVS schema / build flag changes.

## Related issues

Closes #184.
