### PR TITLE
fix(firmware/stackchan): readable touch event log (format bug + per-channel raw decode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,29 @@ documented-only.
 
 ### Firmware
 
+- Fixed: the Si12T head-touch driver's TAP / STROKE log line printed
+  `duration=lums raw=0xNNNN` instead of human-readable values, because
+  ESP-IDF's nano-printf cannot parse the `%llums` specifier and the
+  failed parse stops `va_arg` from advancing past `duration_ms` — so
+  the following `%02X` consumed the long-long's bytes rather than the
+  Si12T Output1 register. `zones=000 raw=0x00` was also misleading
+  because the snapshot fields were overwritten every poll tick and
+  read the post-release zero state by the time the falling-edge
+  handler logged. The log line now uses `%u ms`, captures the
+  rising-edge sensor state separately into `press_start_*`, and reports
+  it as
+  `start_zones=NNN start_raw=0xNN ch=CCCC release_raw=0xNN duration=NN ms`,
+  with `ch=CCCC` decoding Output1's four 2-bit channel levels as
+  `0/L/M/H` (CH4 should always be `0`; a non-`0` CH4 character flags
+  wiring noise / EMI). `HandleTap` also receives the duration so the
+  400-600 ms grey-zone TAPs print their timing. The rising-edge
+  capture also fires on the cooldown-suppressed branch so a touch
+  whose press started during the post-reaction cooldown but released
+  after cooldown expired logs its own start state instead of the
+  previous touch's. Purely a logging change — touch detection logic
+  and timing constants are unchanged. Contributed via
+  [PR #206](https://github.com/kisaragi-mochi/stackchan-mcp/pull/206).
+
 - Fixed: a server-side close arriving between the WebSocket server
   hello and the main task resuming no longer cancels the reconnect
   timer that the per-socket `OnDisconnected` lambda just armed.

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -624,6 +624,15 @@ private:
     uint64_t   last_event_us_ = 0;
     bool       last_zone_snapshot_[3] = {false, false, false};
     uint8_t    last_output1_raw_ = 0;
+    // Press-start snapshot. last_* fields above are overwritten every poll
+    // tick, so by the time HandleTap / HandleStroke fires on the falling edge
+    // they reflect the release state (zones=000 raw=0x00). press_start_*
+    // captures the rising-edge state so the log can show what the sensor
+    // actually saw when the touch began. Useful for distinguishing genuine
+    // touches (CH1〜CH3 set) from false positives (e.g. CH4 noise, raw=0x00
+    // with press judged via debounce, etc.).
+    bool       press_start_zones_[3] = {false, false, false};
+    uint8_t    press_start_output1_raw_ = 0;
 
     // Servo wobble sub-state. Keeps the previously-set angles untouched
     // before/after the wobble so that an external set_head_angles call is
@@ -3435,10 +3444,37 @@ private:
                              (uint64_t)REACTION_HOLD_MS * 1000);
     }
 
