### PR TITLE
chore(release): backfill PR #197 entry + uv.lock sync + publish workflow uv lock --check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,17 @@ jobs:
           print("Version policy: OK (pre-release allowed; local version rejected)")
           PY
 
+      - name: Verify gateway/uv.lock is in sync with gateway/pyproject.toml
+        # Catches the failure mode that motivated this step: a release
+        # bump to gateway/pyproject.toml without re-running `uv lock`,
+        # leaving uv.lock pinned at the previous version. `uv sync
+        # --frozen` reads the lock as-is and does not detect this
+        # drift; `uv lock --check` re-resolves and exits non-zero on
+        # any mismatch, blocking the publish job before it produces a
+        # divergent sdist / wheel.
+        working-directory: gateway
+        run: uv lock --check
+
       - name: Install gateway dependencies
         working-directory: gateway
         run: uv sync --frozen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ change is called out under a `Firmware` subsection of the release entry.
 
 ### Firmware
 
+- Fixed: device booted to `idle` without connecting to the gateway,
+  leaving MCP tools (`set_avatar`, `set_leds`, `move_head`, etc.)
+  unreachable until a touch or wake-word trigger first opened an
+  audio session. `WebsocketProtocol::Start()` now connects to the
+  configured gateway at boot via `OpenAudioChannelInternal(report_error=false,
+  arm_audio_channel=false)`, decoupling the physical WebSocket
+  transport from the logical audio-session state introduced in
+  [#192](https://github.com/kisaragi-mochi/stackchan-mcp/pull/192).
+  Two coupled fixes ride along: (a) the `OpenAudioChannelInternal`
+  failure-exit now clears `intentional_close_` and arms
+  `ScheduleReconnect()` so a gateway-down boot (or any subsequent
+  failed retry) continues to retry automatically instead of silently
+  latching into a no-reconnect state — restoring the apparent intent
+  of the constructor's reconnect-timer lambda, whose own redundant
+  `ScheduleReconnect()` call is removed to prevent double-advancing
+  `reconnect_interval_ms_` per failed retry; (b)
+  `Application::CanEnterSleepMode()` now also blocks the legacy
+  60-second `PowerSaveTimer` deep-sleep entry while a new
+  `Protocol::IsTransportConnected()` virtual returns true, closing
+  the regression in which a boot-time WS connect with
+  `arm_audio_channel=false` would still trip the timer because
+  `audio_channel_open_` stays false. The transport-state predicate
+  is backed by a `std::atomic<bool> transport_connected_` flag
+  updated at server-hello success / disconnect / prologue /
+  destructor, avoiding the use-after-free race that would result
+  from reading `websocket_` directly on `ESP_TIMER_TASK`. External
+  reproduction confirmation by @tjkang. Closes
+  [#169](https://github.com/kisaragi-mochi/stackchan-mcp/issues/169).
+
 - Fixed: WebSocket was torn down on every user-initiated
   `CloseAudioChannel()` (touch in listening mode, audio session abort),
   making MCP control surfaces (LEDs, avatar, head movement, etc.)

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2009,7 +2009,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Three release-pipeline backfills + a CI hardening step that together close the gap exposed by PR #183 (v0.8.0 release):

1. **CHANGELOG `[Unreleased]` Firmware**: add a leading entry for PR #197 (#169 persistent WS on boot + sleep policy), which was missed at merge time and would have been silently dropped from the next `firmware-vX.Y.Z` auto-extracted release notes (same failure mode as PR #179 / #180 / #193).
2. **`gateway/uv.lock`**: sync stackchan-mcp inner version `0.7.0` → `0.8.0` to match `gateway/pyproject.toml`. PR #183 advanced pyproject but did not re-run `uv lock`, leaving the lock pinned at `0.7.0` even though v0.8.0 was published.
3. **`.github/workflows/publish.yml`**: add `uv lock --check` as a pre-release step ahead of `uv sync --frozen`. The existing `uv sync --frozen` step reads the lock as-is and does not detect pyproject ↔ uv.lock drift; `uv lock --check` re-resolves and exits non-zero on any divergence, blocking the publish job before it produces a divergent sdist / wheel.

## Why

- The CHANGELOG drift would surface as silently-incomplete release notes; the lock drift would surface as a misleading `git status` on every fresh `uv sync`.
- The `uv lock --check` step is the structural fix that prevents the same backfill pattern from recurring in future gateway releases.

## Validation

- `git diff main..HEAD --stat`: 3 files, +41/-1.
- `uv lock --check` from `gateway/`: local pass (`Resolved 81 packages in 5ms`, exit 0).
- No source code / personal config / IPs / paths in diff.
- Self-check against `git diff main..HEAD` for `Saki|/Users/shou|192\.168|tailb09d4c`: ✅ clean.

## Out of scope

- Whether to add `uv lock --check` to the PR-side `build.yml` as well (earlier detection at PR review time) is a related question worth a follow-up. Release-side is the last-resort gate; PR-side would catch the drift pre-merge.
- The next `firmware-v1.8.0` release decision is a follow-up after this lands.

Refs #169.