### PR TITLE
release(firmware): firmware-v1.8.0 + CHANGELOG restructure + release gate

### DIFF
--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -37,6 +37,76 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
+      - name: Verify CHANGELOG.md has a dated section for the firmware tag
+        # Re-publish gate that closes the documentation debt that the
+        # CHANGELOG `[Unreleased]` Firmware section accumulated under
+        # firmware-v1.4.1 / v1.5.0 / v1.6.0 / v1.7.0 — each of those
+        # releases shipped binaries to GitHub Releases without ever
+        # promoting the matching `[Unreleased]` entries into a dated
+        # CHANGELOG section, so the in-repo CHANGELOG diverged from the
+        # artifact-of-record. From firmware-v1.8.0 onward, this step
+        # refuses to build the release if CHANGELOG.md does not yet
+        # contain a `## [firmware-vX.Y.Z] - YYYY-MM-DD` line matching
+        # the tag being pushed. Promote the entries belonging to the new
+        # tag in a prep PR, merge it, then push the tag at the merged
+        # commit. See `CONTRIBUTING.md` `Releasing the firmware`.
+        #
+        # workflow_dispatch dry-runs skip this gate because there is no
+        # tag to validate; those runs are intended for smoke-testing the
+        # build pipeline from any branch.
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF" != refs/tags/firmware-v* ]]; then
+            echo "::error::Firmware release tags must start with 'firmware-v' (got: $GITHUB_REF)"
+            exit 1
+          fi
+          TAG="${GITHUB_REF#refs/tags/}"
+
+          # Escape regex metacharacters in TAG so the version dots in
+          # tags like `firmware-v1.8.0` are matched literally rather
+          # than as ERE wildcards. Without this, a typo section header
+          # like `## [firmware-v1x8x0] - 2026-05-20` would falsely
+          # satisfy the gate for the tag `firmware-v1.8.0` (any single
+          # character at the dot positions would match).
+          TAG_ESC="${TAG//./\\.}"
+
+          # Count exact-match dated sections. Requires line layout
+          # `## [<TAG>] - YYYY-MM-DD` with no leading or trailing
+          # content. Uses `-c` so we can also fail on duplicates;
+          # `-q` would only check existence and would let a file with
+          # two matching sections pass, which leaves release-notes
+          # extraction ambiguous.
+          COUNT=$(grep -cE "^## \[${TAG_ESC}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md || true)
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::CHANGELOG.md is missing a dated section for ${TAG}."
+            echo ""
+            echo "Expected to find exactly one line matching:"
+            echo "    ## [${TAG}] - YYYY-MM-DD"
+            echo ""
+            echo "Promote the entries that belong to ${TAG} from [Unreleased] into a"
+            echo "dated section, update the comparison-links block at the bottom of"
+            echo "CHANGELOG.md, open a PR, merge it, and re-push the tag at the merged"
+            echo "commit. See CONTRIBUTING.md 'Releasing the firmware'."
+            exit 1
+          fi
+
+          if [ "$COUNT" -gt 1 ]; then
+            echo "::error::CHANGELOG.md has ${COUNT} dated sections for ${TAG}, expected exactly 1."
+            echo ""
+            echo "Multiple dated sections for the same tag make the release-notes"
+            echo "extraction step (sed -n '/^## \[${TAG}\]/,/^## \[/p') ambiguous and"
+            echo "indicate either a copy-paste mistake during the release-prep PR or a"
+            echo "merge conflict that was resolved by keeping both sides. Collapse the"
+            echo "duplicates into a single section, open a PR, merge it, and re-push"
+            echo "the tag at the merged commit."
+            exit 1
+          fi
+
+          echo "CHANGELOG entry for ${TAG} verified (exactly 1 dated section)."
+
       - name: Build firmware with ESP-IDF Docker image
         # Same build command the regular CI Build workflow uses, so a
         # tag-driven release artifact is byte-identical to what the PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,31 @@ The format is based on
 [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Version tags (`vX.Y.Z`) track the **Python MCP gateway** published to PyPI
-as `stackchan-mcp`. The ESP32 firmware lives in the same repository but is
-built and distributed separately through `firmware/scripts/release.py` and
-the upstream xiaozhi-esp32 firmware version (currently `v2.2.6`); when a
-tagged gateway release also requires a coordinated firmware change, that
-change is called out under a `Firmware` subsection of the release entry.
+Two release series ship from this repository:
+
+- **Gateway** — version tags `vX.Y.Z` track the Python MCP gateway
+  published to PyPI as `stackchan-mcp`. Changes appear under a
+  `Gateway` subsection of the release entry.
+- **Firmware** — version tags `firmware-vX.Y.Z` track the ESP32
+  firmware distributed via GitHub Releases (built through
+  `firmware/scripts/release.py`). Changes appear under a `Firmware`
+  subsection of the release entry. The upstream xiaozhi-esp32 firmware
+  version is currently `v2.2.6`; firmware-v* tags advance independently
+  of the upstream version.
+
+When a tagged release also makes documentation changes that are not
+specific to one side, those go under a `Docs` subsection of the release
+entry.
+
+See `CONTRIBUTING.md` for the release promotion process. The firmware
+release workflow refuses to publish if the new tag does not have a
+matching dated `## [firmware-vX.Y.Z] - YYYY-MM-DD` section in this
+file, so promotion of `[Unreleased]` entries is enforced rather than
+documented-only.
 
 ## [Unreleased]
+
+## [firmware-v1.8.0] - 2026-05-20
 
 ### Firmware
 
@@ -76,6 +93,65 @@ change is called out under a `Firmware` subsection of the release entry.
   [#191](https://github.com/kisaragi-mochi/stackchan-mcp/issues/191)
   (fail-fast on invalid server hello). Closes
   [#187](https://github.com/kisaragi-mochi/stackchan-mcp/issues/187).
+
+### Docs
+
+- Corrected the stack-chan project attribution in `README.md` and
+  `README.ja.md`. The hero blurb, the self-built-stack-chan note,
+  and the "Related projects" entry previously credited the project
+  to "Takawo-san" (mongonta0716 / Takao Akaki) and linked to a
+  personal fork; the project originator is **Shinya Ishikawa**
+  (ししかわ / 石川真也), with public release in 2021, and the
+  canonical upstream is `stack-chan/stack-chan`. The "Related
+  projects" section now also separately credits Takao Akaki
+  (mongonta0716) via the `stack-chan/stackchan-arduino` entry,
+  which is the implementation lineage actually referenced by this
+  firmware. A new `Trademarks` / `商標` section is appended to
+  both READMEs acknowledging that "StackChan" / "スタックチャン"
+  is a registered trademark of Shinya Ishikawa. Closes
+  [#184](https://github.com/kisaragi-mochi/stackchan-mcp/issues/184).
+
+
+## [0.8.0] - 2026-05-19
+
+### Gateway
+
+- Added the `set_auto_torque_release(enabled, timeout_ms)` MCP tool
+  exposure on the gateway, the runtime configuration surface for the
+  firmware-side Phase 4 auto-torque-release feature
+  ([#152](https://github.com/kisaragi-mochi/stackchan-mcp/issues/152)
+  Phase 4). `timeout_ms` is clamped by the firmware to `500..600000`
+  ms; the gateway forwards the request and returns the firmware's
+  response including the `clamped` flag and the
+  `torque_released_at_call` state. Refs
+  [#168](https://github.com/kisaragi-mochi/stackchan-mcp/issues/168).
+
+- Added the `set_servo_torque(yaw_enabled, pitch_enabled)` MCP tool
+  exposure on the gateway. The tool is a per-axis SCS0009 torque
+  toggle primitive originally introduced as a diagnostic probe for the
+  Phase 4 design work but also useful as a standalone power-management
+  primitive. The gateway forwards the request and returns the
+  firmware's response including the `short_circuited` flag indicating
+  whether the bus call was actually issued. Closes
+  [#163](https://github.com/kisaragi-mochi/stackchan-mcp/issues/163).
+
+- Added hardware-lane aware dispatch for ESP32 tool calls. Independent
+  hardware lanes (servo, LED, avatar/display, screen, audio, camera,
+  touch, status) now pipeline concurrently on the gateway side, while
+  ordering within the same lane is preserved. The existing
+  `ESP32Manager.call_tool()` API remains compatible. `tools/call`
+  send-failure handling is also hardened: WebSocket send failures now
+  mark the ESP32 connection disconnected and no longer leave
+  unobserved pending future exceptions. Refs
+  [#73](https://github.com/kisaragi-mochi/stackchan-mcp/issues/73)
+  (firmware-side `tools/call` execution remains serialized by
+  `Application::Schedule()`, so Issue #73 stays open as the
+  firmware-side follow-up).
+
+
+## [firmware-v1.7.0] - 2026-05-19
+
+### Firmware
 
 - Fixed: STROKE-triggered touch wobble previously commanded
   `target_pitch = 0` per step, forcing the SCS0009 pitch axis toward
@@ -168,6 +244,10 @@ change is called out under a `Firmware` subsection of the release entry.
   `CONFIG_STACKCHAN_SERVO_DELEGATED_MOTION=y` opt-in path is unchanged
   from Phase 2 / PR #154.
 
+## [firmware-v1.6.0] - 2026-05-17
+
+### Firmware
+
 - Added a post-init `ReadPos` re-sync step ("Phase 0'") to
   `InitializeServo()` that re-reads the SCS0009 actual position after
   the boot-init `WriteHeadAngles` interpolation completes and
@@ -239,6 +319,123 @@ change is called out under a `Firmware` subsection of the release entry.
   any residual trip on the firmware side; recovery still requires
   PMIC OFF/ON. Refs
   [#143](https://github.com/kisaragi-mochi/stackchan-mcp/issues/143).
+
+## [firmware-v1.5.0] - 2026-05-16
+
+### Firmware
+
+- Added a boot-time snap-suppress hold to `InitializeServo()` to
+  mitigate the [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
+  Problem 1 "downward drop on power-on" symptom. Immediately after the
+  existing pre-init `ReadPos` diagnostic, the firmware now issues a
+  `WritePos(id, current_pos, time=0, speed=0)` per servo, which the
+  SCS0009 treats as a new target equal to its current position and uses
+  to truncate any in-progress "snap-to-last-target" motion. Background:
+  the SCS0009 retains its commanded set-point across power cycles
+  (Hypothesis 1 in #121, confirmed by the firmware-v1.4.1 clean-install
+  reproduction in which `Boot pre-init ReadPos` still matched the
+  pre-power-off pose exactly after a full NVS reset on the ESP32 side,
+  demonstrating the set-point lives in the servo itself). When `VM_EN`
+  asserts at hardware power-on the servo restores torque and snaps
+  toward that retained target before any firmware-side speed limiting
+  can apply, audible as a mechanical end-stop impact when the previous
+  session ended near `pitch=0°`. Efficacy is observable in the serial
+  log via new `Boot snap-suppress yaw/pitch hold(pos=...): r=...`
+  lines; if `ReadPos` already captured an end-stop position the hold is
+  a no-op for that boot and a deeper fix (e.g. firmware-controlled
+  `VM_EN` sequencing through the PY32 IO-expander) would be required,
+  tracked separately. The pitch hold is additionally gated on the
+  `ReadPos` raw value falling inside the same `SAFE_PITCH_MIN..
+  SAFE_PITCH_MAX` range as every other pitch servo-write boundary in
+  the firmware: out-of-range reads (e.g. the head was hand-pushed past
+  an end-stop pre-boot, or the previous session's set-point fell
+  outside the safe range) skip the hold and let the subsequent
+  interpolating boot-init climb to `(yaw=0°, pitch=45°)` drive the
+  head back into the safe range through the existing speed-limited
+  path, instead of pinning the servo against an out-of-range raw
+  position. Refs
+  [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
+  Problem 1.
+
+- Extended the boot-time snap-suppress hold added for #121 Problem 1
+  (PR #137) so that it actually fires on the PMIC long-press OFF / ON
+  path, by retrying the pre-hold `ReadPos` long enough to absorb the
+  SCS0009 `~200 ms` startup latency after `VM_EN` HIGH. Each `ReadPos`
+  in `InitializeServo()` is now attempted up to 5 times at 50 ms
+  intervals (250 ms total budget per axis), well above the observed
+  wake-up latency window. The `Boot pre-init ReadPos` diagnostic line
+  now includes the attempt count taken
+  (`yaw_raw=N (attempts=K) pitch_raw=N (attempts=K)`). If all retries
+  still fail (e.g. a genuine SCS0009 bus hang per #100), the firmware
+  seeds `pitch_motion_.current_deg` with `BOOT_INIT_PITCH_DEG` (45°)
+  instead of leaving the struct-default `current_deg=0`, so the
+  subsequent boot-init `WriteHeadAngles(0, 45, 4000)` interpolation
+  becomes a near-no-op rather than walking `WritePos` calls upward
+  from `pos=620` (the lower mechanical end-stop) through
+  end-stop-adjacent positions. The `BOOT_INIT_YAW_DEG` /
+  `BOOT_INIT_PITCH_DEG` / `BOOT_INIT_MOVE_MS` constants are promoted
+  from local block scope to class-level `static constexpr` so the
+  safe-fallback branch can reference them. Closes
+  [#138](https://github.com/kisaragi-mochi/stackchan-mcp/issues/138).
+  Refs
+  [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
+  Problem 1.
+
+
+- Fixed a missing trailing comma in
+  `firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json`
+  that caused `release.py` to fail to parse the file and silently skip
+  the `sdkconfig_append` entries for the
+  `freenove-esp32s3-display-2.8-lcd` board variant. The variant builds
+  now pick up `CONFIG_LANGUAGE_EN_US=y`,
+  `CONFIG_SR_WN_WN9S_HIESP=y`, and `CONFIG_SR_WN_WN9_HIESP=y` as
+  intended, and the spurious `[ERROR] Failed to parse ...` line is no
+  longer printed during any `release.py` invocation. The default
+  `release.py stackchan` build, which only targets the `stackchan`
+  board, is unaffected. Closes
+  [#113](https://github.com/kisaragi-mochi/stackchan-mcp/issues/113).
+
+- `release.py` now masks `CONFIG_DEFAULT_WEBSOCKET_TOKEN` in its
+  summary stdout so build logs are safe to paste into Issues / PRs
+  without leaking a personal token. The token is still applied to
+  the build itself; this change is purely build-log hygiene. Closes
+  [#131](https://github.com/kisaragi-mochi/stackchan-mcp/issues/131).
+
+## [0.7.0] - 2026-05-14
+
+### Gateway
+
+- `listen()` now accepts optional visual/motion feedback arguments:
+  `motion="face-only"` shows the `thinking` avatar during capture and
+  restores `idle` at the end, while `motion="look-up"` preserves yaw,
+  tilts pitch to `look_up_pitch` (validated to 5..85 degrees), shows
+  `thinking`, and holds the pose on success so the caller's response
+  can continue from the attentive posture. The default
+  `motion="none"` preserves the existing behavior. Refs #96.
+
+- `move_head` MCP tool now constrains `pitch` to `5..85` — the
+  M5Stack-recommended operating range. Both the `inputSchema`
+  (`minimum: 5`, `maximum: 85` for `pitch`; `minimum: -90`, `maximum: 90`
+  for `yaw`) and the gateway `call_tool` handler enforce the bound as
+  belt-and-suspenders. The tool description now references
+  `set_head_angles` for callers that genuinely need the wider firmware
+  hard clamp (`0..88`). This also refuses `move_head(yaw=0, pitch=0)`
+  and other below-`5°` pitch requests at the MCP boundary, so an
+  LLM-driven agent cannot trigger the SCS0009 servo bus hang state
+  tracked in
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
+  from a default pose-reset call. See README "Y-axis (pitch) safe
+  range — two-tier guard" for the gateway-side restrictive vs
+  firmware-side permissive policy contrast, and the comment thread on
+  [#99](https://github.com/kisaragi-mochi/stackchan-mcp/issues/99) /
+  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
+  for the on-device reproduction (2026-05-14). Closes
+  [#109](https://github.com/kisaragi-mochi/stackchan-mcp/issues/109).
+
+
+## [firmware-v1.4.1] - 2026-05-14
+
+### Firmware
 
 - Fixed user-configured WebSocket gateway URLs (e.g.
   `ws://192.168.x.y:8765`) being silently overwritten on every boot by
@@ -315,160 +512,6 @@ change is called out under a `Firmware` subsection of the release entry.
   Problem 2 (climb speed); the separate "unintended downward drop on
   power-on" (#121 Problem 1 / hypotheses 1–3) remains under
   investigation and is unaffected by this change.
-
-- Fixed a missing trailing comma in
-  `firmware/main/boards/freenove-esp32s3-display-2.8-lcd/config.json`
-  that caused `release.py` to fail to parse the file and silently skip
-  the `sdkconfig_append` entries for the
-  `freenove-esp32s3-display-2.8-lcd` board variant. The variant builds
-  now pick up `CONFIG_LANGUAGE_EN_US=y`,
-  `CONFIG_SR_WN_WN9S_HIESP=y`, and `CONFIG_SR_WN_WN9_HIESP=y` as
-  intended, and the spurious `[ERROR] Failed to parse ...` line is no
-  longer printed during any `release.py` invocation. The default
-  `release.py stackchan` build, which only targets the `stackchan`
-  board, is unaffected. Closes
-  [#113](https://github.com/kisaragi-mochi/stackchan-mcp/issues/113).
-
-- Added a boot-time snap-suppress hold to `InitializeServo()` to
-  mitigate the [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
-  Problem 1 "downward drop on power-on" symptom. Immediately after the
-  existing pre-init `ReadPos` diagnostic, the firmware now issues a
-  `WritePos(id, current_pos, time=0, speed=0)` per servo, which the
-  SCS0009 treats as a new target equal to its current position and uses
-  to truncate any in-progress "snap-to-last-target" motion. Background:
-  the SCS0009 retains its commanded set-point across power cycles
-  (Hypothesis 1 in #121, confirmed by the firmware-v1.4.1 clean-install
-  reproduction in which `Boot pre-init ReadPos` still matched the
-  pre-power-off pose exactly after a full NVS reset on the ESP32 side,
-  demonstrating the set-point lives in the servo itself). When `VM_EN`
-  asserts at hardware power-on the servo restores torque and snaps
-  toward that retained target before any firmware-side speed limiting
-  can apply, audible as a mechanical end-stop impact when the previous
-  session ended near `pitch=0°`. Efficacy is observable in the serial
-  log via new `Boot snap-suppress yaw/pitch hold(pos=...): r=...`
-  lines; if `ReadPos` already captured an end-stop position the hold is
-  a no-op for that boot and a deeper fix (e.g. firmware-controlled
-  `VM_EN` sequencing through the PY32 IO-expander) would be required,
-  tracked separately. The pitch hold is additionally gated on the
-  `ReadPos` raw value falling inside the same `SAFE_PITCH_MIN..
-  SAFE_PITCH_MAX` range as every other pitch servo-write boundary in
-  the firmware: out-of-range reads (e.g. the head was hand-pushed past
-  an end-stop pre-boot, or the previous session's set-point fell
-  outside the safe range) skip the hold and let the subsequent
-  interpolating boot-init climb to `(yaw=0°, pitch=45°)` drive the
-  head back into the safe range through the existing speed-limited
-  path, instead of pinning the servo against an out-of-range raw
-  position. Refs
-  [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
-  Problem 1.
-
-- Extended the boot-time snap-suppress hold added for #121 Problem 1
-  (PR #137) so that it actually fires on the PMIC long-press OFF / ON
-  path, by retrying the pre-hold `ReadPos` long enough to absorb the
-  SCS0009 `~200 ms` startup latency after `VM_EN` HIGH. Each `ReadPos`
-  in `InitializeServo()` is now attempted up to 5 times at 50 ms
-  intervals (250 ms total budget per axis), well above the observed
-  wake-up latency window. The `Boot pre-init ReadPos` diagnostic line
-  now includes the attempt count taken
-  (`yaw_raw=N (attempts=K) pitch_raw=N (attempts=K)`). If all retries
-  still fail (e.g. a genuine SCS0009 bus hang per #100), the firmware
-  seeds `pitch_motion_.current_deg` with `BOOT_INIT_PITCH_DEG` (45°)
-  instead of leaving the struct-default `current_deg=0`, so the
-  subsequent boot-init `WriteHeadAngles(0, 45, 4000)` interpolation
-  becomes a near-no-op rather than walking `WritePos` calls upward
-  from `pos=620` (the lower mechanical end-stop) through
-  end-stop-adjacent positions. The `BOOT_INIT_YAW_DEG` /
-  `BOOT_INIT_PITCH_DEG` / `BOOT_INIT_MOVE_MS` constants are promoted
-  from local block scope to class-level `static constexpr` so the
-  safe-fallback branch can reference them. Closes
-  [#138](https://github.com/kisaragi-mochi/stackchan-mcp/issues/138).
-  Refs
-  [#121](https://github.com/kisaragi-mochi/stackchan-mcp/issues/121)
-  Problem 1.
-
-### Docs
-
-- Corrected the stack-chan project attribution in `README.md` and
-  `README.ja.md`. The hero blurb, the self-built-stack-chan note,
-  and the "Related projects" entry previously credited the project
-  to "Takawo-san" (mongonta0716 / Takao Akaki) and linked to a
-  personal fork; the project originator is **Shinya Ishikawa**
-  (ししかわ / 石川真也), with public release in 2021, and the
-  canonical upstream is `stack-chan/stack-chan`. The "Related
-  projects" section now also separately credits Takao Akaki
-  (mongonta0716) via the `stack-chan/stackchan-arduino` entry,
-  which is the implementation lineage actually referenced by this
-  firmware. A new `Trademarks` / `商標` section is appended to
-  both READMEs acknowledging that "StackChan" / "スタックチャン"
-  is a registered trademark of Shinya Ishikawa. Closes
-  [#184](https://github.com/kisaragi-mochi/stackchan-mcp/issues/184).
-
-## [0.8.0] - 2026-05-19
-
-### Gateway
-
-- Added the `set_auto_torque_release(enabled, timeout_ms)` MCP tool
-  exposure on the gateway, the runtime configuration surface for the
-  firmware-side Phase 4 auto-torque-release feature
-  ([#152](https://github.com/kisaragi-mochi/stackchan-mcp/issues/152)
-  Phase 4). `timeout_ms` is clamped by the firmware to `500..600000`
-  ms; the gateway forwards the request and returns the firmware's
-  response including the `clamped` flag and the
-  `torque_released_at_call` state. Refs
-  [#168](https://github.com/kisaragi-mochi/stackchan-mcp/issues/168).
-
-- Added the `set_servo_torque(yaw_enabled, pitch_enabled)` MCP tool
-  exposure on the gateway. The tool is a per-axis SCS0009 torque
-  toggle primitive originally introduced as a diagnostic probe for the
-  Phase 4 design work but also useful as a standalone power-management
-  primitive. The gateway forwards the request and returns the
-  firmware's response including the `short_circuited` flag indicating
-  whether the bus call was actually issued. Closes
-  [#163](https://github.com/kisaragi-mochi/stackchan-mcp/issues/163).
-
-- Added hardware-lane aware dispatch for ESP32 tool calls. Independent
-  hardware lanes (servo, LED, avatar/display, screen, audio, camera,
-  touch, status) now pipeline concurrently on the gateway side, while
-  ordering within the same lane is preserved. The existing
-  `ESP32Manager.call_tool()` API remains compatible. `tools/call`
-  send-failure handling is also hardened: WebSocket send failures now
-  mark the ESP32 connection disconnected and no longer leave
-  unobserved pending future exceptions. Refs
-  [#73](https://github.com/kisaragi-mochi/stackchan-mcp/issues/73)
-  (firmware-side `tools/call` execution remains serialized by
-  `Application::Schedule()`, so Issue #73 stays open as the
-  firmware-side follow-up).
-
-## [0.7.0] - 2026-05-14
-
-### Gateway
-
-- `listen()` now accepts optional visual/motion feedback arguments:
-  `motion="face-only"` shows the `thinking` avatar during capture and
-  restores `idle` at the end, while `motion="look-up"` preserves yaw,
-  tilts pitch to `look_up_pitch` (validated to 5..85 degrees), shows
-  `thinking`, and holds the pose on success so the caller's response
-  can continue from the attentive posture. The default
-  `motion="none"` preserves the existing behavior. Refs #96.
-
-- `move_head` MCP tool now constrains `pitch` to `5..85` — the
-  M5Stack-recommended operating range. Both the `inputSchema`
-  (`minimum: 5`, `maximum: 85` for `pitch`; `minimum: -90`, `maximum: 90`
-  for `yaw`) and the gateway `call_tool` handler enforce the bound as
-  belt-and-suspenders. The tool description now references
-  `set_head_angles` for callers that genuinely need the wider firmware
-  hard clamp (`0..88`). This also refuses `move_head(yaw=0, pitch=0)`
-  and other below-`5°` pitch requests at the MCP boundary, so an
-  LLM-driven agent cannot trigger the SCS0009 servo bus hang state
-  tracked in
-  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
-  from a default pose-reset call. See README "Y-axis (pitch) safe
-  range — two-tier guard" for the gateway-side restrictive vs
-  firmware-side permissive policy contrast, and the comment thread on
-  [#99](https://github.com/kisaragi-mochi/stackchan-mcp/issues/99) /
-  [#100](https://github.com/kisaragi-mochi/stackchan-mcp/issues/100)
-  for the on-device reproduction (2026-05-14). Closes
-  [#109](https://github.com/kisaragi-mochi/stackchan-mcp/issues/109).
 
 ## [0.6.0] - 2026-05-12
 
@@ -604,6 +647,7 @@ change is called out under a `Firmware` subsection of the release entry.
   silently raises sub-zero requests with an `ESP_LOGW` warning. README
   gains a new "Hardware safety notes" section. Refs #80.
 
+
 ## [0.5.0] - 2026-05-10
 
 ### Added
@@ -649,6 +693,7 @@ change is called out under a `Firmware` subsection of the release entry.
   state. All four tools no-op cleanly with an `available=false`
   reply when the PY32 init failed, so a flaky expander does not
   cascade into errors.
+
 
 ## [0.4.0] - 2026-05-09
 
@@ -761,6 +806,7 @@ change is called out under a `Firmware` subsection of the release entry.
 [#5]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/5
 [#43]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/43
 
+
 ## [0.3.0] - 2026-05-08
 
 ### Added
@@ -795,6 +841,7 @@ change is called out under a `Firmware` subsection of the release entry.
 [#53]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/53
 [#54]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/54
 
+
 ## [0.2.0] - 2026-05-08
 
 ### Added
@@ -818,6 +865,7 @@ change is called out under a `Firmware` subsection of the release entry.
 
 [#3]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/3
 [#25]: https://github.com/kisaragi-mochi/stackchan-mcp/issues/25
+
 
 ## [0.1.0] - 2026-05-07
 
@@ -860,10 +908,20 @@ uv tool install stackchan-mcp
   releases only and does not maintain a moving `@v8` major-version
   alias, so the previous floating pin no longer resolved. ([#47])
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.8.0...HEAD
+
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.8.0...HEAD
+[firmware-v1.8.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.7.0...firmware-v1.8.0
 [0.8.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.7.0...v0.8.0
+[firmware-v1.7.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.6.0...firmware-v1.7.0
+[firmware-v1.6.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.5.0...firmware-v1.6.0
+[firmware-v1.5.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.4.1...firmware-v1.5.0
 [0.7.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.6.0
+[firmware-v1.4.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.3.0...firmware-v1.4.1
+[0.6.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.5.0...v0.6.0
+[firmware-v1.3.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.2.0...firmware-v1.3.0
+[firmware-v1.2.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.1.0...firmware-v1.2.0
+[firmware-v1.1.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.0.0...firmware-v1.1.0
+[firmware-v1.0.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/firmware-v1.0.0
 [0.5.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.5.0
 [0.4.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.4.0
 [0.3.0]: https://github.com/kisaragi-mochi/stackchan-mcp/releases/tag/v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,6 +321,92 @@ names, or token-based upload steps back to upstream. The upstream
 pipeline is intentionally strict about the canonical project name and
 the OIDC-only path.
 
+## Releasing the firmware
+
+Maintainers publish firmware binaries (`merged-binary.bin`, `xiaozhi.bin`,
+`v*_stackchan.zip`) to GitHub Releases by tagging a release on `main`. The
+`.github/workflows/firmware-release.yml` workflow runs on every tag matching
+`firmware-v*`, builds the firmware via the ESP-IDF Docker image, and attaches
+the build artifacts to a GitHub Release.
+
+Firmware tags (`firmware-vX.Y.Z`) advance independently of the PyPI
+gateway tags (`vX.Y.Z`). Both can coexist on `main`; a single PR that
+touches both sides in a coupled way should cut both tags and mention
+the pairing in each release's notes.
+
+### Release gates
+
+The firmware-release workflow only succeeds if all of the following hold:
+
+- The tag has a `firmware-v` prefix.
+- `CHANGELOG.md` contains a matching dated section
+  `## [firmware-vX.Y.Z] - YYYY-MM-DD` for the new tag. Without this
+  section the workflow fails fast in the `Verify CHANGELOG.md ...`
+  step before any build runs, so promoting `[Unreleased]` Firmware
+  entries into a dated CHANGELOG section is **enforced**, not just
+  documented. (This gate was added after firmware-v1.4.1 / v1.5.0 /
+  v1.6.0 / v1.7.0 each shipped binaries without ever promoting the
+  matching CHANGELOG entries; firmware-v1.8.0 is the first release
+  cut under the enforced gate.)
+- The build job produces `firmware/build/merged-binary.bin`,
+  `firmware/build/xiaozhi.bin`, and `firmware/releases/v*_stackchan.zip`.
+
+### Per-release steps
+
+1. On a topic branch, promote the `[Unreleased]` Firmware entries
+   destined for the new release into a dated section in `CHANGELOG.md`:
+   - Add a new `## [firmware-vX.Y.Z] - YYYY-MM-DD` section and move the
+     applicable entries from `[Unreleased] > Firmware` into it. Place
+     the new section in chronological position relative to the other
+     dated sections (newer dates go higher in the file). Same idea for
+     a `Docs` subsection if the release also includes documentation
+     changes that are not specific to one side.
+   - Leave a fresh empty `## [Unreleased]` at the top so future merges
+     have a clear destination.
+   - Update the comparison-links block at the bottom of `CHANGELOG.md`:
+     ```
+     [Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-vX.Y.Z...HEAD
+     [firmware-vX.Y.Z]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v<PREV>...firmware-vX.Y.Z
+     ```
+     (the `[Unreleased]` link tracks whichever side just released, so it
+     may compare against either a firmware-v* or a v* tag depending on
+     which release went out last).
+   Open a PR with these changes.
+2. After the PR is merged, tag the resulting commit on `main`:
+   ```bash
+   git switch main
+   git pull
+   git tag firmware-v1.8.0
+   git push origin firmware-v1.8.0
+   ```
+3. The firmware-release workflow validates the gates above, builds the
+   firmware in the ESP-IDF Docker image, and attaches the binaries to a
+   fresh GitHub Release named after the tag. The default release body
+   is the standard flash-instructions template; maintainers can edit it
+   after the workflow finishes to add a release-specific `Highlights` /
+   `License` / `Migration notes` section. The natural source is the new
+   CHANGELOG dated section, which can be extracted with:
+   ```bash
+   # Extract the new section from CHANGELOG, dropping the section
+   # header and the trailing section-boundary line.
+   sed -n '/^## \[firmware-vX\.Y\.Z\]/,/^## \[/p' CHANGELOG.md \
+     | sed '1d;$d' > /tmp/firmware-release-notes.md
+   gh release edit firmware-vX.Y.Z --repo kisaragi-mochi/stackchan-mcp \
+     --notes-file /tmp/firmware-release-notes.md
+   ```
+4. Confirm the new release on
+   <https://github.com/kisaragi-mochi/stackchan-mcp/releases>.
+
+### Yank policy
+
+If a firmware release ships and a critical issue surfaces immediately,
+prefer cutting `firmware-vX.Y.(Z+1)` with a fix rather than deleting the
+tag — GitHub Releases preserves the activity feed event even if the
+release page is deleted, so a yank cannot retroactively retract the
+event for watchers. The `firmware-v1.4.0` release (yanked within ~12
+minutes on 2026-05-14, replaced by `firmware-v1.4.1`) is the historical
+example.
+
 ## Communication
 
 Be polite and concrete. This is a small hardware community, and clear technical


### PR DESCRIPTION
## Summary

Prepares the `firmware-v1.8.0` release **and** closes the structural debt that caused firmware-v1.4.1 / v1.5.0 / v1.6.0 / v1.7.0 to ship binaries without ever promoting the matching `CHANGELOG.md` entries from `[Unreleased]` into dated sections. From this PR forward, the release workflow refuses to publish a firmware tag that lacks a matching dated CHANGELOG section, so the same backfill pattern cannot recur.

Three coordinated changes in one PR:

1. **`CHANGELOG.md` restructure** — the 19 entries that had accumulated under `[Unreleased] > Firmware` are promoted into dated sections matching the tag they actually shipped under:
   - **`[firmware-v1.8.0] - 2026-05-20`** (new): 3 Firmware entries (PR #197 / PR #136 / PR #192) + 1 Docs entry (PR #185).
   - **`[firmware-v1.7.0] - 2026-05-19`** (backfill): 7 entries.
   - **`[firmware-v1.6.0] - 2026-05-17`** (backfill): 4 entries.
   - **`[firmware-v1.5.0] - 2026-05-16`** (backfill): 4 entries (3 from `[Unreleased]` + 1 new entry for PR #135 release.py token mask, which never got a CHANGELOG entry at the time).
   - **`[firmware-v1.4.1] - 2026-05-14`** (backfill): 4 entries.
   - Comparison-links block at the bottom of `CHANGELOG.md` extended to cover all firmware-v* tags (v1.0.0–v1.8.0, with v1.4.0 skipped per the historical yank). The `[Unreleased]` link now compares against `firmware-v1.8.0` since that is the most recent release tag of either series.
   - All existing Gateway sections (`[0.8.0]` … `[0.1.0]`) carry through byte-for-byte from `main` — they were extracted via `git show main:CHANGELOG.md` to avoid any drift from manual editing.

2. **`.github/workflows/firmware-release.yml` — CHANGELOG promote enforcement** — a new `Verify CHANGELOG.md has a dated section for the firmware tag` step runs ahead of the firmware build job on `push` events (skipped on `workflow_dispatch` dry-runs so they can still smoke-test the build pipeline from any branch). The step:
   - Verifies the tag starts with `firmware-v`.
   - Counts the number of CHANGELOG lines matching `^## \[<TAG>] - YYYY-MM-DD$` with **`<TAG>` escaped to literal** (so a typo like `## [firmware-v1x8x0] - …` cannot satisfy the gate for tag `firmware-v1.8.0`, which the previous draft of this gate would have accepted because `.` was treated as an ERE wildcard) and **using `grep -c` rather than `-q`** (so a duplicated section is also rejected, since multiple matching sections would make release-notes extraction ambiguous).
   - Fails fast with a specific remediation message pointing at `CONTRIBUTING.md > Releasing the firmware`.

3. **`CONTRIBUTING.md` — `Releasing the firmware` section** — documents the firmware release workflow, the gate behavior, the per-release steps (CHANGELOG promote → PR → merge → tag → push), the release-notes extraction recipe using `sed` (BSD-portable, matches the form already documented for the gateway PyPI release), and the yank policy (prefer cutting `firmware-vX.Y.(Z+1)` over deleting the tag).

## Why

- Auto-extracted release notes for the next `firmware-vX.Y.Z` tag read from `CHANGELOG.md`; without the matching dated section, user-visible changes ship silently. PR #179 / #180 / #193 / #198 were after-the-fact backfill PRs for exactly this failure mode. Restructuring + enforcing in the workflow closes the loop at the source.
- The `firmware-v1.4.0` yank (2026-05-14) was contributed to in part by CHANGELOG hygiene weakness obscuring what was actually shipping. Enforcing CHANGELOG promotion as a release gate raises the floor for future judgments.
- Issue #157 explicitly asked for the v1.4.1 / v1.5.0 / v1.6.0 backfill plus a process-improvement follow-up. This PR delivers both, extended to v1.7.0 (which exhibited the same drift) and v1.8.0 (the first release cut under the enforced gate).

## Validation

- `git diff main..HEAD --stat`: 3 files, +359/-145.
- All existing dated Gateway sections (`[0.8.0]`, `[0.7.0]`, …, `[0.1.0]`) confirmed byte-identical against `main:CHANGELOG.md` via `diff <(awk ...) <(awk ...)`; differences are limited to inter-section blank-line insertions where new firmware-v* sections were spliced in.
- Local gate behavior tested against three cases:
  - Real tag `firmware-v1.8.0` → matches the dated section, count = 1, gate passes.
  - Typo tag `firmware-v1x8x0` → does **not** match `firmware-v1.8.0`'s dated section (count = 0), gate fails as intended.
  - Absent tag `firmware-v2.0.0` → count = 0, gate fails as intended.
- Codex adversarial review (1 round) flagged the dot-as-wildcard / `-q` existence-only failure mode in the first draft of the gate; that finding is addressed in the current diff via `${TAG//./\.}` literal escaping and `grep -cE` + duplicate-count check.
- No source code / personal config / IPs / paths in the diff. The single `192.168.x.y` occurrence inside the `[firmware-v1.4.1]` PR #110 entry is the historical placeholder example carried over from `[Unreleased]` verbatim, not a new disclosure.

## Out of scope (carve-outs)

- **Shell-test snippet for the gate**: Codex's "Next steps" suggested adding a documented shell-test snippet covering malformed heading / duplicate heading / missing heading / workflow_dispatch skip cases. A snippet inside `CONTRIBUTING.md` does not actually execute in CI, so it has limited defense-in-depth value compared to the gate it documents. A follow-up Issue can propose actual CI coverage (e.g. a dedicated job that exercises the gate with synthetic CHANGELOG inputs) if maintainers want that defense-in-depth layer.
- **Adding `uv lock --check` to PR-side `build.yml`** (mentioned in PR #198): same release-side vs PR-side trade-off, follow-up.

Closes #157.