### PR TITLE
fix(firmware): trigger play_popup_on_listening_ from StartListening()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,25 @@ documented-only.
   close) is unchanged. Closes
   [#189](https://github.com/kisaragi-mochi/stackchan-mcp/issues/189).
 
+- Fixed: the `OGG_POPUP` listening cue was only triggered on wake-word
+  activation paths (`HandleWakeWordDetectedEvent` /
+  `ContinueWakeWordInvoke`), so callers of the public
+  `Application::StartListening()` API — board-level touch buttons,
+  server-driven listen, etc. — silently lost the audible "listening
+  started" feedback. `HandleStartListeningEvent` now arms
+  `play_popup_on_listening_` itself, after the early-return branches
+  for `kDeviceStateActivating` / `kDeviceStateWifiConfiguring` /
+  null-protocol but before the Idle / Speaking-abort listening
+  dispatches, so the flag is only latched when the function is
+  actually going to transition the device toward listening. The
+  public `Application::StartListening()` stays a thin event setter
+  (`xEventGroupSetBits` + return) so the write happens entirely on
+  the main task, matching the wake-word path that already flips the
+  flag from the main task before calling `ContinueWakeWordInvoke`.
+  No behaviour change for the wake-word path (the flag was already
+  true there before this function ran). Contributed via
+  [PR #207](https://github.com/kisaragi-mochi/stackchan-mcp/pull/207).
+
 - Fixed: WebSocket candidate fallback is now fail-fast when a server
   hello is malformed (missing/non-string `transport`, missing/empty
   `session_id`, or unsupported `transport`). A new

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -703,6 +703,10 @@ void Application::ToggleChatState() {
 }
 
 void Application::StartListening() {
+    // Thin event setter. The popup-on-listening flag is armed inside
+    // HandleStartListeningEvent (main task) so all writes to
+    // play_popup_on_listening_ converge to the same task that reads
+    // and clears it in HandleStateChangedEvent.
     xEventGroupSetBits(event_group_, MAIN_EVENT_START_LISTENING);
 }
 
@@ -780,7 +784,25 @@ void Application::HandleStartListeningEvent() {
         ESP_LOGE(TAG, "Protocol not initialized");
         return;
     }
-    
+
+    if (state == kDeviceStateIdle || state == kDeviceStateSpeaking) {
+        // Arm the OGG_POPUP cue that HandleStateChangedEvent plays after
+        // the kDeviceStateListening branch resets the decoder
+        // (~line 980). Previously this flag was set only on wake-word
+        // activation paths (HandleWakeWordDetectedEvent /
+        // ContinueWakeWordInvoke), so callers of the public
+        // StartListening() API — board-level touch buttons,
+        // server-driven listen, etc. — silently lost the cue.
+        //
+        // Setting it here (main task, after the Activating /
+        // WifiConfiguring / null-protocol early returns and gated on
+        // the states that actually transition toward Listening) avoids
+        // latching the flag for a no-op StartListening so an unrelated
+        // future Listening transition doesn't unexpectedly play the
+        // popup.
+        play_popup_on_listening_ = true;
+    }
+
     if (state == kDeviceStateIdle) {
         if (!protocol_->IsAudioChannelOpened()) {
             SetDeviceState(kDeviceStateConnecting);


### PR DESCRIPTION
## Summary

`Application::StartListening()` is a public API called from board-level touch
buttons, gateway-driven `listen.start`, and any other path that wants to bring
the device into listening mode. But the `OGG_POPUP` "listening started" audio
cue currently only fires on the wake-word activation paths
(`HandleWakeWordDetectedEvent` / `ContinueWakeWordInvoke`) — every other
activation source set `MAIN_EVENT_START_LISTENING` and reached the
`kDeviceStateListening` branch in `HandleStateChangedEvent`, but the
post-`ResetDecoder` `PlaySound` site there is gated on
`play_popup_on_listening_` and stayed silent.

## Fix (revised after review)

Move `play_popup_on_listening_ = true` into `HandleStartListeningEvent`,
**not** into the public `StartListening()` setter — per review feedback the
public setter should stay a thin event setter
(`xEventGroupSetBits` + return) so every write to the flag stays on the
same main task that reads and clears it in `HandleStateChangedEvent`,
matching the wake-word path that already flips the flag from the main
task before calling `ContinueWakeWordInvoke`.

The flag set sits after the `kDeviceStateActivating` /
`kDeviceStateWifiConfiguring` / null-protocol early returns and is gated
on `state == kDeviceStateIdle || state == kDeviceStateSpeaking` (= the
states that actually transition toward Listening). A no-op
`StartListening()` therefore does not latch the cue for some unrelated
future listening transition.

## Why this matters for downstream

For boards that expose touch / button activation paths (the stack-chan board
in this repo, but the pattern is generic), the silent listen activation made
the device feel unresponsive — there was no audible feedback that the user
input had been registered. The wake-word UX has had this cue from the start;
generalizing it to all activation paths is just removing an accidental
asymmetry.

## Test plan

- [x] Builds clean with ESP-IDF v5.5.2 (Docker image used by CI).
- [x] Flashed to hardware (stack-chan board, FT6336 touch panel). Touch-driven
      listen activation now plays the popup sound on listening entry,
      matching wake-word activation.
- [x] Wake-word activation still plays the cue (no double-play, the flag is
      idempotent).

## Notes

This is the first of a two-PR set for stack-chan touch-driven listen UX.
**PR-M is now open as #208** (`feat(firmware/stackchan): touch-driven listen
UX (single-shot push-to-talk)`) and handles the stack-chan board-side
changes (touch routing to `StopListening` for listening-state taps, debounce,
RGB LED feedback, etc.). PR-L is the more broadly useful half because it
benefits any board that uses touch / button activation, not just stack-chan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)