-    void HandleTap() {
-        ESP_LOGI(TAG, "touch event: TAP (zones=%d%d%d raw=0x%02X)",
-                 last_zone_snapshot_[0], last_zone_snapshot_[1], last_zone_snapshot_[2],
-                 last_output1_raw_);
+    // Decode a 2-bit channel level from the Si12T Output1 byte.
+    // 00 = no output, 01 = low, 10 = medium, 11 = high.
+    static inline char Si12tChLevelChar(uint8_t raw, int ch) {
+        uint8_t v = (raw >> (ch * 2)) & 0x3;
+        return "0LMH"[v];
+    }
+
+    // Emit the touch event log line. press_zones/press_raw are the
+    // rising-edge snapshot (= the touch the user actually made);
+    // release_raw is whatever the sensor reports at the falling edge
+    // (normally 0x00 — anything else hints at debounce / hysteresis quirks).
+    // ch=%c%c%c%c spells CH1〜CH4 levels using 0/L/M/H. CH4 is unused on
+    // stack-chan (the head has 3 zones), so anything non-0 on CH4 is a
+    // wiring noise / EMI signature worth investigating.
+    void LogTouchEvent(const char* event_name, uint64_t duration_ms) {
+        ESP_LOGI(TAG,
+                 "touch event: %s start_zones=%d%d%d start_raw=0x%02X ch=%c%c%c%c "
+                 "release_raw=0x%02X duration=%u ms",
+                 event_name,
+                 press_start_zones_[0], press_start_zones_[1], press_start_zones_[2],
+                 press_start_output1_raw_,
+                 Si12tChLevelChar(press_start_output1_raw_, 0),
+                 Si12tChLevelChar(press_start_output1_raw_, 1),
+                 Si12tChLevelChar(press_start_output1_raw_, 2),
+                 Si12tChLevelChar(press_start_output1_raw_, 3),
+                 last_output1_raw_,
+                 (unsigned)duration_ms);
+    }
+
+    void HandleTap(uint64_t duration_ms) {
+        LogTouchEvent("TAP", duration_ms);
         last_event_ = TouchEvent::TAP;
         last_event_us_ = esp_timer_get_time();
         // Use the IfActive variant so a tap during set_avatar("off") does
@@ -3448,9 +3484,7 @@ private:
     }
 
     void HandleStroke(uint64_t duration_ms) {
-        ESP_LOGI(TAG, "touch event: STROKE (zones=%d%d%d duration=%llums raw=0x%02X)",
-                 last_zone_snapshot_[0], last_zone_snapshot_[1], last_zone_snapshot_[2],
-                 (unsigned long long)duration_ms, last_output1_raw_);
+        LogTouchEvent("STROKE", duration_ms);
         last_event_ = TouchEvent::STROKE;
         last_event_us_ = esp_timer_get_time();
         SetAvatarExpressionIfActive("embarrassed");
@@ -3509,7 +3543,17 @@ private:
         uint64_t now_us = esp_timer_get_time();
 
         if (now) {
-            // Rising edge.
+            // Rising edge. Capture the sensor state for the falling-edge
+            // log either way — without this, a press that begins during
+            // the post-reaction cooldown and is held until the cooldown
+            // expires would log the previous touch's start_zones /
+            // start_raw on its falling edge, exactly the
+            // repeated-touch / noise-overlap scenario this logging is
+            // meant to clarify.
+            press_start_zones_[0] = s.zone[0];
+            press_start_zones_[1] = s.zone[1];
+            press_start_zones_[2] = s.zone[2];
+            press_start_output1_raw_ = s.output1_raw;
             if (now_us < cooldown_until_us_) {
                 // Suppress press event while in post-reaction cooldown.
                 touch_pressed_prev_ = now;
@@ -3530,7 +3574,7 @@ private:
                 HandleStroke(duration_ms);
             } else {
                 // Treat the 400-600 ms grey zone as TAP.
-                HandleTap();
+                HandleTap(duration_ms);
             }
             cooldown_until_us_ = now_us + (uint64_t)COOLDOWN_MS * 1000ULL;
         }


### PR DESCRIPTION
## Summary

The TAP / STROKE log line in the Si12T head-touch driver currently emits
`duration=lums raw=0xNNNN` instead of human-readable values. This PR
fixes the log so it actually tells you what the touch was.

## Why it matters

Without this fix, both fields are effectively garbage:

```
touch event: STROKE (zones=000 duration=lums raw=0x1130)
touch event: STROKE (zones=000 duration=lums raw=0x1F3)
```

I assumed for a while that the trailing `raw=0x1130` (4400) was an actual
sensor reading and that the false strokes I was chasing had a raw-value
signature distinguishing them from real touches. They don't — the value
shown there is `duration_ms`'s low byte, not the Si12T register.

## Root cause

ESP-IDF's nano-printf does not parse `%llums`. The literal `lums` prints
verbatim and the va_arg pointer never advances over `duration_ms`, so the
following `%02X` consumes the long-long's bytes instead of
`last_output1_raw_`. `zones=000` is also misleading: the snapshot is
overwritten every poll tick, so by the time `HandleTap` / `HandleStroke`
fires on the falling edge those fields always read the post-release zero
state, not what the user actually touched.

## What this PR does

- Switch `%llums` to `%u ms` after casting to `unsigned`. Matches the
  `%ums` style already used elsewhere in this file (e.g. motion driver
  duration logs) and side-steps the `ll` modifier limitation.
- Capture the rising-edge sensor state into `press_start_zones_` /
  `press_start_output1_raw_` so the log can report what the touch
  actually looked like, not what it looked like after the user lifted.
- Extend the log line with `start_zones=NNN start_raw=0xNN ch=CCCC
  release_raw=0xNN`. The `ch=CCCC` field decodes Output1's four 2-bit
  channel levels as `0/L/M/H`. CH4 is unwired on stack-chan, so a non-`0`
  CH4 character is an immediate flag for wiring noise / EMI.
- Thread `duration_ms` through `HandleTap` too, so 400-600 ms grey-zone
  presses are visible in the log instead of being silently logged as TAP
  with no timing.

## Before / after

```
# Before
touch event: STROKE (zones=000 duration=lums raw=0x1F3)

# After (deliberate single-zone stroke on CH1)
touch event: STROKE start_zones=100 start_raw=0x03 ch=H000 release_raw=0x00 duration=1200 ms
```

## Test plan

- [x] Builds clean with ESP-IDF v5.5.4 (`idf.py build`, no warnings,
      same binary size class as before).
- [x] Flashed to hardware via `idf.py flash`. Deliberate TAP and STROKE
      events on CH1 now produce the new readable format with correct
      duration values, raw byte that matches the touched zone, and
      `release_raw=0x00` at the falling edge.
- [ ] Reviewer hardware test (optional): trigger TAP and STROKE,
      confirm the log line is parseable.

## Notes

This is purely a logging change — no touch detection logic or timing
constants were modified. The new fields are additive; if a downstream
tool greps for `touch event: STROKE` followed by `duration=` it will
still match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)