### PR TITLE
fix(firmware): #169 persistent WebSocket connect on boot + sleep policy

### DIFF
--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -1094,6 +1094,18 @@ bool Application::CanEnterSleepMode() {
         return false;
     }
 
+    // Block sleep while the MCP control transport (e.g. WebSocket) is alive.
+    // After PR #169 the WebSocket is established at boot for persistent MCP
+    // control, decoupled from any audio session — without this check the
+    // legacy PowerSaveTimer would still trip after ~60 s of idle even
+    // though MCP tools remain in use, dropping the transport and forcing a
+    // touch / wake to recover. Subclasses that lack a persistent transport
+    // notion inherit the default `return false;` from Protocol so existing
+    // behavior is unchanged for them.
+    if (protocol_ && protocol_->IsTransportConnected()) {
+        return false;
+    }
+
     if (!audio_service_.IsIdle()) {
         return false;
     }

--- a/firmware/main/protocols/protocol.h
+++ b/firmware/main/protocols/protocol.h
@@ -67,6 +67,14 @@ public:
     virtual bool OpenAudioChannel() = 0;
     virtual void CloseAudioChannel(bool send_goodbye = true) = 0;
     virtual bool IsAudioChannelOpened() const = 0;
+    // Physical transport-level connection state, independent of the logical
+    // audio-session state reported by IsAudioChannelOpened(). For transports
+    // that maintain a persistent connection (e.g. WebSocket kept alive for
+    // MCP control after PR #136 / #169), this lets the application keep the
+    // power-save / sleep timer disengaged while the transport is live even
+    // when no audio session is currently armed. Default false so subclasses
+    // that lack a persistent-transport notion are unaffected.
+    virtual bool IsTransportConnected() const { return false; }
     virtual bool SendAudio(std::unique_ptr<AudioStreamPacket> packet) = 0;
     virtual void SendWakeWordDetected(const std::string& wake_word);
     virtual void SendStartListening(ListeningMode mode);

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -61,8 +61,14 @@ WebsocketProtocol::WebsocketProtocol() {
 
                 ESP_LOGI(TAG, "Reconnecting to websocket server");
                 if (!protocol->OpenAudioChannelInternal(false, false)) {
-                    ESP_LOGW(TAG, "Reconnect attempt failed; rescheduling");
-                    protocol->ScheduleReconnect();
+                    // OpenAudioChannelInternal's failure-exit path is now
+                    // the single source of reconnect-rescheduling. Calling
+                    // ScheduleReconnect() here too would double-advance
+                    // reconnect_interval_ms_ (two consecutive
+                    // StopReconnectTimer → start_once cycles per failed
+                    // retry), driving the backoff to its 60s cap faster
+                    // than intended.
+                    ESP_LOGW(TAG, "Reconnect attempt failed; OpenAudioChannelInternal will arm next retry");
                 }
             });
         },
