### PR TITLE
fix(gateway): I2C MCP tool schemas restrict addr to 0x08..0x77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Fixed: MCP tool schemas for `i2c_read` / `i2c_write` / `i2c_write_read`
+  now constrain the `addr` parameter to the I2C 7-bit address range
+  `0x08..0x77`, matching the `i2c_scan` probe range and the firmware-side
+  `Property` range introduced in
+  [PR #196](https://github.com/kisaragi-mochi/stackchan-mcp/pull/196).
+  The previous JSON Schema advertised `0..127`, which let LLM callers
+  attempt reserved-range addresses (0x00 General Call, 0x78–0x7F
+  reserved); the firmware tool property still rejected these at the
+  request-handling layer, so this closes a tool-surface inconsistency
+  rather than a functional gap. Tool descriptions now state the
+  constraint explicitly.
+
 ## [firmware-v1.8.0] - 2026-05-20
 
 ### Firmware

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -614,9 +614,13 @@ def create_server() -> Server:
                     "properties": {
                         "addr": {
                             "type": "integer",
-                            "description": "7-bit I2C address (0..127).",
-                            "minimum": 0,
-                            "maximum": 127,
+                            "description": (
+                                "7-bit I2C address; range 0x08..0x77 "
+                                "(I2C reserved ranges excluded — matches "
+                                "the i2c_scan probe range)."
+                            ),
+                            "minimum": 8,
+                            "maximum": 119,
                         },
                         "n_bytes": {
                             "type": "integer",
@@ -642,9 +646,13 @@ def create_server() -> Server:
                     "properties": {
                         "addr": {
                             "type": "integer",
-                            "description": "7-bit I2C address (0..127).",
-                            "minimum": 0,
-                            "maximum": 127,
+                            "description": (
+                                "7-bit I2C address; range 0x08..0x77 "
+                                "(I2C reserved ranges excluded — matches "
+                                "the i2c_scan probe range)."
+                            ),
+                            "minimum": 8,
+                            "maximum": 119,
                         },
                         "bytes": {
                             "type": "array",
@@ -674,9 +682,13 @@ def create_server() -> Server:
                     "properties": {
                         "addr": {
                             "type": "integer",
-                            "description": "7-bit I2C address (0..127).",
-                            "minimum": 0,
-                            "maximum": 127,
+                            "description": (
+                                "7-bit I2C address; range 0x08..0x77 "
+                                "(I2C reserved ranges excluded — matches "
+                                "the i2c_scan probe range)."
+                            ),
+                            "minimum": 8,
+                            "maximum": 119,
                         },
                         "write_bytes": {
                             "type": "array",


### PR DESCRIPTION
## Summary

Align the gateway JSON Schema for `i2c_read` / `i2c_write` / `i2c_write_read` with the firmware-side `Property("addr", kPropertyTypeInteger, 0x08, 0x77)` range introduced in #196. Updates schema bounds (`minimum: 8, maximum: 119`) and tool descriptions so the LLM-facing tool surface matches the firmware contract.

## Why

In the review of #196 the address-range constraint was applied to the firmware tool property range, description, and `i2c_scan` symmetry, but the gateway-side `inputSchema` was left at `minimum: 0, maximum: 127`. The firmware tool property still validates the address at the request-handling layer, so no functional gap was open — but the LLM tool surface advertised reserved-range addresses (0x00 General Call, 0x78–0x7F reserved) as valid input. This carve-out PR closes the tool-surface inconsistency.

## Changes

- `gateway/stackchan_mcp/stdio_server.py`: `addr` schema for the three I2C tools tightened to 0x08..0x77, with descriptions referencing the `i2c_scan` probe range.
- `CHANGELOG.md`: `[Unreleased] Gateway` entry added.

## Validation

- `uv run pytest` — 251 passed, 5 skipped
- `uv run ruff check .` — clean
- `codex review --base main --wait` — 0 findings
- Schema-only change; no firmware build / real-device step needed.

## Refs

Refs #196.