### PR TITLE
chore(ci): enforce CHANGELOG entry on PRs + backfill #195/#196

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,3 +78,193 @@ jobs:
       - name: Run pytest
         working-directory: gateway
         run: uv run pytest
+
+  changelog-check:
+    name: CHANGELOG check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify [Unreleased] subsection entry for each touched component
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # List paths changed between the PR base and head.
+          CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          echo "Changed files between $BASE_SHA and $HEAD_SHA:"
+          printf '%s\n' "$CHANGED"
+          echo "---"
+
+          firmware_touched=0
+          gateway_touched=0
+
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              # Machine-generated lockfile sync — does not require a
+              # CHANGELOG entry on its own. If a PR is purely a lockfile
+              # bump and nothing else under firmware/ or gateway/ changes,
+              # this check passes.
+              gateway/uv.lock | gateway/poetry.lock)
+                continue
+                ;;
+              firmware/*)
+                firmware_touched=1
+                ;;
+              gateway/*)
+                gateway_touched=1
+                ;;
+            esac
+          done <<EOF
+          $CHANGED
+          EOF
+
+          if [ "$firmware_touched" -eq 0 ] && [ "$gateway_touched" -eq 0 ]; then
+            echo "No firmware/ or gateway/ source changes detected; CHANGELOG check skipped."
+            exit 0
+          fi
+
+          # Verify the [Unreleased] section gained content via Python
+          # (portable parsing logic, identical between CI and local).
+          #
+          # Mission: catch the common miss case — a source-touching PR
+          # that forgets to add a CHANGELOG entry. This is the floor;
+          # finer judgement on the content of the entries belongs to
+          # maintainer review of the diff at merge time, and to the
+          # release-time gate in `firmware-release.yml` at promotion
+          # time.
+          #
+          # NOT in scope (intentionally hands off to maintainer review):
+          #   - Cross-subsection bullet moves
+          #   - Wholesale restructuring (deletions, replacements,
+          #     consolidating duplicates)
+          #   - Typo-polish that incidentally changes [Unreleased]
+          #
+          # Rationale: this repository's priority is to welcome
+          # contributors and LLM users. CI should keep the floor
+          # honest (entry present, structure sound) without micromanaging
+          # CHANGELOG diff shape — over-strict CI blocks legitimate
+          # contributor workflows (mixing a new entry with a small
+          # polish, consolidating duplicates) for no end-user benefit.
+          BASE_TEXT="$(git show "$BASE_SHA:CHANGELOG.md")" \
+          HEAD_TEXT="$(git show "$HEAD_SHA:CHANGELOG.md")" \
+          python3 - <<'PY'
+          import os
+          import sys
+
+          base_text = os.environ["BASE_TEXT"]
+          head_text = os.environ["HEAD_TEXT"]
+
+          UNRELEASED_HEADING = "## [Unreleased]"
+
+
+          def extract_unreleased_body(text: str) -> str:
+              """Return the body of the first [Unreleased] section,
+              starting right after the heading and ending just before
+              the next '## ' heading. Leading/trailing whitespace is
+              stripped so cosmetic blank-line-only diffs do not pass."""
+              lines = []
+              in_section = False
+              for line in text.split("\n"):
+                  if line == UNRELEASED_HEADING:
+                      in_section = True
+                      continue
+                  if in_section and line.startswith("## "):
+                      break
+                  if in_section:
+                      lines.append(line)
+              return "\n".join(lines).strip()
+
+
+          def validate_structure(text: str):
+              """Return None if valid, otherwise an error string.
+
+              Enforces:
+                1. Exactly one '## [Unreleased]' heading
+                2. The [Unreleased] heading appears before the first
+                   dated release heading (e.g.
+                   '## [1.0.0] - 2025-01-01' or
+                   '## [firmware-v1.8.0] - 2026-05-20')
+
+              Both invariants matter because release-prep tooling
+              (`firmware-release.yml` sed extraction, the
+              CONTRIBUTING.md promotion flow) operates on the active
+              top [Unreleased] section.
+              """
+              lines = text.split("\n")
+              unreleased_idx = None
+              first_dated_idx = None
+              for i, line in enumerate(lines):
+                  if line == UNRELEASED_HEADING:
+                      if unreleased_idx is not None:
+                          return (
+                              "duplicate '## [Unreleased]' heading "
+                              f"(at lines {unreleased_idx + 1} and "
+                              f"{i + 1})"
+                          )
+                      unreleased_idx = i
+                  elif line.startswith("## ") and " - " in line:
+                      if first_dated_idx is None:
+                          first_dated_idx = i
+              if unreleased_idx is None:
+                  return "no '## [Unreleased]' heading found"
+              if (
+                  first_dated_idx is not None
+                  and unreleased_idx > first_dated_idx
+              ):
+                  return (
+                      "'## [Unreleased]' heading must appear before "
+                      "the first dated release heading "
+                      f"(at line {unreleased_idx + 1}, after a dated "
+                      f"release at line {first_dated_idx + 1})"
+                  )
+              return None
+
+          head_err = validate_structure(head_text)
+          if head_err:
+              print(
+                  "::error title=Invalid CHANGELOG.md structure (HEAD)::"
+                  f"{head_err}. The gate cannot validate per-PR entries "
+                  "against a malformed [Unreleased] section; fix the "
+                  "structure before merging."
+              )
+              sys.exit(1)
+
+          base_body = extract_unreleased_body(base_text)
+          head_body = extract_unreleased_body(head_text)
+
+          if base_body == head_body:
+              print(
+                  "::error title=Missing [Unreleased] entry::"
+                  "Source changes detected under firmware/ or gateway/, "
+                  "but the [Unreleased] section of CHANGELOG.md is "
+                  "unchanged between base and head."
+              )
+              print()
+              print(
+                  "Add an entry under the matching subsection of "
+                  "[Unreleased] before merging:"
+              )
+              print("  * [Unreleased] > ### Firmware  for firmware/ changes")
+              print("  * [Unreleased] > ### Gateway   for gateway/ changes")
+              print()
+              print(
+                  "Touching CHANGELOG.md outside [Unreleased] (e.g. a "
+                  "typo fix on an older release section) does not "
+                  "satisfy this gate. See CONTRIBUTING.md > 'Changelog "
+                  "entries per PR' for the auto-skip list and the "
+                  "relationship to the release-time gate in "
+                  "firmware-release.yml."
+              )
+              sys.exit(1)
+
+          print("CHANGELOG check passed ([Unreleased] body changed).")
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,44 @@ documented-only.
 
 ## [Unreleased]
 
+### Firmware
+
+- Added: generic Grove Port A I2C bus and four `self.i2c.*` MCP tools
+  (`scan` / `read` / `write` / `write_read`) so attached M5Stack Unit
+  modules (ENV III, ToF, gas sensor, PaHub, etc.) can be driven from
+  the gateway without recompiling firmware per Unit. Port A runs on
+  I2C controller 0, physically independent from the controller-1
+  internal bus (PMIC, AW9523, touch, audio codec, IMU), so the generic
+  tools cannot accidentally reach safety-critical ICs. `addr` is
+  constrained to 0x08..0x77 (I2C reserved ranges excluded), and
+  `bytes` / `write_bytes` payloads are capped at 256 items (matching
+  the `n_bytes` read cap). Contributed via
+  [PR #196](https://github.com/kisaragi-mochi/stackchan-mcp/pull/196).
+
+- Added: `kPropertyTypeArray` for MCP tool parameters, supporting
+  integer arrays (with optional per-element range) and string arrays.
+  An optional `set_max_items` setter caps the array length in the
+  emitted JSON Schema (`maxItems`) and rejects oversized arrays in
+  `set_value()` validation before they reach the tool callback. (The
+  parse-time `std::vector::reserve(array_size)` in `DoToolCall` still
+  runs before the cap is checked, so the cap acts as a
+  payload-acceptance guard rather than a pre-allocation guard;
+  tightening to a pre-allocation guard is tracked separately.) The
+  generic default-value constructor explicitly rejects
+  `kPropertyTypeArray` so future array tools must use the
+  element-type-aware constructor. Contributed via
+  [PR #195](https://github.com/kisaragi-mochi/stackchan-mcp/pull/195).
+
 ### Gateway
+
+- Added: MCP tool surface for the firmware-side Grove Port A generic
+  I2C bus introduced in
+  [PR #196](https://github.com/kisaragi-mochi/stackchan-mcp/pull/196) —
+  `i2c_scan` (discover attached Units), `i2c_read` (raw read at a 7-bit
+  address), `i2c_write` (raw write), and `i2c_write_read`
+  (Repeated-Start write-then-read for the register-pointer idiom).
+  Exposes the firmware tools so LLM clients can drive attached
+  M5Stack Unit modules from the gateway side.
 
 - Fixed: MCP tool schemas for `i2c_read` / `i2c_write` / `i2c_write_read`
   now constrain the `addr` parameter to the I2C 7-bit address range

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,11 @@ not apply, and explain anything you could not test.
 - Hardware notes: required for firmware changes
 - Breaking changes: MCP tool API, NVS schema, build flags, or `None`
 - Related issues: `Closes #N` or `Refs #N` when applicable
+- CHANGELOG entry: add an `[Unreleased]` line under the matching
+  subsection (`### Firmware` for `firmware/` changes, `### Gateway` for
+  `gateway/` changes, `### Docs` for cross-cutting docs that ship with a
+  release). See "Changelog entries per PR" below for the enforcing CI
+  gate and the list of paths that automatically skip the check.
 
 Small, focused PRs are easier to review. Prefer one issue per PR, or one small
 maintenance purpose per PR.
@@ -65,10 +70,79 @@ pushes to `main`. It currently verifies:
 - Firmware: `python ./scripts/release.py stackchan` inside
   `espressif/idf:v5.5.2`
 - Gateway: `uv sync --frozen`, `uv run ruff check .`, and `uv run pytest`
+- CHANGELOG: PR-level enforcement that `CHANGELOG.md` is updated when
+  `firmware/` or `gateway/` paths change (see "Changelog entries per PR"
+  below)
 
 CI is the shared baseline. For firmware changes, real hardware testing is still
 needed before merge, but contributors without hardware are welcome to open PRs
 and ask for maintainer verification.
+
+## Changelog entries per PR
+
+`CHANGELOG.md` is the source of truth for user-visible changes between
+releases. Every PR that touches `firmware/` or `gateway/` must add an
+entry under the matching `[Unreleased]` subsection:
+
+- `[Unreleased] > ### Firmware` for `firmware/` changes
+- `[Unreleased] > ### Gateway`  for `gateway/` changes
+- `[Unreleased] > ### Docs`     for cross-cutting documentation that
+  ships alongside a release
+
+The `Build` workflow runs a `CHANGELOG check` job on every PR. When
+the PR touches `firmware/` or `gateway/`, the gate verifies that the
+`[Unreleased]` section of `CHANGELOG.md` changed between the PR base
+and head. A `CHANGELOG.md` edit somewhere else in the file (typo
+fix on an older release section, comparison-link adjustments, blank
+lines) does **not** satisfy the gate — the change has to land
+inside `[Unreleased]`.
+
+The gate also runs a light structure check: there must be exactly
+one `## [Unreleased]` heading at HEAD, and it must appear before the
+first dated release heading. These are zero-cost invariants that
+keep release-prep tooling (`firmware-release.yml` extraction,
+promotion flow) working reliably.
+
+### Scope of this gate (and what it leaves to humans)
+
+The gate's mission is the **common miss case**: a source-touching
+PR that forgets to add a CHANGELOG entry. It is intentionally
+lenient about everything else — mixing a typo polish with a new
+entry, consolidating duplicates, reclassifying a bullet between
+`### Firmware` and `### Gateway`, large reorderings. Those are
+legitimate maintainer workflows and CI should not block them.
+
+Content judgement on whether the entries are accurate, appropriately
+worded, or in the right subsection belongs to maintainer review of
+the CHANGELOG diff at merge time — and is double-checked at
+release-prep time, when the maintainer promotes `[Unreleased]`
+entries into the new dated section. Over-strict CI here would only
+slow contributors down without giving end users a tangible win.
+
+**Automatic skip** (no CHANGELOG entry required):
+
+- Machine-generated lockfile sync only (`gateway/uv.lock`,
+  `gateway/poetry.lock`)
+
+If your PR is purely a docs-only / housekeeping change that does not
+touch `firmware/` or `gateway/` at all, the gate does not fire and no
+CHANGELOG entry is needed.
+
+### Why this gate exists
+
+Without this gate, the prior workflow was that contributors would land
+source changes without an `[Unreleased]` entry, and the gap was only
+discovered during release prep — at which point a maintainer had to file
+a back-fill PR for every missing entry before the release could go out
+(this happened across firmware-v1.4.1, v1.5.0, v1.6.0, v1.7.0, and again
+during the v1.8.0 prep). Catching the missed entry on each PR avoids
+that back-fill cycle and keeps `CHANGELOG.md` accurate as commits land,
+rather than being reconstructed retroactively.
+
+This gate complements the `firmware-release.yml` release-time gate that
+enforces promotion of `[Unreleased]` entries into a dated
+`## [firmware-vX.Y.Z]` section at tag-push time. Both gates target the
+same accuracy invariant from different ends of the lifecycle.
 
 ## Gateway Checks
 


### PR DESCRIPTION
## Summary

Add a contributor-friendly `CHANGELOG check` job to `build.yml` that catches the common miss case: a PR that touches `firmware/` or `gateway/` but forgets to update `CHANGELOG.md`'s `[Unreleased]` section. Also backfills `[Unreleased]` entries for PR #195 (Array property type) and PR #196 (Port A I2C bus + 4 generic MCP tools), and documents the gate in `CONTRIBUTING.md`.

## Why

Across recent releases (firmware-v1.4.1 / v1.5.0 / v1.6.0 / v1.7.0 / v1.8.0) every release prep needed back-fill PRs because contributors merged source changes without their matching `[Unreleased]` entry. PR #199 added a release-time gate (`firmware-release.yml` refuses to publish without a matching dated section), but that fires after the fact; this PR adds a complementary PR-level gate that catches the miss before merge, eliminating the back-fill cycle.

## Design philosophy

This repo's stated priority is **contributor-welcoming** and **LLM-user-first**. The gate is intentionally lenient — it catches the floor case (entry completely forgotten) and a basic structure invariant, and leaves everything else to maintainer review of the diff and to the release-time gate.

**Caught by CI**:
- Source-touching PR with no change to `[Unreleased]` section content (typo fix on an older release section does not satisfy)
- `[Unreleased]` heading missing at HEAD
- `[Unreleased]` heading after a dated release heading (structure invariant for promotion tooling)

**Not in scope (handed off to maintainer review)**:
- Cross-subsection bullet moves (Gateway entry reclassified to Firmware)
- Wholesale restructuring (deletions, replacements, consolidating duplicates)
- Mixing typo polish with a new entry in one PR
- Content correctness of the entries

The rationale is in `CONTRIBUTING.md > Changelog entries per PR > Scope of this gate`.

## Changes

- `.github/workflows/build.yml`: added `changelog-check` job. Bash for path detection (firmware/ vs gateway/ vs lockfile auto-skip), Python heredoc for `[Unreleased]` body extraction, structure validation, and the equality compare. Auto-skips PRs that don't touch source paths.
- `CHANGELOG.md`: backfilled `[Unreleased]` entries for PR #195 and PR #196 (firmware-side and gateway-side).
- `CONTRIBUTING.md`: added "Changelog entries per PR" section explaining the gate, the auto-skip cases (lockfile sync, docs-only PR), and the explicit scope decision.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` — workflow YAML parses
- Local unit test (7 cases) on the Python gate logic:
  - new entry → PASS
  - typo on old release section only → FAIL (entry forgotten)
  - new + typo polish on existing entry in one PR → PASS (contributor-friendly mix)
  - consolidating duplicates + new entry in one PR → PASS
  - cross-subsection move + new entry → PASS (reclassification allowed)
  - `[Unreleased]` heading after a dated heading → FAIL (structure broken)
  - docs-only PR → PASS (auto-skip)

## Refs

Refs #195, #196 (the entries being backfilled). Complements PR #199 (release-time gate).