@@ -77,6 +83,7 @@ WebsocketProtocol::WebsocketProtocol() {
 WebsocketProtocol::~WebsocketProtocol() {
     alive_->store(false);
     intentional_close_.store(true);
+    transport_connected_.store(false);
     if (current_notify_disconnect_) {
         current_notify_disconnect_->store(false);
     }
@@ -92,8 +99,20 @@ WebsocketProtocol::~WebsocketProtocol() {
 }
 
 bool WebsocketProtocol::Start() {
-    // Only connect to server when audio channel is needed
-    return true;
+    // Connect to the configured gateway at boot so MCP control is
+    // available before any user interaction (no touch / wake required).
+    // arm_audio_channel=false keeps the logical audio-session state
+    // separate from the physical WebSocket transport state — see PR #136
+    // (CloseAudioChannel keeps the WS alive) and PR #192 (audio_channel_open_
+    // is a logical-session flag, see websocket_protocol.h:60-67).
+    //
+    // If the gateway is unreachable at boot (gateway not started, network
+    // not yet stable, token mismatch, etc.), OpenAudioChannelInternal
+    // returns false with report_error=false suppressing UI feedback, and
+    // arms the reconnect timer via its failure-exit path so the device
+    // retries automatically once the gateway becomes reachable.
+    // Closes #169.
+    return OpenAudioChannelInternal(false, false);
 }
 
 bool WebsocketProtocol::SendAudio(std::unique_ptr<AudioStreamPacket> packet) {
@@ -146,6 +165,18 @@ bool WebsocketProtocol::IsAudioChannelOpened() const {
     return audio_channel_open_.load() && websocket_ != nullptr && websocket_->IsConnected() && !error_occurred_ && !IsTimeout();
 }
 
+bool WebsocketProtocol::IsTransportConnected() const {
+    // Returns the cached atomic transport-state flag, which is updated on the
+    // WS task (OnDisconnected) and the main task (OpenAudioChannelInternal
+    // prologue + success exit, destructor). Read from ESP_TIMER_TASK via
+    // Application::CanEnterSleepMode(), so this read must not racily
+    // dereference websocket_ while main-task code is calling websocket_.reset().
+    // The flag also intentionally ignores Protocol::IsTimeout(), which tracks
+    // the audio-session inbound-frame deadline — an idle persistent MCP
+    // connection has no inbound audio frames but is still healthy transport.
+    return transport_connected_.load();
+}
+
 void WebsocketProtocol::CloseAudioChannel(bool send_goodbye) {
     (void)send_goodbye;
     // Keep WebSocket alive — only notify the application that the audio
@@ -180,6 +211,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
     // new socket below installs a fresh token of its own and clears
     // intentional_close_ once the server hello has been acked.
     audio_channel_open_.store(false);
+    transport_connected_.store(false);
     intentional_close_.store(true);
     if (current_notify_disconnect_) {
         current_notify_disconnect_->store(false);
@@ -397,6 +429,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
 
         websocket_->OnDisconnected([this, notify_disconnect]() {
             audio_channel_open_.store(false);
+            transport_connected_.store(false);
             // notify_disconnect carries this socket's reconnect intent.
             // ParseServerHello() arms it (true) once the handshake
             // completes; intentional teardown paths (CloseAudioChannel,
@@ -454,6 +487,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
         // synchronously when intentionally tearing this socket down.
         current_notify_disconnect_ = notify_disconnect;
         intentional_close_.store(false);
+        transport_connected_.store(true);
         reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
         StopReconnectTimer();
 
@@ -477,6 +511,14 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             SetError(Lang::Strings::SERVER_NOT_CONNECTED);
         }
     }
+    // Clear the intentional_close_ latch (set in the prologue at line ~183)
+    // on the failure exit path so ScheduleReconnect can arm a retry.
+    // Without this, any subsequent reconnect attempt — including the
+    // timer-driven retry the constructor's lambda installs below on
+    // recursive failure — would be silently refused because
+    // intentional_close_ remained latched at true.
+    intentional_close_.store(false);
+    ScheduleReconnect();
     return false;
 }
 

--- a/firmware/main/protocols/websocket_protocol.h
+++ b/firmware/main/protocols/websocket_protocol.h
@@ -26,6 +26,7 @@ public:
     bool OpenAudioChannel() override;
     void CloseAudioChannel(bool send_goodbye = true) override;
     bool IsAudioChannelOpened() const override;
+    bool IsTransportConnected() const override;
 
 private:
     std::shared_ptr<std::atomic<bool>> alive_ = std::make_shared<std::atomic<bool>>(true);
@@ -65,6 +66,13 @@ private:
     // MCP control does not make callers (ToggleChatState,
     // CanEnterSleepMode) believe an audio session is still active.
     std::atomic<bool> audio_channel_open_ = false;
+    // Physical WebSocket transport state, updated on the WS task (OnDisconnected)
+    // and the main task (OpenAudioChannelInternal prologue + success exit +
+    // destructor). IsTransportConnected() returns this flag and is read from
+    // Application::CanEnterSleepMode(), which runs on ESP_TIMER_TASK — atomic
+    // so the timer-task read does not race with main-task websocket_.reset()
+    // in OpenAudioChannelInternal / destructor / reconnect paths.
+    std::atomic<bool> transport_connected_ = false;
     int reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
     int version_ = 1;
 


### PR DESCRIPTION
## Summary

Three coupled firmware-side fixes that together restore the "MCP control works from idle without touch / wake" use case described in #169:

1. **`WebsocketProtocol::Start()`** now connects to the configured gateway at boot with `arm_audio_channel=false`, so MCP tools (`set_avatar`, `set_leds`, `move_head`, etc.) work from idle without requiring a touch or wake-word trigger first.
2. **`OpenAudioChannelInternal()` failure-exit path** now clears `intentional_close_` and arms `ScheduleReconnect()`, so gateway-down boots (and any subsequent failed connect attempts) retry automatically instead of silently latching the device in a no-reconnect state.
3. **`Application::CanEnterSleepMode()`** now also checks `Protocol::IsTransportConnected()` (new virtual, default false), so the legacy 60-second PowerSaveTimer does not deep-sleep the device while the MCP control transport is alive.

Closes #169.

## Background

Three coupled symptoms of the on-demand WebSocket lifecycle:

1. Boot reaches `idle` without connecting to the gateway — `WebsocketProtocol::Start()` was a no-op returning `true`, the NVS URL was only read inside `OpenAudioChannelInternal()` (touch / wake / listening triggers).
2. After connection, an audio-session close (`CloseAudioChannel`) tore down the WebSocket, taking MCP control with it.
3. `audio_channel_open_` doubled as both the physical and logical state predicate.

PR #136 fixed (2) by removing `websocket_.reset()` from `CloseAudioChannel`. PR #192 fixed (3) by adding the `arm_audio_channel` parameter to `OpenAudioChannelInternal` and clarifying `audio_channel_open_` as a logical-session flag. This PR fixes (1) plus two dormant bugs that surfaced during adversarial review and real-device verification.

## Why the minimal "one-line" version wasn't enough

The first cut was a single-line `Start() => OpenAudioChannelInternal(false, false)` change, on the theory that PR #136 + #192 had already established the audio-vs-transport state separation. Three subsequent issues surfaced:

**During adversarial code review:** `OpenAudioChannelInternal`'s prologue (line 183) sets `intentional_close_=true` to suppress spurious reconnect from the previous-socket teardown. The success path (line 467) clears it. The failure-exit path did not — so any boot-time connection failure (gateway not up, network blip, token mismatch) would leave `intentional_close_=true` latched, and `ScheduleReconnect()` would silently refuse to arm. The existing reconnect-timer lambda at line 65 ostensibly called `ScheduleReconnect()` on failed retries, but its own call would have been silently refused too. Dormant before this PR (because `Start()` never called `OpenAudioChannelInternal`), but it would have been load-bearing on the new boot path.

**During real-device verification:** With `arm_audio_channel=false`, `audio_channel_open_` stays false even with the WebSocket alive. The legacy `Application::CanEnterSleepMode()` only checked `IsAudioChannelOpened()` (logical session), so it returned true 60 seconds after boot, the xiaozhi `PowerSaveTimer` tripped, the device entered deep sleep, the USB CDC port dropped, the WebSocket disconnected, and MCP control vanished — requiring a touch / wake to recover. In other words, the original symptom relocated rather than resolved.

The pre-PR behavior accidentally avoided this because the touch / wake that triggered audio session also reset the PowerSaveTimer's user-activity gate; decoupling the WS from user activity (which is the whole point of this PR) exposed the dormant gap.

**During a follow-up adversarial review on the sleep policy fix:** A naive `IsTransportConnected()` that read `websocket_ != nullptr && websocket_->IsConnected() && !IsTimeout()` had two issues. (1) `Application::CanEnterSleepMode()` is called from `ESP_TIMER_TASK`, so reading `websocket_` directly on that path races with `websocket_.reset()` on the main task (`OpenAudioChannelInternal` prologue, destructor, reconnect) — an unsynchronized read/free with use-after-free potential. (2) `Protocol::IsTimeout()` tracks the audio-session inbound-frame deadline (`last_incoming_time_` from `OnData`), so an idle persistent MCP connection with no inbound audio frames would be incorrectly seen as a timed-out transport after 120 s, re-introducing the sleep regression. Switched the predicate to a `std::atomic<bool> transport_connected_` flag updated at server-hello success / disconnect / prologue / destructor.

## Changes

`firmware/main/protocols/websocket_protocol.cc`:

- **`Start()`** (line 94-108): now calls `OpenAudioChannelInternal(false, false)`:
  - `report_error=false` — boot-time connect failure is not surfaced as a user-facing UI error.
  - `arm_audio_channel=false` — logical audio-session state stays decoupled from the physical WebSocket transport, preserving the invariant documented at `websocket_protocol.h:60-67`.
- **`OpenAudioChannelInternal()` failure-exit** (line 491-499): now clears `intentional_close_.store(false)` and calls `ScheduleReconnect()` so the timer-driven retry loop is reachable. Restores the apparent intent of the constructor lambda at line 63-66.
- **Constructor reconnect-timer lambda** (line 62-72): removed the lambda's own `ScheduleReconnect()` call on `OpenAudioChannelInternal` failure. With the failure-exit now arming retry itself, the lambda's call would have double-advanced `reconnect_interval_ms_` (two consecutive `StopReconnectTimer → esp_timer_start_once` cycles per failed retry, each doubling the interval), driving the 60 s backoff cap faster than intended.
- **`IsTransportConnected()`** (new): returns the cached `transport_connected_` atomic flag. Cross-task safe — the `ESP_TIMER_TASK` read from `Application::CanEnterSleepMode()` never dereferences `websocket_` directly, avoiding a use-after-free race with main-task `websocket_.reset()`. Decoupled from `Protocol::IsTimeout()` so an idle persistent MCP connection without inbound audio frames is still seen as alive.
- **`transport_connected_`** (new `std::atomic<bool>` member): physical WS transport state. Set true at the main-task success path right after `intentional_close_.store(false)`. Set false in: (a) the destructor before `websocket_.reset()`; (b) `OpenAudioChannelInternal`'s prologue before `websocket_.reset()`; (c) the per-socket `OnDisconnected` lambda's entry on the WS task (both the legitimate disconnect and the candidate-failure paths).

`firmware/main/protocols/websocket_protocol.h`:

- Adds `bool IsTransportConnected() const override;` declaration.

`firmware/main/protocols/protocol.h`:

- Adds `virtual bool IsTransportConnected() const { return false; }` on the `Protocol` base. Default false so non-WebSocket subclasses (any `MqttProtocol` variant, etc.) inherit conservative behavior unaffected by this PR.

`firmware/main/application.cc`:

- **`CanEnterSleepMode()`**: now also returns false if `protocol_ && protocol_->IsTransportConnected()`. Placed between the existing `IsAudioChannelOpened()` check and the `audio_service_.IsIdle()` check.

## Compatibility / behavior changes

| Path | Pre-PR | Post-PR |
|---|---|---|
| Boot completion → MCP tool call | Requires touch / wake to trigger WS connect | WS connects at boot, MCP available from idle |
| Boot connect failure | Device stranded, no retry until manual reset | Reconnect timer fires every 5 s (initial interval), exponential backoff up to 60 s |
| Idle device with WS alive | Deep-sleeps after 60 s, USB CDC drops, MCP control unrecoverable without touch | Sleep blocked while MCP transport is alive |
| WS disconnected (network drop, gateway down) | Sleep on idle as before | Sleep still permitted (transport not alive → CanEnterSleepMode returns true via the new check returning to its prior path) |
| `CloseAudioChannel` (PR #136 path) | Unchanged | Unchanged |
| `OpenAudioChannel` (touch / wake) success | Unchanged | Unchanged |
| `OpenAudioChannel` (touch / wake) failure | Device stays at previous state, user must retry | Reconnect timer arms — user gets automatic retry within 5 s |
| Existing reconnect-timer-driven retry success | Unchanged | Unchanged |
| Existing reconnect-timer-driven retry failure | Silently stops retrying after 1 failed attempt (dormant bug) | Continues retrying with proper single-stage backoff |
| Force-mode `sdkconfig.defaults.local` override | Read inside `OpenAudioChannelInternal`, works automatically | Same — works at boot too |
| Other Protocol subclasses (any future `MqttProtocol`, etc.) | N/A | Inherit `IsTransportConnected()=false`, sleep behavior unchanged |

The touch/wake-failure behavior change (automatic retry replaces silent dead state) is UX-improving but technically a behavior change. The never-sleep behavior change (WS alive → no PowerSave) is intentional for the stackchan-mcp MCP-server use case (AC-powered, persistent MCP control expected); users on battery can still disable it via `Settings::wifi::sleep_mode` (existing `PowerSaveTimer::SetEnabled` gate, unchanged).

## Real-device validation (performed)

Tested on M5Stack CoreS3 stackchan board against the local gateway via Tailscale Funnel:

- ✅ **Cold boot → idle MCP**: power-cycled, `xiaozhi.bin` flashed to `0x20000`, hard-reset via esptool RTS pin. Boot log captured the new path:
  ```
  I (12715) WS: Session ID: c5dc67c4-1f0b-4db3-a20c-6f9577e171aa
  I (12715) WS: Connected to websocket server candidate 1/1: wss://<gateway>/
  I (12715) Application: Activation done
  I (12725) StateMachine: State: activating -> idle
  ```
  `Connected to websocket server` arrives before `Activation done` — Start() now establishes the transport synchronously during InitializeProtocol(), exactly as intended.
- ✅ **MCP tool calls from idle without any touch / wake**: `get_status` returned `connected: true` with `tools_count: 21`. `set_avatar(happy)` returned `{"face":"happy","ok":true}`. `move_head(yaw=10, pitch=45)` returned `{"servo_init_ok":true, ..., "yaw_motion_started":1, "pitch_motion_started":1}` — head moved on the real device.
- ✅ **Sleep policy regression check**: With the pre-sleep-fix variant of this PR, the device deep-slept ~60-100 s after boot (USB CDC dropped, `get_status` returned `connected:false`). After adding the `IsTransportConnected()` check in `CanEnterSleepMode()`, this regression is closed in the post-fix variant (real-device confirmation pending re-flash of the final commit).

## Out of scope (separate Issues / PRs)

- **#61** — post-handshake server-side disconnect reconnect; separate code path that this PR does not touch.
- **#77** — avatar auto-show on MCP connection / boot; depends on this PR landing first so a transport-connected event can be hooked, then the xiaozhi default sleep face / status text overlay can be cleanly replaced.
- **#188** / **#189** — race fixes; independent.
- **Future polish**: short-circuit `OpenAudioChannel()` when the WebSocket is already connected and not armed, to avoid the unnecessary re-handshake at touch / wake.

## Acknowledgements

Builds on the foundation laid by @Qizhan7 (PR #136) and the session_id-based gating work (PR #192). External reproduction confirmation by @tjkang on Issue #169.
