### PR TITLE
fix(firmware/wifi): retry first-attempt association failure with delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ documented-only.
   element-type-aware constructor. Contributed via
   [PR #195](https://github.com/kisaragi-mochi/stackchan-mcp/pull/195).
 
+- Fixed: WiFi association now retries with a brief delay and cancels
+  the in-flight `esp_wifi_connect()` on attempt timeout (via
+  `esp_wifi_disconnect()` on the `bits == 0` path), so access points
+  that respond slowly or drop the first 802.11 Association Comeback
+  frame no longer cause the device to fail WiFi at boot. The retry
+  log message also distinguishes timeout vs. driver-reported failure
+  to ease real slow-AP debugging. Contributed via
+  [PR #186](https://github.com/kisaragi-mochi/stackchan-mcp/pull/186).
+
 ### Gateway
 
 - Added: MCP tool surface for the firmware-side Grove Port A generic

--- a/firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc
+++ b/firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc
@@ -948,9 +948,22 @@ bool WifiConfigurationAp::ConnectToWifi(const std::string &ssid, const std::stri
         if (bits & WIFI_CONNECTED_BIT) {
             connected = true;
         } else {
+            const bool timed_out = (bits == 0);
+            if (timed_out) {
+                // Timeout — neither WIFI_CONNECTED_BIT nor WIFI_FAIL_BIT
+                // was set, so WIFI_EVENT_STA_DISCONNECTED has not fired
+                // and the driver may still be in `connecting` state.
+                // Cancel the in-flight attempt explicitly before the
+                // retry delay; without this the next esp_wifi_connect()
+                // can return ESP_ERR_WIFI_STATE on a connecting-state
+                // driver (per esp_wifi.h attention 3), making the retry
+                // a no-op on slow / event-dropping APs.
+                esp_wifi_disconnect();
+            }
             ESP_LOGW(TAG,
-                "Attempt %d/%d failed%s",
+                "Attempt %d/%d %s%s",
                 attempt, kMaxAttempts,
+                timed_out ? "timed out (driver may still be connecting)" : "failed",
                 attempt < kMaxAttempts ? " — will retry" : "");
         }
     }

--- a/firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc
+++ b/firmware/components/78__esp-wifi-connect/wifi_configuration_ap.cc
@@ -871,45 +871,99 @@ bool WifiConfigurationAp::ConnectToWifi(const std::string &ssid, const std::stri
     }
     
     is_connecting_ = true;
-    esp_wifi_scan_stop();
-    xEventGroupClearBits(event_group_, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
 
-    wifi_config_t wifi_config;
-    bzero(&wifi_config, sizeof(wifi_config));
-    strlcpy((char *)wifi_config.sta.ssid, ssid.c_str(), 32);
-    strlcpy((char *)wifi_config.sta.password, password.c_str(), 64);
-    wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
-    wifi_config.sta.failure_retry_cnt = 1;
-    
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
-    auto ret = esp_wifi_connect();
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to connect to WiFi: %d", ret);
-        is_connecting_ = false;
-        return false;
-    }
-    ESP_LOGI(TAG, "Connecting to WiFi %s", ssid.c_str());
+    // Upper-level retry loop with delay between attempts.
+    //
+    // Background: in APSTA mode the captive-portal session is on the AP
+    // beacon channel (typically 1), and the target home AP is on some
+    // other channel (e.g. 10). When ConnectToWifi triggers, esp-wifi
+    // performs a Channel Switch Announcement to move both AP and STA to
+    // the home AP's channel, then immediately issues an association
+    // request. The home AP frequently responds with "Association
+    // Response status=30 (Refused Temporarily)" + a Comeback Time in
+    // TUs (= ~1.1s for Buffalo routers, observed) because its own
+    // state hasn't settled yet for the new station.
+    //
+    // The ESP-IDF wifi driver's failure_retry_cnt issues re-association
+    // attempts back-to-back (within a few ms) and does not honor the
+    // 802.11 Comeback Time, so every driver-internal retry is refused
+    // the same way and the first ConnectToWifi() call returns failure.
+    // By the time the user clicks "submit" a second time (~8s later)
+    // the AP has fully settled and association succeeds on the first
+    // try — which is why users observe "it always fails the first
+    // time, then works".
+    //
+    // Fix: when an attempt fails, wait long enough for the comeback
+    // timer + AP state settle (~3s is safe), then retry once. This
+    // produces a single user-visible success path instead of forcing
+    // the user to resubmit. The driver-internal retries (set below
+    // via failure_retry_cnt) are kept as a secondary safety net.
+    constexpr int kMaxAttempts = 2;
+    constexpr int kRetryDelayMs = 3000;
+    bool connected = false;
 
-    // Wait for the connection to complete for 10 or 25 seconds
-    EventBits_t bits = xEventGroupWaitBits(
-        event_group_,
-        WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-        pdTRUE,
-        pdFALSE,
+    for (int attempt = 1; attempt <= kMaxAttempts && !connected; ++attempt) {
+        if (attempt > 1) {
+            ESP_LOGI(TAG,
+                "WiFi attempt %d/%d after %d ms delay "
+                "(waiting for AP comeback timer + state settle)",
+                attempt, kMaxAttempts, kRetryDelayMs);
+            vTaskDelay(pdMS_TO_TICKS(kRetryDelayMs));
+        }
+
+        xEventGroupClearBits(event_group_, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
+        esp_wifi_scan_stop();
+
+        wifi_config_t wifi_config;
+        bzero(&wifi_config, sizeof(wifi_config));
+        strlcpy((char *)wifi_config.sta.ssid, ssid.c_str(), 32);
+        strlcpy((char *)wifi_config.sta.password, password.c_str(), 64);
+        wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+        wifi_config.sta.failure_retry_cnt = 1;
+
+        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+        auto ret = esp_wifi_connect();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG,
+                "esp_wifi_connect failed: %d (attempt %d/%d)",
+                ret, attempt, kMaxAttempts);
+            continue;
+        }
+        ESP_LOGI(TAG, "Connecting to WiFi %s (attempt %d/%d)",
+            ssid.c_str(), attempt, kMaxAttempts);
+
+        // Wait for the connection to complete for 10 or 25 seconds.
+        EventBits_t bits = xEventGroupWaitBits(
+            event_group_,
+            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+            pdTRUE,
+            pdFALSE,
 #ifdef CONFIG_SOC_WIFI_SUPPORT_5G
-        pdMS_TO_TICKS(25000)
+            pdMS_TO_TICKS(25000)
 #else
-        pdMS_TO_TICKS(10000)
+            pdMS_TO_TICKS(10000)
 #endif
-    );
+        );
+
+        if (bits & WIFI_CONNECTED_BIT) {
+            connected = true;
+        } else {
+            ESP_LOGW(TAG,
+                "Attempt %d/%d failed%s",
+                attempt, kMaxAttempts,
+                attempt < kMaxAttempts ? " — will retry" : "");
+        }
+    }
     is_connecting_ = false;
 
-    if (bits & WIFI_CONNECTED_BIT) {
+    if (connected) {
         ESP_LOGI(TAG, "Connected to WiFi %s", ssid.c_str());
         esp_wifi_disconnect();
         return true;
     } else {
-        ESP_LOGE(TAG, "Failed to connect to WiFi %s", ssid.c_str());
+        ESP_LOGE(TAG,
+            "Failed to connect to WiFi %s after %d attempts",
+            ssid.c_str(), kMaxAttempts);
         return false;
     }
 }


### PR DESCRIPTION
## Symptom

When a user runs through the captive-portal Wi-Fi setup, the first
submission of SSID/Password always fails. Submitting the **same**
credentials a second time (~8s later) succeeds. This makes the setup
UX confusing — users frequently think they typed something wrong.

## Root cause

In APSTA mode the captive-portal session is on the AP beacon channel
(typically 1), and the target home AP is on a different channel
(e.g. 10 in my test environment). When `ConnectToWifi` triggers,
esp-wifi performs a Channel Switch Announcement to move both AP and
STA to the home AP's channel, then immediately issues an association
request.

The home AP responds with "Association Response status=30 (Refused
Temporarily)" plus a Comeback Time (observed ~1.1s on a Buffalo
router) because its own state hasn't settled for the new station.

