### PR TITLE
fix(firmware): #187 session_id-based gating for tts/listen messages

### DIFF
--- a/firmware/docs/websocket.md
+++ b/firmware/docs/websocket.md
@@ -43,7 +43,7 @@ This document describes the WebSocket communication protocol between the device 
 
 4. **Server replies with "hello"**
    - The device waits for a JSON message whose `"type"` is `"hello"` and whose `"transport"` is `"websocket"`.
-   - The server may include a `session_id`; the device will store it.
+   - The server **must** include a non-empty string `session_id`; the device stores it and uses it to validate subsequent `tts.*` / `listen.*` messages. A hello without a valid `session_id` is rejected and the device falls back to the next candidate URL (or surfaces a connection failure when no candidates remain).
    - Example:
    ```json
    {
@@ -232,9 +232,9 @@ WebSocket text frames carry JSON. The most common `"type"` values and their sema
 1. **Hello**
    - The handshake acknowledgement.
    - Must include `"type": "hello"` and `"transport": "websocket"`.
+   - Must include a non-empty string `session_id` which the device records; subsequent `tts.*` / `listen.*` messages must echo the same value to pass the firmware's session-match gate.
    - May include `audio_params`, meaning the audio parameters the server expects / the canonical set agreed with the device.
-   - May include a `session_id` which the device records.
-   - Once received, the device sets the "audio channel open" event.
+   - Once received (and `session_id` validated), the device sets the "audio channel open" event.
 
 2. **STT**
    - `{"session_id": "xxx", "type": "stt", "text": "..."}`

--- a/firmware/docs/websocket_zh.md
+++ b/firmware/docs/websocket_zh.md
@@ -42,7 +42,7 @@
 
 4. **服务器回复 "hello"**  
    - 设备等待服务器返回一条包含 `"type": "hello"` 的 JSON 消息，并检查 `"transport": "websocket"` 是否匹配。  
-   - 服务器可选下发 `session_id` 字段，设备端收到后会自动记录。  
+   - 服务器**必须**下发非空字符串 `session_id` 字段，设备端会记录并用于后续 `tts.*` / `listen.*` 消息的会话匹配校验。缺失、空或非字符串的 `session_id` 会导致设备拒绝该握手并回退到下一个候选 URL（或在候选用尽时上报连接失败）。  
    - 示例：
    ```json
    {
@@ -221,9 +221,9 @@ WebSocket 文本帧以 JSON 方式传输，以下为常见的 `"type"` 字段及
 1. **Hello**  
    - 服务器端返回的握手确认消息。  
    - 必须包含 `"type": "hello"` 和 `"transport": "websocket"`。  
+   - 必须包含非空字符串 `session_id` 字段，设备端会记录；后续的 `tts.*` / `listen.*` 消息必须携带相同的 `session_id` 才能通过固件侧的会话匹配校验。  
    - 可能会带有 `audio_params`，表示服务器期望的音频参数，或与设备端对齐的配置。   
-   - 服务器可选下发 `session_id` 字段，设备端收到后会自动记录。  
-   - 成功接收后设备端会设置事件标志，表示 WebSocket 通道就绪。
+   - 成功接收（且 `session_id` 通过校验）后设备端会设置事件标志，表示 WebSocket 通道就绪。
 
 2. **STT**  
    - `{"session_id": "xxx", "type": "stt", "text": "..."}`

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -161,6 +161,7 @@ void WebsocketProtocol::CloseAudioChannel(bool send_goodbye) {
     // the app transitions back to idle while the WebSocket stays connected
     // for continued MCP control.
     audio_channel_open_.store(false);
+    // Keep session_id_ across a logical audio-session close; it belongs to the WebSocket connection lifetime.
     ESP_LOGI(TAG, "CloseAudioChannel: keeping WebSocket alive for MCP");
     if (on_audio_channel_closed_ != nullptr) {
         on_audio_channel_closed_();
@@ -185,6 +186,11 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
     }
     StopReconnectTimer();
     websocket_.reset();
+    // Clear session_id_ at the start of a fresh socket attempt so a
+    // malformed or version-skewed server hello cannot leave the previous
+    // connection's id active as the tts/listen gate key. CloseAudioChannel
+    // intentionally keeps session_id_ alive across a logical audio-session
+    // close while the WebSocket stays connected.
     session_id_ = "";
     xEventGroupClearBits(event_group_handle_, WEBSOCKET_PROTOCOL_SERVER_HELLO_EVENT);
 
@@ -313,10 +319,10 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
 
         websocket_->OnData([this, notify_disconnect, arm_audio_channel](const char* data, size_t len, bool binary) {
             if (binary) {
-                // Drop inbound audio when the audio channel is logically
-                // closed. Without this guard, a late TTS frame from the
-                // previous session could resurrect kDeviceStateSpeaking.
-                if (!audio_channel_open_.load()) {
+                // Drop binary frames before parsing when the device is not
+                // speaking. This mirrors Application::OnIncomingAudio's
+                // downstream gate while avoiding stale-frame parse/allocation.
+                if (Application::GetInstance().GetDeviceState() != kDeviceStateSpeaking) {
                     return;
                 }
                 if (on_incoming_audio_ != nullptr) {
@@ -360,14 +366,22 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
                 if (cJSON_IsString(type)) {
                     if (strcmp(type->valuestring, "hello") == 0) {
                         ParseServerHello(root, notify_disconnect, arm_audio_channel);
-                    } else if (!audio_channel_open_.load() &&
-                               (strcmp(type->valuestring, "tts") == 0 ||
-                                strcmp(type->valuestring, "listen") == 0)) {
-                        // Drop audio-session JSON (tts.*, listen.*) when
-                        // the channel is logically closed. A late tts.start
-                        // from the previous session would otherwise
-                        // schedule kDeviceStateSpeaking against intent.
-                        ESP_LOGD(TAG, "Dropping %s message (audio channel closed)", type->valuestring);
+                    } else if (strcmp(type->valuestring, "tts") == 0 ||
+                               strcmp(type->valuestring, "listen") == 0) {
+                        // Drop tts/listen messages whose session_id does not
+                        // match the current WebSocket session set by
+                        // ParseServerHello, while allowing the gateway's
+                        // current-session control messages through.
+                        auto session_id_obj = cJSON_GetObjectItem(root, "session_id");
+                        const char* incoming_sid = cJSON_IsString(session_id_obj) ? session_id_obj->valuestring : nullptr;
+                        bool session_match = incoming_sid != nullptr &&
+                                             !session_id_.empty() &&
+                                             strcmp(session_id_.c_str(), incoming_sid) == 0;
+                        if (!session_match) {
+                            ESP_LOGD(TAG, "Dropping %s message (session_id mismatch or missing)", type->valuestring);
+                        } else if (on_incoming_json_ != nullptr) {
+                            on_incoming_json_(root);
+                        }
                     } else {
                         if (on_incoming_json_ != nullptr) {
                             on_incoming_json_(root);
@@ -542,10 +556,21 @@ void WebsocketProtocol::ParseServerHello(const cJSON* root,
     }
 
     auto session_id = cJSON_GetObjectItem(root, "session_id");
-    if (cJSON_IsString(session_id)) {
-        session_id_ = session_id->valuestring;
-        ESP_LOGI(TAG, "Session ID: %s", session_id_.c_str());
+    if (!cJSON_IsString(session_id) ||
+        session_id->valuestring == nullptr ||
+        session_id->valuestring[0] == '\0') {
+        // session_id is the gate key for tts/listen messages (#187). A
+        // missing or empty session_id at hello time would leave session_id_
+        // empty after this PR's OpenAudioChannelInternal clear, causing
+        // every gateway-driven tts/listen to mismatch and silently drop.
+        // Reject the hello here so the candidate loop's xEventGroupWaitBits
+        // times out and the next candidate (or a failure) is surfaced
+        // instead of an unusable connection.
+        ESP_LOGE(TAG, "Server hello missing or empty session_id; rejecting candidate");
+        return;
     }
+    session_id_ = session_id->valuestring;
+    ESP_LOGI(TAG, "Session ID: %s", session_id_.c_str());
 
     auto audio_params = cJSON_GetObjectItem(root, "audio_params");
     if (cJSON_IsObject(audio_params)) {


### PR DESCRIPTION
## Summary

Companion fix to #136 (merged as `41a22d2`). #136 keeps the WebSocket alive across `CloseAudioChannel()` so MCP control survives an audio-session close. However, the drop logic introduced in #136 (`firmware/main/protocols/websocket_protocol.cc:363-370`) discarded all inbound `tts.*` / `listen.*` JSON messages whenever `audio_channel_open_=false`, which silently broke the gateway's `say()` and `listen()` MCP tools — they send `{"type":"tts","state":"start"}` / `{"type":"listen","state":"start"}` over the same WebSocket to drive the firmware state machine.

This PR replaces the binary `audio_channel_open_` predicate with a session_id-based gate: gateway-current-session messages pass through, stale (mismatched session_id) messages are still dropped.

Closes #187.

## Why session_id-based gating

The gateway already generates a per-connection UUID-based `session_id` and echoes it in every `tts.*` / `listen.*` message (`gateway/stackchan_mcp/esp32_client.py:419, 237, 262`). The firmware already tracks `session_id_` per WebSocket handshake (`firmware/main/protocols/websocket_protocol.cc` via `ParseServerHello`). The fix validates these against each other on the inbound side, which:

- **Preserves the original stale-frame protection from #136**: a `tts.start` carrying a different session_id (a previous WebSocket session) is still dropped.
- **Allows the gateway-driven audio control path to flow through**: current-session `tts.start` / `listen.start` reach the firmware state machine, so `say()` and `listen()` MCP tools work after a user-initiated `CloseAudioChannel()`.
- **Confined to one file** plus public docs alignment.

## Changes

`firmware/main/protocols/websocket_protocol.cc`:

- **`CloseAudioChannel`**: retain `session_id_` across the close. The session_id is owned by the WebSocket connection lifetime, not the audio-session lifetime — the gateway echoes the same UUID across its full connection, and `ParseServerHello` overwrites `session_id_` on reconnect or a fresh hello exchange.
- **`OpenAudioChannelInternal`**: clear `session_id_` at the start of a fresh socket attempt so a malformed or version-skewed server hello cannot leave the previous connection's id active as the tts/listen gate key.
- **`ParseServerHello`**: require a non-empty string `session_id` in the server hello. A missing, empty, or non-string `session_id` is rejected (no event bit, no `notify_disconnect` arm) so the candidate loop falls back to the next URL or surfaces failure.
- **`OnData` JSON branch**: replace the `audio_channel_open_`-based drop predicate with a `session_id` mismatch check. Current-session messages pass through; missing / mismatched session_id messages are still logged and dropped.
- **`OnData` binary branch**: replace the `audio_channel_open_` guard with an early `kDeviceStateSpeaking` gate via `Application::GetInstance().GetDeviceState()`. Avoids BinaryProtocol2/3 header parsing and AudioStreamPacket payload allocation on the closed-channel path.

`firmware/docs/websocket.md`, `firmware/docs/websocket_zh.md`:

- Tighten the public WebSocket protocol contract: `session_id` in the server hello is now documented as a **required non-empty string** (previously documented as optional), matching the new firmware-side enforcement above.

## Known limitations (carved-out follow-ups)

These were surfaced during five rounds of Codex adversarial review on this PR. They do not block #187 and are tracked separately:

- **#190 — Same-session delayed `tts.start` after `CloseAudioChannel`** (low real-world probability, recoverable). A `tts.start` already in flight from the gateway when the user closes the audio channel will pass the session_id gate. Resolving this requires an **audio-operation-level identifier** (separate from the WebSocket session_id) so the firmware can distinguish "current audio operation" from "stale audio operation within the same WebSocket session". Two design options proposed in the Issue.
- **#191 — Invalid server hello burns the full 10s candidate timeout before fallback** (low real-world probability, ~10s startup delay only). The `ParseServerHello` rejection returns early without setting the event bit, so the candidate loop waits the full timeout before treating the candidate as failed. The canonical `stackchan-mcp` gateway always sends a valid `session_id`, so this only surfaces with legacy / malformed gateways. Fix direction: dedicated `SERVER_HELLO_FAILED` event bit for fail-fast paths.

## Compatibility with #136

This PR replaces the gate introduced in #136 with the session_id-based gate. It is intended to land soon after #136 (which has just merged as `41a22d2`) to restore gateway-driven `say()` / `listen()` semantics.

## Validation

- **Build**: confirmed via `python ./scripts/release.py stackchan` (Docker `espressif/idf:v5.5.2`). Artifacts produced: `build/xiaozhi.bin`, `build/merged-binary.bin`, `releases/v2.2.6_stackchan.zip`.
- **Gateway tests**: `cd gateway && uv run pytest` — all existing tests pass (255 passed, 1 skipped). Gateway-side behaviour is unchanged.
- **Code review**: five rounds of Codex adversarial-review run before opening this PR. Findings addressed in-PR:
  - **Finding 2 (Round 1)** — binary frames parsed before drop, potential out-of-bounds via untrusted `payload_size`. Addressed: early `kDeviceStateSpeaking` gate replaces the `audio_channel_open_` guard.
  - **Finding 3 (Round 1)** — malformed server hello leaves stale `session_id` active. Addressed: `OpenAudioChannelInternal` clears `session_id_` at fresh-socket-attempt time; `ParseServerHello` requires non-empty `session_id`.
  - **Finding 4 (Round 4)** — public docs contract stale. Addressed: `websocket.md` / `websocket_zh.md` updated to require non-empty `session_id`.
  - **Finding 1 (Round 1)** carved out to **#190**.
  - **Finding 5 (Round 5)** carved out to **#191**.

## Test plan (real-device, post-merge)

Pending real-device confirmation on M5Stack CoreS3 stackchan board:

- [ ] After user touch closes the audio channel (`audio_channel_open_=false`, WS alive per #136), `gateway say("hello")` produces audible output on the device.
- [ ] After the same close, `gateway listen()` captures audio from the device microphone.
- [ ] Injecting a `tts.start` with a mismatched `session_id` (e.g. from a stale separate connection) is still dropped — verified via firmware serial log (`Dropping tts message (session_id mismatch or missing)`).
- [ ] `CanEnterSleepMode()` continues to return false when audio session is open and true when closed — `audio_channel_open_` semantic preserved (this PR does not touch the flag itself).

## Refs

- Closes #187
- Companion to #136 (merged as `41a22d2`)
- Carved-out follow-ups: #190 (audio-operation-level identifier), #191 (fail-fast on invalid hello)
- Related lifecycle Issues (race conditions, low real-world probability, independent of #187): #188 (stale disconnect callback), #189 (hello-then-disconnect timer cancel)