The ESP-IDF wifi driver's `failure_retry_cnt` issues re-association
attempts back-to-back (within a few ms) and does **not** honor the
802.11 Comeback Time, so every driver-internal retry is refused the
same way and the first `ConnectToWifi()` call returns failure. By the
time the user clicks "submit" a second time (~8s later) the AP has
fully settled and association succeeds on the first try — which is
why users observe "it always fails the first time, then works".

## Fix

Add an upper-level retry loop in `ConnectToWifi` with a 3-second delay
between attempts. When an attempt fails, wait long enough for the
comeback timer + AP state to settle, then retry once. This produces a
single user-visible success path instead of forcing the user to
resubmit.

The driver-internal `failure_retry_cnt` is kept at its default 1; the
retry logic lives in the upper layer where the delay is easy to
express.

## Verification

Tested on M5Stack CoreS3 (stackchan board) against a Buffalo
Buffalo-G-E640 router (WPA2-PSK, channel 10).

**Before** (first attempt fails, user has to resubmit):

    Connecting to WiFi Buffalo-G-E640
    wifi: Association refused temporarily, comeback time 1124 TUs
    wifi: Association refused too many times, max allowed 1
    Failed to connect to WiFi Buffalo-G-E640
    [user has to resubmit, ~8s later succeeds]

**After** (single user-visible success after ~7s):

    Connecting to WiFi Buffalo-G-E640 (attempt 1/2)
    wifi: Association refused temporarily, comeback time 1124 TUs
    Attempt 1/2 failed — will retry
    WiFi attempt 2/2 after 3000 ms delay
    Connecting to WiFi Buffalo-G-E640 (attempt 2/2)
    Connected to WiFi Buffalo-G-E640

## Limitations

- Observed on a Buffalo router only; the underlying 802.11 spec
  allows any compliant router to defer association similarly
  (especially with MFP / 802.11w enabled), so the fix should help
  broadly but has only been verified against this one AP model.
- Environments where the first attempt already succeeds are
  unaffected (the retry loop is not entered).
- ``kMaxAttempts`` is set to 2 (= one retry); empirically the second
  attempt always succeeds on the test environment. Could be raised
  later if reports show single retry is insufficient on other routers.

## Test plan

- [x] Build + flash on M5Stack CoreS3 stackchan board
- [x] NVS reset → captive portal → first submission succeeds
- [ ] Verify on other router models (left to maintainer / community)