### PR TITLE
feat(avatar): dynamic AvatarSet transfer pipeline (HTTP fetch + AdoptOwnedBuffer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,6 @@ documented-only.
 
 ### Gateway
 
-<<<<<<< HEAD
 - Added: `send_pcm_audio(gateway, pcm, source_rate=...)` helper
   extracted from `synthesize_and_send`'s encode-and-push back-half.
   External producers — HTTP PCM bridges, sound-effect players,
@@ -218,8 +217,7 @@ documented-only.
   the existing `resample_pcm16_linear` helper, so producers at
   non-device rates work without manual resampling. Contributed via
   [PR #TBD-A1](https://github.com/kisaragi-mochi/stackchan-mcp/pull/TBD-A1).
-||||||| parent of bb37747 (docs(changelog): add Unreleased entries for PR-E1 (dynamic AvatarSet))
-=======
+
 - Added: `load_avatar_set` MCP tool + supporting HTTP staging /
   WebSocket fetch protocol for the firmware's dynamic AvatarSet
   pipeline (PR-E1 firmware side). The gateway stages a raw RGB565
@@ -229,7 +227,6 @@ documented-only.
   filesystem `archive_path` rather than inline bytes so the MCP JSON
   transport stays free of multi-MB base64 payloads. Contributed via
   [PR #210](https://github.com/kisaragi-mochi/stackchan-mcp/pull/210).
->>>>>>> bb37747 (docs(changelog): add Unreleased entries for PR-E1 (dynamic AvatarSet))
 
 - Fixed: `pip install stackchan-mcp[tts]` did not work out-of-the-box
   on Windows because `opuslib` calls `find_library("opus")`, which on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,33 @@ documented-only.
   and timing constants are unchanged. Contributed via
   [PR #206](https://github.com/kisaragi-mochi/stackchan-mcp/pull/206).
 
+- Added: dynamic avatar-set transfer pipeline. A new `AvatarSet`
+  scaffold (layered face / eyes / mouth, ~537 KB total in RGB565)
+  can be staged on the gateway and fetched into PSRAM at runtime via
+  a new `avatar_set_fetch` WebSocket protocol, replacing the old
+  build-time `avatar_images.cc` table. The fetch path uses a small
+  `AvatarSetFetcher` HTTP client that streams the raw payload
+  straight into a PSRAM staging buffer, validates SHA256, then hands
+  the buffer over to `AvatarSet::AdoptOwnedBuffer()` (an
+  ownership-transfer load, no memcpy). This caps the load-time
+  PSRAM peak at `old + new_size` instead of the pre-fix `old +
+  staging + new_size`, which was overshooting the 8 MB PSRAM budget
+  in matrix-mode (~3.3 MB) loads and producing `Load: PSRAM
+  allocation failed (size=3456000)`. Expression-change commands
+  arriving during a fetch are deferred until completion so the
+  display does not flicker between the old set and the partially
+  loaded new set. A small `%zu` → `%u` adjustment in two ESP_LOG
+  call-sites keeps nano-printf from crashing on those format
+  specifiers. Contributed via
+  [PR #210](https://github.com/kisaragi-mochi/stackchan-mcp/pull/210).
+
+- Fixed: `Protocol::SendText` was protected, so board-side code that
+  wants to push a board-initiated WS message (e.g. an `avatar_set_loaded`
+  reply from the AvatarSet fetcher) had no clean entry point.
+  Exposed as public; no behavioral change for existing callers.
+  Contributed via
+  [PR #210](https://github.com/kisaragi-mochi/stackchan-mcp/pull/210).
+
 - Fixed: a server-side close arriving between the WebSocket server
   hello and the main task resuming no longer cancels the reconnect
   timer that the per-socket `OnDisconnected` lambda just armed.
@@ -179,6 +206,7 @@ documented-only.
 
 ### Gateway
 
+<<<<<<< HEAD
 - Added: `send_pcm_audio(gateway, pcm, source_rate=...)` helper
   extracted from `synthesize_and_send`'s encode-and-push back-half.
   External producers — HTTP PCM bridges, sound-effect players,
@@ -190,6 +218,18 @@ documented-only.
   the existing `resample_pcm16_linear` helper, so producers at
   non-device rates work without manual resampling. Contributed via
   [PR #TBD-A1](https://github.com/kisaragi-mochi/stackchan-mcp/pull/TBD-A1).
+||||||| parent of bb37747 (docs(changelog): add Unreleased entries for PR-E1 (dynamic AvatarSet))
+=======
+- Added: `load_avatar_set` MCP tool + supporting HTTP staging /
+  WebSocket fetch protocol for the firmware's dynamic AvatarSet
+  pipeline (PR-E1 firmware side). The gateway stages a raw RGB565
+  payload on its capture HTTP server (one-time fetch, Bearer-token
+  auth, GC'd after 120 s), notifies the device over WebSocket, and
+  awaits the device's `avatar_set_loaded` reply. The tool takes a
+  filesystem `archive_path` rather than inline bytes so the MCP JSON
+  transport stays free of multi-MB base64 payloads. Contributed via
+  [PR #210](https://github.com/kisaragi-mochi/stackchan-mcp/pull/210).
+>>>>>>> bb37747 (docs(changelog): add Unreleased entries for PR-E1 (dynamic AvatarSet))
 
 - Fixed: `pip install stackchan-mcp[tts]` did not work out-of-the-box
   on Windows because `opuslib` calls `find_library("opus")`, which on

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -645,6 +645,12 @@ void Application::InitializeProtocol() {
             } else {
                 ESP_LOGW(TAG, "Alert command requires status, message and emotion");
             }
+        } else if (strcmp(type->valuestring, "avatar_set_fetch") == 0) {
+            // Phase 4.5 avatar (saiverse-stackchan-addon): dispatch to the
+            // current board for HTTP fetch + SHA256 verify + AvatarSet::Load.
+            // Non-stackchan boards default to a no-op (Board::OnAvatarSetFetch).
+            // See docs/intent/stackchan_avatar_pipeline.md §C-3 (SAIVerse).
+            board.OnAvatarSetFetch(root);
 #if CONFIG_RECEIVE_CUSTOM_MESSAGE
         } else if (strcmp(type->valuestring, "custom") == 0) {
             auto payload = cJSON_GetObjectItem(root, "payload");
@@ -1158,6 +1164,17 @@ void Application::SendMcpMessage(const std::string& payload) {
     Schedule([this, payload = std::move(payload)]() {
         if (protocol_) {
             protocol_->SendMcpMessage(payload);
+        }
+    });
+}
+
+void Application::SendJsonString(const std::string& json_str) {
+    // Thread-safe generic WS text frame send. Used by board-initiated
+    // notifications such as avatar_set_loaded (Phase 4.5 avatar). Mirrors
+    // SendMcpMessage's main-task Schedule pattern for protocol safety.
+    Schedule([this, json_str]() {
+        if (protocol_) {
+            protocol_->SendText(json_str);
         }
     });
 }

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -647,7 +647,7 @@ void Application::InitializeProtocol() {
             }
         } else if (strcmp(type->valuestring, "avatar_set_fetch") == 0) {
             // Phase 4.5 avatar (saiverse-stackchan-addon): dispatch to the
-            // current board for HTTP fetch + SHA256 verify + AvatarSet::Load.
+            // current board for HTTP fetch + SHA256 verify + AvatarSet adoption.
             // Non-stackchan boards default to a no-op (Board::OnAvatarSetFetch).
             // See docs/intent/stackchan_avatar_pipeline.md §C-3 (SAIVerse).
             board.OnAvatarSetFetch(root);

--- a/firmware/main/application.h
+++ b/firmware/main/application.h
@@ -108,6 +108,12 @@ public:
     bool UpgradeFirmware(const std::string& url, const std::string& version = "");
     bool CanEnterSleepMode();
     void SendMcpMessage(const std::string& payload);
+
+    // Phase 4.5 avatar: thread-safe generic WS text frame send.
+    // Wraps Protocol::SendText through the main-task Schedule for the
+    // same thread-safety reasons as SendMcpMessage. Intended for board-
+    // initiated notifications such as avatar_set_loaded.
+    void SendJsonString(const std::string& json_str);
     void SetAecMode(AecMode mode);
     AecMode GetAecMode() const { return aec_mode_; }
     void PlaySound(const std::string_view& sound);

--- a/firmware/main/boards/common/board.h
+++ b/firmware/main/boards/common/board.h
@@ -46,6 +46,7 @@ using NetworkEventCallback = std::function<void(NetworkEvent event, const std::s
 void* create_board();
 class AudioCodec;
 class Display;
+struct cJSON;
 class Board {
 private:
     Board(const Board&) = delete; // 禁用拷贝构造函数
@@ -87,6 +88,15 @@ public:
     // override these to drive lip-sync animation while TTS audio is playing.
     virtual void OnTtsStart() {}
     virtual void OnTtsStop() {}
+
+    // Phase 4.5 avatar (saiverse-stackchan-addon): dynamic avatar set fetch
+    // notification dispatched from Application::OnIncomingJson. The cJSON
+    // object carries url / token / mode / checksum / expected_size fields
+    // (see docs/intent/stackchan_avatar_pipeline.md §C-3 in the SAIVerse
+    // repository). Default no-op so non-stackchan boards are unaffected;
+    // StackChanBoard overrides to spawn a worker task that performs the
+    // HTTP fetch via AvatarSetFetcher and loads the result into avatar_set_.
+    virtual void OnAvatarSetFetch(const cJSON* root) { (void)root; }
 };
 
 #define DECLARE_BOARD(BOARD_CLASS_NAME) \

--- a/firmware/main/boards/stackchan/avatar_set.cc
+++ b/firmware/main/boards/stackchan/avatar_set.cc
@@ -1,0 +1,148 @@
+#include "avatar_set.h"
+
+#include <cstring>
+
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+
+#define TAG "AvatarSet"
+
+AvatarSet::AvatarSet() = default;
+
+AvatarSet::~AvatarSet() {
+    Unload();
+}
+
+const lv_image_dsc_t* AvatarSet::GetFace(int face_index) const {
+    if (!loaded_ || mode_ != Mode::kLayered) {
+        return nullptr;
+    }
+    if (face_index < 0 || face_index >= kNumFaces) {
+        return nullptr;
+    }
+    return &face_table_[face_index];
+}
+
+const lv_image_dsc_t* AvatarSet::GetEyes(int eyes_index) const {
+    if (!loaded_ || mode_ != Mode::kLayered) {
+        return nullptr;
+    }
+    if (eyes_index < 0 || eyes_index >= kNumEyes) {
+        return nullptr;
+    }
+    return &eyes_table_[eyes_index];
+}
+
+const lv_image_dsc_t* AvatarSet::GetMouth(int mouth_index) const {
+    if (!loaded_ || mode_ != Mode::kLayered) {
+        return nullptr;
+    }
+    if (mouth_index < 0 || mouth_index >= kNumMouths) {
+        return nullptr;
+    }
+    return &mouth_table_[mouth_index];
+}
+
+const lv_image_dsc_t* AvatarSet::GetMatrix(int face_index, int eyes_index, int mouth_index) const {
+    if (!loaded_ || mode_ != Mode::kMatrix) {
+        return nullptr;
+    }
+    if (face_index < 0 || face_index >= kNumFaces ||
+        eyes_index < 0 || eyes_index >= kNumEyes ||
+        mouth_index < 0 || mouth_index >= kNumMouths) {
+        return nullptr;
+    }
+    const int idx = face_index * kNumEyes * kNumMouths
+                  + eyes_index * kNumMouths
+                  + mouth_index;
+    return &matrix_table_[idx];
+}
+
+bool AvatarSet::Load(Mode mode, const uint8_t* image_data, size_t image_data_size) {
+    if (image_data == nullptr) {
+        ESP_LOGW(TAG, "Load: image_data is null");
+        return false;
+    }
+
+    const size_t expected =
+        (mode == Mode::kLayered) ? kLayeredPayloadBytes : kMatrixPayloadBytes;
+    if (image_data_size != expected) {
+        ESP_LOGW(TAG,
+                 "Load: size mismatch (got %zu, expected %zu for mode=%d)",
+                 image_data_size, expected, static_cast<int>(mode));
+        return false;
+    }
+
+    uint8_t* new_buffer = static_cast<uint8_t*>(
+        heap_caps_malloc(image_data_size, MALLOC_CAP_SPIRAM));
+    if (new_buffer == nullptr) {
+        ESP_LOGE(TAG, "Load: PSRAM allocation failed (size=%zu)", image_data_size);
+        return false;
+    }
+
+    std::memcpy(new_buffer, image_data, image_data_size);
+
+    // Atomically swap: free previous buffer only after the new one is staged.
+    Unload();
+
+    image_buffer_ = new_buffer;
+    image_buffer_size_ = image_data_size;
+    mode_ = mode;
+
+    if (mode == Mode::kLayered) {
+        size_t offset = 0;
+        for (int i = 0; i < kNumFaces; ++i) {
+            InitImageHeader(&face_table_[i]);
+            face_table_[i].data = image_buffer_ + offset;
+            offset += kImageBytes;
+        }
+        for (int i = 0; i < kNumEyes; ++i) {
+            InitImageHeader(&eyes_table_[i]);
+            eyes_table_[i].data = image_buffer_ + offset;
+            offset += kImageBytes;
+        }
+        for (int i = 0; i < kNumMouths; ++i) {
+            InitImageHeader(&mouth_table_[i]);
+            mouth_table_[i].data = image_buffer_ + offset;
+            offset += kImageBytes;
+        }
+    } else {
+        for (int i = 0; i < kMatrixSize; ++i) {
+            InitImageHeader(&matrix_table_[i]);
+            matrix_table_[i].data = image_buffer_ + static_cast<size_t>(i) * kImageBytes;
+        }
+    }
+
+    loaded_ = true;
+    ESP_LOGI(TAG, "Avatar set loaded: mode=%d, bytes=%zu",
+             static_cast<int>(mode), image_data_size);
+    return true;
+}
+
+void AvatarSet::Unload() {
+    if (image_buffer_ != nullptr) {
+        heap_caps_free(image_buffer_);
+        image_buffer_ = nullptr;
+        image_buffer_size_ = 0;
+    }
+
+    // Clear all lv_image_dsc_t entries — `data` pointers no longer valid.
+    std::memset(face_table_, 0, sizeof(face_table_));
+    std::memset(eyes_table_, 0, sizeof(eyes_table_));
+    std::memset(mouth_table_, 0, sizeof(mouth_table_));
+    std::memset(matrix_table_, 0, sizeof(matrix_table_));
+
+    loaded_ = false;
+}
+
+void AvatarSet::InitImageHeader(lv_image_dsc_t* dsc) {
+    dsc->header.magic     = LV_IMAGE_HEADER_MAGIC;
+    dsc->header.cf        = LV_COLOR_FORMAT_RGB565;
+    dsc->header.flags     = 0;
+    dsc->header.w         = kImageWidth;
+    dsc->header.h         = kImageHeight;
+    dsc->header.stride    = kImageWidth * 2;
+    dsc->header.reserved_2 = 0;
+    dsc->data_size = kImageBytes;
+    // `data` is set by the caller (PSRAM offset).
+}

--- a/firmware/main/boards/stackchan/avatar_set.cc
+++ b/firmware/main/boards/stackchan/avatar_set.cc
@@ -58,9 +58,9 @@ const lv_image_dsc_t* AvatarSet::GetMatrix(int face_index, int eyes_index, int m
     return &matrix_table_[idx];
 }
 
-bool AvatarSet::Load(Mode mode, const uint8_t* image_data, size_t image_data_size) {
-    if (image_data == nullptr) {
-        ESP_LOGW(TAG, "Load: image_data is null");
+bool AvatarSet::AdoptOwnedBuffer(Mode mode, uint8_t* owned_buffer, size_t image_data_size) {
+    if (owned_buffer == nullptr) {
+        ESP_LOGW(TAG, "AdoptOwnedBuffer: owned_buffer is null");
         return false;
     }
 
@@ -68,27 +68,21 @@ bool AvatarSet::Load(Mode mode, const uint8_t* image_data, size_t image_data_siz
         (mode == Mode::kLayered) ? kLayeredPayloadBytes : kMatrixPayloadBytes;
     if (image_data_size != expected) {
         ESP_LOGW(TAG,
-                 "Load: size mismatch (got %u, expected %u for mode=%d)",
+                 "AdoptOwnedBuffer: size mismatch (got %u, expected %u for mode=%d)",
                  static_cast<unsigned int>(image_data_size),
                  static_cast<unsigned int>(expected),
                  static_cast<int>(mode));
+        // Ownership stays with caller — caller frees on false return.
         return false;
     }
 
-    uint8_t* new_buffer = static_cast<uint8_t*>(
-        heap_caps_malloc(image_data_size, MALLOC_CAP_SPIRAM));
-    if (new_buffer == nullptr) {
-        ESP_LOGE(TAG, "Load: PSRAM allocation failed (size=%u)",
-                 static_cast<unsigned int>(image_data_size));
-        return false;
-    }
-
-    std::memcpy(new_buffer, image_data, image_data_size);
-
-    // Atomically swap: free previous buffer only after the new one is staged.
+    // Atomically swap: free previous buffer (= drop old descriptors first
+    // for clarity) right before installing the new one. lv_image_dsc_t::data
+    // pointers are repopulated below, so the LCD draws from the old buffer
+    // up to this point and from the new one on the next LVGL invalidation.
     Unload();
 
-    image_buffer_ = new_buffer;
+    image_buffer_ = owned_buffer;
     image_buffer_size_ = image_data_size;
     mode_ = mode;
 
@@ -117,7 +111,7 @@ bool AvatarSet::Load(Mode mode, const uint8_t* image_data, size_t image_data_siz
     }
 
     loaded_ = true;
-    ESP_LOGI(TAG, "Avatar set loaded: mode=%d, bytes=%u",
+    ESP_LOGI(TAG, "Avatar set adopted: mode=%d, bytes=%u",
              static_cast<int>(mode),
              static_cast<unsigned int>(image_data_size));
     return true;

--- a/firmware/main/boards/stackchan/avatar_set.cc
+++ b/firmware/main/boards/stackchan/avatar_set.cc
@@ -68,15 +68,18 @@ bool AvatarSet::Load(Mode mode, const uint8_t* image_data, size_t image_data_siz
         (mode == Mode::kLayered) ? kLayeredPayloadBytes : kMatrixPayloadBytes;
     if (image_data_size != expected) {
         ESP_LOGW(TAG,
-                 "Load: size mismatch (got %zu, expected %zu for mode=%d)",
-                 image_data_size, expected, static_cast<int>(mode));
+                 "Load: size mismatch (got %u, expected %u for mode=%d)",
+                 static_cast<unsigned int>(image_data_size),
+                 static_cast<unsigned int>(expected),
+                 static_cast<int>(mode));
         return false;
     }
 
     uint8_t* new_buffer = static_cast<uint8_t*>(
         heap_caps_malloc(image_data_size, MALLOC_CAP_SPIRAM));
     if (new_buffer == nullptr) {
-        ESP_LOGE(TAG, "Load: PSRAM allocation failed (size=%zu)", image_data_size);
+        ESP_LOGE(TAG, "Load: PSRAM allocation failed (size=%u)",
+                 static_cast<unsigned int>(image_data_size));
         return false;
     }
 
@@ -114,8 +117,9 @@ bool AvatarSet::Load(Mode mode, const uint8_t* image_data, size_t image_data_siz
     }
 
     loaded_ = true;
-    ESP_LOGI(TAG, "Avatar set loaded: mode=%d, bytes=%zu",
-             static_cast<int>(mode), image_data_size);
+    ESP_LOGI(TAG, "Avatar set loaded: mode=%d, bytes=%u",
+             static_cast<int>(mode),
+             static_cast<unsigned int>(image_data_size));
     return true;
 }
 

--- a/firmware/main/boards/stackchan/avatar_set.h
+++ b/firmware/main/boards/stackchan/avatar_set.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <lvgl.h>
+#include <cstdint>
+#include <cstddef>
+
+// AvatarSet — runtime-loadable avatar art container in PSRAM.
+//
+// Replaces the compile-time static `avatar_images.{cc,h}` lookup with a
+// dynamic set uploaded from the gateway via WebSocket binary frames.
+// See docs/intent/stackchan_avatar_pipeline.md in the SAIVerse repository
+// for the pipeline design, the load_avatar_set MCP tool, the 3-layer
+// fallback (placeholder / local static / dynamic set), and the rationale
+// for raw-RGB565-only on the firmware side.
+//
+// Coexistence policy:
+//   - Until Load() succeeds at least once, callers should fall back to
+//     the existing static tables in avatar_images.h (= placeholder or
+//     local override). is_loaded() reports the current state.
+//   - This class does NOT consume or modify avatar_images.{cc,h} — it
+//     lives alongside them as a separate path. Existing local-override
+//     users see no behaviour change.
+
+class AvatarSet {
+public:
+    enum class Mode : uint8_t {
+        kLayered = 0,  // 14 symbols (face 6 + eyes 3 + mouth 5)
+        kMatrix  = 1,  // 90 symbols (face 6 × eyes 3 × mouth 5)
+    };
+
+    static constexpr int kNumFaces  = 6;  // idle / happy / thinking / sad / surprised / embarrassed
+    static constexpr int kNumEyes   = 3;  // open / half / closed
+    static constexpr int kNumMouths = 5;  // closed / half / open / e / u
+    static constexpr int kMatrixSize = kNumFaces * kNumEyes * kNumMouths;  // 90
+
+    // Fixed geometry — matches firmware/scripts/avatar_convert/convert_avatars.py
+    // (TARGET_W / TARGET_H) and the LVGL scale already applied in stackchan.cc.
+    static constexpr int kImageWidth  = 160;
+    static constexpr int kImageHeight = 120;
+    static constexpr size_t kImageBytes =
+        static_cast<size_t>(kImageWidth) * static_cast<size_t>(kImageHeight) * 2;  // RGB565 LE
+
+    // Expected raw payload sizes (for early size checks at the loader boundary).
+    static constexpr size_t kLayeredPayloadBytes =
+        static_cast<size_t>(kNumFaces + kNumEyes + kNumMouths) * kImageBytes;   // 14 * 38400
+    static constexpr size_t kMatrixPayloadBytes =
+        static_cast<size_t>(kMatrixSize) * kImageBytes;                          // 90 * 38400
+
+    AvatarSet();
+    ~AvatarSet();
+
+    AvatarSet(const AvatarSet&) = delete;
+    AvatarSet& operator=(const AvatarSet&) = delete;
+
+    Mode mode() const { return mode_; }
+    bool is_loaded() const { return loaded_; }
+
+    // ---- Layered mode lookups ----
+    // 0-indexed. Returns nullptr if not loaded, mode != kLayered, or index out of range.
+    const lv_image_dsc_t* GetFace(int face_index) const;
+    const lv_image_dsc_t* GetEyes(int eyes_index) const;
+    const lv_image_dsc_t* GetMouth(int mouth_index) const;
+
+    // ---- Matrix mode lookup ----
+    // Returns nullptr if not loaded, mode != kMatrix, or any index out of range.
+    const lv_image_dsc_t* GetMatrix(int face_index, int eyes_index, int mouth_index) const;
+
+    // Load an avatar set from a raw RGB565 payload.
+    //
+    // Layered layout:
+    //   [0 ..)                                      face   × 6
+    //   [kNumFaces * kImageBytes ..)                eyes   × 3
+    //   [(kNumFaces + kNumEyes) * kImageBytes ..)   mouth  × 5
+    //   total = kLayeredPayloadBytes
+    //
+    // Matrix layout (linear, idx = face * 15 + eyes * 5 + mouth):
+    //   [idx * kImageBytes .. (idx+1) * kImageBytes)
+    //   total = kMatrixPayloadBytes
+    //
+    // The payload is copied into a freshly allocated PSRAM buffer; the
+    // caller may release its source buffer immediately after Load returns.
+    // On allocation failure or size mismatch, returns false and the
+    // previously loaded set (if any) is preserved.
+    bool Load(Mode mode, const uint8_t* image_data, size_t image_data_size);
+
+    // Release the PSRAM buffer and clear all internal lv_image_dsc_t entries.
+    // Safe to call multiple times.
+    void Unload();
+
+private:
+    Mode mode_ = Mode::kLayered;
+    bool loaded_ = false;
+
+    // PSRAM buffer holding all image data for the current set.
+    // lv_image_dsc_t::data of each table entry points into this buffer.
+    uint8_t* image_buffer_ = nullptr;
+    size_t   image_buffer_size_ = 0;
+
+    // lv_image_dsc_t entries populated by Load() to point into image_buffer_.
+    lv_image_dsc_t face_table_[kNumFaces]{};
+    lv_image_dsc_t eyes_table_[kNumEyes]{};
+    lv_image_dsc_t mouth_table_[kNumMouths]{};
+    lv_image_dsc_t matrix_table_[kMatrixSize]{};
+
+    // Fill the fixed fields (magic / cf / w / h / stride / data_size) of a
+    // descriptor. The caller still sets `data` to the PSRAM offset.
+    static void InitImageHeader(lv_image_dsc_t* dsc);
+};

--- a/firmware/main/boards/stackchan/avatar_set.h
+++ b/firmware/main/boards/stackchan/avatar_set.h
@@ -65,7 +65,7 @@ public:
     // Returns nullptr if not loaded, mode != kMatrix, or any index out of range.
     const lv_image_dsc_t* GetMatrix(int face_index, int eyes_index, int mouth_index) const;
 
-    // Load an avatar set from a raw RGB565 payload.
+    // Adopt an externally-allocated PSRAM buffer as the new avatar set.
     //
     // Layered layout:
     //   [0 ..)                                      face   × 6
@@ -77,11 +77,21 @@ public:
     //   [idx * kImageBytes .. (idx+1) * kImageBytes)
     //   total = kMatrixPayloadBytes
     //
-    // The payload is copied into a freshly allocated PSRAM buffer; the
-    // caller may release its source buffer immediately after Load returns.
-    // On allocation failure or size mismatch, returns false and the
-    // previously loaded set (if any) is preserved.
-    bool Load(Mode mode, const uint8_t* image_data, size_t image_data_size);
+    // Ownership: on success, AvatarSet takes ownership of `owned_buffer`
+    // (allocated with heap_caps_malloc(SPIRAM)) and will heap_caps_free it
+    // on the next Unload() / AdoptOwnedBuffer() / destruction. The caller
+    // MUST NOT free `owned_buffer` after a successful call. On failure
+    // (null pointer or size mismatch) the function returns false WITHOUT
+    // touching `owned_buffer` — the caller retains ownership and is
+    // responsible for freeing it. The previously loaded set (if any) is
+    // preserved on any failure path.
+    //
+    // This is ownership-transfer to keep PSRAM peak low: the fetcher's
+    // staging buffer is handed directly to AvatarSet without an internal
+    // memcpy. The pointer swap to lv_image_dsc_t entries happens after
+    // the new buffer is fully validated, so the LCD draws from the old
+    // buffer until the swap commits (no black-frame flash on update).
+    bool AdoptOwnedBuffer(Mode mode, uint8_t* owned_buffer, size_t image_data_size);
 
     // Release the PSRAM buffer and clear all internal lv_image_dsc_t entries.
     // Safe to call multiple times.

--- a/firmware/main/boards/stackchan/avatar_set_fetcher.cc
+++ b/firmware/main/boards/stackchan/avatar_set_fetcher.cc
@@ -70,15 +70,11 @@ void AvatarSetFetcher::Fetch(
         return;
     }
 
-    // Allocate PSRAM staging buffer.
-    //
-    // Note: AvatarSet::Load currently copies its input into a fresh PSRAM
-    // buffer, so during Load() the firmware temporarily holds 2× the set
-    // size in PSRAM (this buffer + the AvatarSet's own buffer). For matrix
-    // mode (~3.3 MB) this approaches the PSRAM ceiling. A follow-up
-    // optimization is to switch AvatarSet::Load to ownership-transfer
-    // semantics (e.g., std::unique_ptr<uint8_t[], PsramDeleter>), at which
-    // point this buffer can be handed directly to AvatarSet without a copy.
+    // Allocate the PSRAM buffer that will become the AvatarSet's owned
+    // image_buffer_ on success. We fill it via HTTP read, verify the SHA256,
+    // then hand it off to AvatarSet::AdoptOwnedBuffer with ownership transfer
+    // (= no internal memcpy). PSRAM peak during a swap is therefore
+    // (old AvatarSet buffer + this buffer) and not 3× the set size.
     uint8_t* buffer = static_cast<uint8_t*>(
         heap_caps_malloc(expected_size, MALLOC_CAP_SPIRAM));
     if (buffer == nullptr) {
@@ -116,10 +112,12 @@ void AvatarSetFetcher::Fetch(
         return;
     }
 
-    const bool loaded = target_set.Load(mode, buffer, expected_size);
-    heap_caps_free(buffer);  // AvatarSet::Load copies internally.
-
+    // Hand ownership to AvatarSet. On success it owns `buffer` and will
+    // free it on the next Unload() / destruction; on failure ownership
+    // stays with us and we must free it ourselves.
+    const bool loaded = target_set.AdoptOwnedBuffer(mode, buffer, expected_size);
     if (!loaded) {
+        heap_caps_free(buffer);
         on_complete(false, actual_sha256, "load_failed");
         return;
     }

--- a/firmware/main/boards/stackchan/avatar_set_fetcher.cc
+++ b/firmware/main/boards/stackchan/avatar_set_fetcher.cc
@@ -62,8 +62,9 @@ void AvatarSetFetcher::Fetch(
 
     const size_t content_length = http->GetBodyLength();
     if (content_length != expected_size) {
-        ESP_LOGW(TAG, "Fetch: Content-Length mismatch (got=%zu, expected=%zu)",
-                 content_length, expected_size);
+        ESP_LOGW(TAG, "Fetch: Content-Length mismatch (got=%u, expected=%u)",
+                 static_cast<unsigned int>(content_length),
+                 static_cast<unsigned int>(expected_size));
         http->Close();
         on_complete(false, "", "content_length_mismatch");
         return;
@@ -81,7 +82,8 @@ void AvatarSetFetcher::Fetch(
     uint8_t* buffer = static_cast<uint8_t*>(
         heap_caps_malloc(expected_size, MALLOC_CAP_SPIRAM));
     if (buffer == nullptr) {
-        ESP_LOGE(TAG, "Fetch: PSRAM staging allocation failed (size=%zu)", expected_size);
+        ESP_LOGE(TAG, "Fetch: PSRAM staging allocation failed (size=%u)",
+                 static_cast<unsigned int>(expected_size));
         http->Close();
         on_complete(false, "", "psram_oom");
         return;
@@ -93,7 +95,8 @@ void AvatarSetFetcher::Fetch(
         int n = http->Read(reinterpret_cast<char*>(buffer + total_read),
                            static_cast<int>(to_read));
         if (n <= 0) {
-            ESP_LOGE(TAG, "Fetch: Read failed at offset %zu (n=%d)", total_read, n);
+            ESP_LOGE(TAG, "Fetch: Read failed at offset %u (n=%d)",
+                     static_cast<unsigned int>(total_read), n);
             heap_caps_free(buffer);
             http->Close();
             on_complete(false, "", "read_failed");
@@ -121,7 +124,14 @@ void AvatarSetFetcher::Fetch(
         return;
     }
 
-    ESP_LOGI(TAG, "Fetch: avatar set loaded (mode=%d, bytes=%zu, sha256=%s)",
-             static_cast<int>(mode), expected_size, actual_sha256.c_str());
+    // ESP-IDF defaults to newlib-nano printf which does NOT support %zu;
+    // a stray %zu is silently skipped, shifting downstream arguments — in
+    // particular the next %s reads a size_t value as a const char* and
+    // dereferences it, blowing up with LoadProhibited @ <that size>.
+    // Cast size_t to unsigned int and use %u to stay nano-printf-safe.
+    ESP_LOGI(TAG, "Fetch: avatar set loaded (mode=%d, bytes=%u, sha256=%s)",
+             static_cast<int>(mode),
+             static_cast<unsigned int>(expected_size),
+             actual_sha256.c_str());
     on_complete(true, actual_sha256, "");
 }

--- a/firmware/main/boards/stackchan/avatar_set_fetcher.cc
+++ b/firmware/main/boards/stackchan/avatar_set_fetcher.cc
@@ -8,6 +8,7 @@
 #include <esp_log.h>
 
 #include "board.h"
+#include "display/display.h"
 
 #define TAG "AvatarSetFetcher"
 
@@ -115,7 +116,24 @@ void AvatarSetFetcher::Fetch(
     // Hand ownership to AvatarSet. On success it owns `buffer` and will
     // free it on the next Unload() / destruction; on failure ownership
     // stays with us and we must free it ourselves.
-    const bool loaded = target_set.AdoptOwnedBuffer(mode, buffer, expected_size);
+    //
+    // AdoptOwnedBuffer frees the previously adopted PSRAM buffer and
+    // rewrites the lv_image_dsc_t descriptors backing the on-screen avatar.
+    // OnAvatarSetFetch quiesced the autonomous LVGL writers (lipsync / mouth
+    // sequence / blink timers) before spawning this task, but that only
+    // blocks new set_src writes — the LVGL display task can still be reading
+    // the current descriptor source. Hold the display lock across the swap so
+    // a concurrent render can't race into a half-freed buffer or a
+    // half-cleared descriptor.
+    auto* display = board.GetDisplay();
+    bool loaded;
+    if (display != nullptr) {
+        DisplayLockGuard lock(display);
+        loaded = target_set.AdoptOwnedBuffer(mode, buffer, expected_size);
+    } else {
+        // Headless board (NoDisplay): no LVGL reader to race against.
+        loaded = target_set.AdoptOwnedBuffer(mode, buffer, expected_size);
+    }
     if (!loaded) {
         heap_caps_free(buffer);
         on_complete(false, actual_sha256, "load_failed");

--- a/firmware/main/boards/stackchan/avatar_set_fetcher.cc
+++ b/firmware/main/boards/stackchan/avatar_set_fetcher.cc
@@ -1,0 +1,127 @@
+#include "avatar_set_fetcher.h"
+
+#include <algorithm>
+#include <cstdio>
+
+#include <mbedtls/sha256.h>
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+
+#include "board.h"
+
+#define TAG "AvatarSetFetcher"
+
+namespace {
+
+constexpr size_t kReadChunkBytes = 4096;
+
+std::string Sha256Hex(const uint8_t* data, size_t size) {
+    uint8_t hash[32];
+    mbedtls_sha256(data, size, hash, 0);
+    char hex[65];
+    for (int i = 0; i < 32; ++i) {
+        std::snprintf(hex + i * 2, 3, "%02x", hash[i]);
+    }
+    hex[64] = '\0';
+    return std::string("sha256:") + hex;
+}
+
+}  // namespace
+
+void AvatarSetFetcher::Fetch(
+    AvatarSet& target_set,
+    const std::string& url,
+    const std::string& bearer_token,
+    AvatarSet::Mode mode,
+    size_t expected_size,
+    const std::string& expected_sha256,
+    CompletionCallback on_complete) {
+    auto& board = Board::GetInstance();
+    auto network = board.GetNetwork();
+    if (network == nullptr) {
+        ESP_LOGE(TAG, "Fetch: network is null");
+        on_complete(false, "", "http_open_failed");
+        return;
+    }
+
+    auto http = network->CreateHttp(0);
+    if (http == nullptr) {
+        ESP_LOGE(TAG, "Fetch: CreateHttp returned null");
+        on_complete(false, "", "http_open_failed");
+        return;
+    }
+
+    http->SetHeader("Authorization", (std::string("Bearer ") + bearer_token).c_str());
+    http->SetHeader("Accept", "application/octet-stream");
+
+    if (!http->Open("GET", url)) {
+        ESP_LOGE(TAG, "Fetch: Open failed for url=%s", url.c_str());
+        on_complete(false, "", "http_open_failed");
+        return;
+    }
+
+    const size_t content_length = http->GetBodyLength();
+    if (content_length != expected_size) {
+        ESP_LOGW(TAG, "Fetch: Content-Length mismatch (got=%zu, expected=%zu)",
+                 content_length, expected_size);
+        http->Close();
+        on_complete(false, "", "content_length_mismatch");
+        return;
+    }
+
+    // Allocate PSRAM staging buffer.
+    //
+    // Note: AvatarSet::Load currently copies its input into a fresh PSRAM
+    // buffer, so during Load() the firmware temporarily holds 2× the set
+    // size in PSRAM (this buffer + the AvatarSet's own buffer). For matrix
+    // mode (~3.3 MB) this approaches the PSRAM ceiling. A follow-up
+    // optimization is to switch AvatarSet::Load to ownership-transfer
+    // semantics (e.g., std::unique_ptr<uint8_t[], PsramDeleter>), at which
+    // point this buffer can be handed directly to AvatarSet without a copy.
+    uint8_t* buffer = static_cast<uint8_t*>(
+        heap_caps_malloc(expected_size, MALLOC_CAP_SPIRAM));
+    if (buffer == nullptr) {
+        ESP_LOGE(TAG, "Fetch: PSRAM staging allocation failed (size=%zu)", expected_size);
+        http->Close();
+        on_complete(false, "", "psram_oom");
+        return;
+    }
+
+    size_t total_read = 0;
+    while (total_read < expected_size) {
+        const size_t to_read = std::min(kReadChunkBytes, expected_size - total_read);
+        int n = http->Read(reinterpret_cast<char*>(buffer + total_read),
+                           static_cast<int>(to_read));
+        if (n <= 0) {
+            ESP_LOGE(TAG, "Fetch: Read failed at offset %zu (n=%d)", total_read, n);
+            heap_caps_free(buffer);
+            http->Close();
+            on_complete(false, "", "read_failed");
+            return;
+        }
+        total_read += static_cast<size_t>(n);
+    }
+    http->Close();
+
+    const std::string actual_sha256 = Sha256Hex(buffer, expected_size);
+
+    if (!expected_sha256.empty() && actual_sha256 != expected_sha256) {
+        ESP_LOGW(TAG, "Fetch: SHA256 mismatch (actual=%s expected=%s)",
+                 actual_sha256.c_str(), expected_sha256.c_str());
+        heap_caps_free(buffer);
+        on_complete(false, actual_sha256, "checksum_mismatch");
+        return;
+    }
+
+    const bool loaded = target_set.Load(mode, buffer, expected_size);
+    heap_caps_free(buffer);  // AvatarSet::Load copies internally.
+
+    if (!loaded) {
+        on_complete(false, actual_sha256, "load_failed");
+        return;
+    }
+
+    ESP_LOGI(TAG, "Fetch: avatar set loaded (mode=%d, bytes=%zu, sha256=%s)",
+             static_cast<int>(mode), expected_size, actual_sha256.c_str());
+    on_complete(true, actual_sha256, "");
+}

--- a/firmware/main/boards/stackchan/avatar_set_fetcher.h
+++ b/firmware/main/boards/stackchan/avatar_set_fetcher.h
@@ -7,16 +7,19 @@
 
 #include "avatar_set.h"
 
-// AvatarSetFetcher — HTTP fetch + checksum verify + AvatarSet::Load.
+// AvatarSetFetcher — HTTP fetch + checksum verify + AvatarSet adoption.
 //
 // Invoked when the gateway sends a WS `avatar_set_fetch` message containing
 // a URL, one-time bearer token, mode, expected size, and SHA256 checksum.
 // The fetcher performs an authenticated HTTP GET against the gateway's
 // staging endpoint (see docs/intent/stackchan_avatar_pipeline.md §C-2),
-// verifies the SHA256, and hands the raw RGB565 payload to AvatarSet::Load.
+// verifies the SHA256, and hands the raw RGB565 payload to AvatarSet via
+// AdoptOwnedBuffer() with ownership transfer (= no internal memcpy in the
+// target set; PSRAM peak during swap is held to old + new only).
 //
 // On any failure the previously loaded set (if any) is left intact —
-// AvatarSet::Load only commits when the new buffer is validated.
+// AvatarSet only commits on AdoptOwnedBuffer success, and the fetcher's
+// PSRAM buffer is freed in the failure path here.
 
 class AvatarSetFetcher {
 public:

--- a/firmware/main/boards/stackchan/avatar_set_fetcher.h
+++ b/firmware/main/boards/stackchan/avatar_set_fetcher.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <functional>
+#include <cstdint>
+#include <cstddef>
+
+#include "avatar_set.h"
+
+// AvatarSetFetcher — HTTP fetch + checksum verify + AvatarSet::Load.
+//
+// Invoked when the gateway sends a WS `avatar_set_fetch` message containing
+// a URL, one-time bearer token, mode, expected size, and SHA256 checksum.
+// The fetcher performs an authenticated HTTP GET against the gateway's
+// staging endpoint (see docs/intent/stackchan_avatar_pipeline.md §C-2),
+// verifies the SHA256, and hands the raw RGB565 payload to AvatarSet::Load.
+//
+// On any failure the previously loaded set (if any) is left intact —
+// AvatarSet::Load only commits when the new buffer is validated.
+
+class AvatarSetFetcher {
+public:
+    // Completion callback signature: (ok, actual_checksum, error_code).
+    // - ok=true: actual_checksum equals the expected checksum and Load
+    //   succeeded. error_code is empty.
+    // - ok=false: error_code is one of:
+    //     "http_open_failed", "content_length_mismatch",
+    //     "psram_oom", "read_failed", "checksum_mismatch", "load_failed".
+    //   actual_checksum is empty if the failure occurred before reading
+    //   completed.
+    using CompletionCallback = std::function<void(
+        bool ok,
+        const std::string& actual_checksum,
+        const std::string& error_code)>;
+
+    // Synchronously fetch + verify + load. Blocks the calling task until
+    // completion. Intended to be invoked from a worker task (= not from
+    // the WS receive callback directly).
+    static void Fetch(
+        AvatarSet& target_set,
+        const std::string& url,
+        const std::string& bearer_token,
+        AvatarSet::Mode mode,
+        size_t expected_size,
+        const std::string& expected_sha256,  // "sha256:<hex>" form, may be empty to skip
+        CompletionCallback on_complete);
+};

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -6036,10 +6036,17 @@ public:
         auto checksum = cJSON_GetObjectItem(root, "checksum");
         auto size_j   = cJSON_GetObjectItem(root, "expected_size");
 
+        // The gateway correlates avatar_set_loaded replies by checksum
+        // (see ESP32Connection._avatar_set_waiters). Reply with the
+        // requested checksum on every error path so a failure can wake
+        // the waiter promptly instead of timing out.
+        const std::string req_checksum =
+            cJSON_IsString(checksum) ? checksum->valuestring : "";
+
         if (!cJSON_IsString(url) || !cJSON_IsString(token) ||
             !cJSON_IsString(mode_j) || !cJSON_IsNumber(size_j)) {
             ESP_LOGW(TAG, "OnAvatarSetFetch: missing required fields");
-            SendAvatarSetLoadedError("", "missing_fields");
+            SendAvatarSetLoadedError(req_checksum, "missing_fields");
             return;
         }
 
@@ -6050,7 +6057,7 @@ public:
             mode_enum = AvatarSet::Mode::kMatrix;
         } else {
             ESP_LOGW(TAG, "OnAvatarSetFetch: unknown mode '%s'", mode_j->valuestring);
-            SendAvatarSetLoadedError("", "unknown_mode");
+            SendAvatarSetLoadedError(req_checksum, "unknown_mode");
             return;
         }
 
@@ -6062,7 +6069,7 @@ public:
         // mutex instance).
         if (avatar_fetch_in_progress_.exchange(true, std::memory_order_acq_rel)) {
             ESP_LOGW(TAG, "OnAvatarSetFetch: another fetch already in progress");
-            SendAvatarSetLoadedError("", "fetch_in_progress");
+            SendAvatarSetLoadedError(req_checksum, "fetch_in_progress");
             return;
         }
         EnsureAvatarPendingLock();
@@ -6099,7 +6106,7 @@ public:
             ESP_LOGE(TAG, "OnAvatarSetFetch: failed to create avatar_fetch task");
             delete context;
             avatar_fetch_in_progress_.store(false, std::memory_order_release);
-            SendAvatarSetLoadedError("", "task_create_failed");
+            SendAvatarSetLoadedError(req_checksum, "task_create_failed");
         }
     }
 
@@ -6122,14 +6129,23 @@ public:
     }
 
     void RunAvatarFetch(const AvatarFetchContext* ctx) {
+        // Capture expected_sha256 by value so the callback can fall back
+        // to it when AvatarSetFetcher reports an error before computing
+        // the actual checksum (HTTP error, size mismatch, allocation
+        // failure, etc.). The gateway's _avatar_set_waiters dict is keyed
+        // by checksum; replying with an empty key means the failure
+        // cannot resolve any waiter and the caller waits until timeout.
+        const std::string expected_sha256 = ctx->expected_sha256;
         AvatarSetFetcher::Fetch(
             avatar_set_,
             ctx->url, ctx->token,
             ctx->mode, ctx->expected_size, ctx->expected_sha256,
-            [](bool ok,
-               const std::string& actual_checksum,
-               const std::string& error_code) {
-                SendAvatarSetLoaded(ok, actual_checksum, error_code);
+            [expected_sha256](bool ok,
+                              const std::string& actual_checksum,
+                              const std::string& error_code) {
+                const std::string& correlation =
+                    actual_checksum.empty() ? expected_sha256 : actual_checksum;
+                SendAvatarSetLoaded(ok, correlation, error_code);
             });
 
         // Fetch finished (success or failure). Clear the in-progress flag

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -578,8 +578,8 @@ private:
     // ---- Avatar fetch in-progress quiescence (intent doc invariant #6) ---
     //
     // Between the WS `avatar_set_fetch` notify and `avatar_set_loaded`
-    // reply, AvatarSet::Load briefly atomically swaps the PSRAM buffer
-    // backing every face/eyes/mouth lv_image_dsc_t. Any LVGL set_src write
+    // reply, AvatarSet::AdoptOwnedBuffer briefly atomically swaps the PSRAM
+    // buffer backing every face/eyes/mouth lv_image_dsc_t. Any LVGL set_src write
     // during that window can land on a dangling pointer, so we suppress
     // writes for the whole fetch lifetime and remember the user's last
     // expressed intent. When the fetch completes (success or failure) we
@@ -3854,7 +3854,7 @@ private:
     }
 
     // Drain avatar_pending_ and apply it. Called from the avatar_fetch
-    // worker task after AvatarSet::Load returns (regardless of success);
+    // worker task after AvatarSet::AdoptOwnedBuffer returns (regardless of success);
     // the caller must have already cleared avatar_fetch_in_progress_ so
     // that the public SetAvatarExpression / SetMouthShape / set_blink
     // paths invoked here run their live LVGL writes instead of looping
@@ -6019,7 +6019,7 @@ public:
     // Phase 4.5 avatar (saiverse-stackchan-addon): handle the gateway's
     // `avatar_set_fetch` WS message. Parse url/token/mode/checksum/
     // expected_size, spawn a worker task that performs HTTP GET + SHA256
-    // verify + AvatarSet::Load, then send `avatar_set_loaded` back via
+    // verify + AvatarSet::AdoptOwnedBuffer, then send `avatar_set_loaded` back via
     // the protocol. Runs on the protocol receive task; the actual fetch
     // is delegated to a FreeRTOS task to avoid blocking the receive loop
     // while the LCD-sized payload flows in.
@@ -6070,8 +6070,8 @@ public:
             xSemaphoreGive(avatar_pending_lock_);
         }
         // Quiesce every autonomous LVGL writer so no set_src lands while
-        // AvatarSet::Load atomically swaps the PSRAM buffer backing each
-        // lv_image_dsc_t. The schedule timers / state machines restart
+        // AvatarSet::AdoptOwnedBuffer atomically swaps the PSRAM buffer backing
+        // each lv_image_dsc_t. The schedule timers / state machines restart
         // from ApplyPendingAvatarAfterFetch (blink) or the next tts.start
         // (TTS lipsync) once the fetch resolves.
         StopTtsLipSync();
@@ -6137,12 +6137,12 @@ public:
         // defer helpers and the pending state would never be drained.
         avatar_fetch_in_progress_.store(false, std::memory_order_release);
 
-        // After a successful Load the previously displayed face is still
+        // After a successful adoption the previously displayed face is still
         // pointing into the freed static-table data via avatar_img_; force a
         // refresh so the new AvatarSet entry is picked up by the next
         // RenderAvatarLocked() call. Skipped on failure (the old static
-        // image is still valid since AvatarSet::Load preserves the
-        // previous buffer on size/allocation errors).
+        // image is still valid since AvatarSet::AdoptOwnedBuffer preserves the
+        // previous buffer on size/allocation/HTTP/checksum errors).
         if (avatar_set_.is_loaded()) {
             SetAvatarExpressionIfActive(current_avatar_face_.c_str());
         }

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -29,6 +29,7 @@ using ScsBus = SCSCL;
 static inline bool ServoWritePosOk(int r) { return r > 0; }
 #endif
 #include "avatar_images.h"
+#include "avatar_set.h"
 
 #include <smooth_ui_toolkit.hpp>
 #include <esp_log.h>
@@ -533,6 +534,12 @@ private:
     lv_obj_t* avatar_img_ = nullptr;
     esp_timer_handle_t avatar_init_timer_ = nullptr;
     std::string current_avatar_face_ = "idle";
+
+    // Dynamic avatar set loaded via the load_avatar_set MCP tool. Stays
+    // unloaded by default — AvatarImageFor() then falls back to the static
+    // const tables in avatar_images.h (placeholder or local override). See
+    // docs/intent/stackchan_avatar_pipeline.md in the SAIVerse repository.
+    AvatarSet avatar_set_;
 
     // Phase 2: blinking + lip-sync overlay state.
     // Blink works as a four-step state machine driven by blink_step_timer_:
@@ -3668,10 +3675,42 @@ private:
         ESP_LOGI(TAG, "Si12T touch poll started (%d ms interval)", TOUCH_POLL_MS);
     }
 
+    // Map a face name to AvatarSet's 0-indexed slot, or -1 if unknown.
+    static int FaceNameToIndex(const char* face) {
+        if (face == nullptr) return -1;
+        if (strcmp(face, "idle") == 0)        return 0;
+        if (strcmp(face, "happy") == 0)       return 1;
+        if (strcmp(face, "thinking") == 0)    return 2;
+        if (strcmp(face, "sad") == 0)         return 3;
+        if (strcmp(face, "surprised") == 0)   return 4;
+        if (strcmp(face, "embarrassed") == 0) return 5;
+        return -1;
+    }
+
     // Map a face name (idle/happy/...) to the embedded RGB565 image.
     // Returns nullptr if the name is unknown.
-    static const lv_image_dsc_t* AvatarImageFor(const char* face) {
+    //
+    // Lookup order:
+    //   1. If a dynamic AvatarSet has been loaded via the load_avatar_set
+    //      MCP tool and its mode is layered, use AvatarSet::GetFace().
+    //   2. Otherwise fall back to the static const tables in avatar_images.h
+    //      (placeholder or avatar_images.local.cc override). This keeps
+    //      existing upstream users unaffected.
+    // Matrix-mode lookups (= face × eyes × mouth) live in a separate path
+    // and are not exposed through this function.
+    const lv_image_dsc_t* AvatarImageFor(const char* face) const {
         if (face == nullptr) return nullptr;
+
+        if (avatar_set_.is_loaded() && avatar_set_.mode() == AvatarSet::Mode::kLayered) {
+            const int idx = FaceNameToIndex(face);
+            if (idx >= 0) {
+                const lv_image_dsc_t* dsc = avatar_set_.GetFace(idx);
+                if (dsc != nullptr) {
+                    return dsc;
+                }
+            }
+        }
+
         if (strcmp(face, "idle") == 0)        return &avatar_idle;
         if (strcmp(face, "happy") == 0)       return &avatar_happy;
         if (strcmp(face, "thinking") == 0)    return &avatar_thinking;

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -542,6 +542,63 @@ private:
     // docs/intent/stackchan_avatar_pipeline.md in the SAIVerse repository.
     AvatarSet avatar_set_;
 
+    // ---- Avatar rendering state (Phase 4.5-a) -----------------------------
+    //
+    // The avatar is represented as three independent axes — face, eyes,
+    // mouth — each carrying a 0-indexed slot identical to AvatarSet's
+    // GetFace / GetEyes / GetMouth layout. The on-screen image is then
+    // derived from this state in a mode-aware way (RenderAvatarLocked):
+    //
+    //   - Layered mode (or AvatarSet not loaded): there is no compositor
+    //     on the firmware side — avatar_img_ shows exactly one image at a
+    //     time. active_layer_ selects which axis drives the current frame
+    //     (face during rest / mouth during set_mouth / eyes during blink),
+    //     matching the upstream Phase 2 behaviour where blink temporarily
+    //     replaces the face image and is then restored.
+    //   - Matrix mode: avatar_set_.GetMatrix(face, eyes, mouth) returns the
+    //     pre-composed image for the current (face, eyes, mouth) triple.
+    //     active_layer_ is ignored; every state change updates the
+    //     composed frame.
+    //
+    // Indices remain valid across mode switches so a future load_avatar_set
+    // call into a different mode does not lose the persona's current
+    // expression. current_avatar_face_ is kept as the string form because
+    // existing internal callers (touch reactions, SetAvatarOff resume,
+    // mouth-sequence restore) still address the face by name.
+    enum class ActiveLayer : uint8_t {
+        FACE = 0,
+        EYES = 1,
+        MOUTH = 2,
+    };
+    int current_face_index_ = 0;   // 0..5  (idle / happy / thinking / sad / surprised / embarrassed)
+    int current_eyes_index_ = 0;   // 0..2  (open / half / closed) — 0 is the resting state
+    int current_mouth_index_ = 0;  // 0..4  (closed / half / open / e / u) — 0 is the resting state
+    ActiveLayer active_layer_ = ActiveLayer::FACE;
+
+    // ---- Avatar fetch in-progress quiescence (intent doc invariant #6) ---
+    //
+    // Between the WS `avatar_set_fetch` notify and `avatar_set_loaded`
+    // reply, AvatarSet::Load briefly atomically swaps the PSRAM buffer
+    // backing every face/eyes/mouth lv_image_dsc_t. Any LVGL set_src write
+    // during that window can land on a dangling pointer, so we suppress
+    // writes for the whole fetch lifetime and remember the user's last
+    // expressed intent. When the fetch completes (success or failure) we
+    // apply the latest pending state — on success against the new set, on
+    // failure against the preserved old set.
+    //
+    // The flag is also the entry guard: a concurrent `avatar_set_fetch`
+    // gets rejected via avatar_set_loaded error="fetch_in_progress" rather
+    // than racing with the worker task already running.
+    std::atomic<bool> avatar_fetch_in_progress_{false};
+    SemaphoreHandle_t avatar_pending_lock_ = nullptr;
+    struct PendingAvatarState {
+        bool has_off = false;
+        bool has_face = false;     std::string face_name;
+        bool has_mouth = false;    std::string mouth_shape;
+        bool has_blink = false;    bool blink_enabled = false;
+    };
+    PendingAvatarState avatar_pending_;
+
     // Phase 2: blinking + lip-sync overlay state.
     // Blink works as a four-step state machine driven by blink_step_timer_:
     //   FACE -> EYES_HALF -> EYES_CLOSED -> EYES_HALF -> FACE (restore last face)
@@ -3721,6 +3778,115 @@ private:
         return nullptr;
     }
 
+    // ---- Avatar fetch pending machinery (intent doc invariant #6) -------
+
+    // Lazily create avatar_pending_lock_. Safe to call repeatedly.
+    void EnsureAvatarPendingLock() {
+        if (avatar_pending_lock_ == nullptr) {
+            avatar_pending_lock_ = xSemaphoreCreateMutex();
+        }
+    }
+
+    // Record the request as pending if a fetch is currently in progress.
+    // Returns true when the request was captured (caller should NOT proceed
+    // with the live LVGL write); false when no fetch is active and the
+    // caller should run its normal path.
+    //
+    // Each helper writes the relevant subset of avatar_pending_ — a later
+    // call within the same fetch window wins (the user's most recent
+    // intent is what we apply when the fetch completes). set_avatar(face)
+    // and set_avatar("off") are mutually exclusive on the face axis, so
+    // they clear each other; mouth and blink axes are independent.
+    bool DeferAvatarFaceIfFetching(const char* face) {
+        if (!avatar_fetch_in_progress_.load(std::memory_order_acquire)) return false;
+        EnsureAvatarPendingLock();
+        if (avatar_pending_lock_ == nullptr) return false;
+        if (xSemaphoreTake(avatar_pending_lock_, portMAX_DELAY) == pdTRUE) {
+            avatar_pending_.has_off = false;
+            avatar_pending_.has_face = true;
+            avatar_pending_.face_name = (face != nullptr) ? face : "";
+            xSemaphoreGive(avatar_pending_lock_);
+        }
+        ESP_LOGI(TAG, "SetAvatarExpression('%s') deferred (avatar fetch in progress)",
+                 face != nullptr ? face : "(null)");
+        return true;
+    }
+
+    bool DeferAvatarOffIfFetching() {
+        if (!avatar_fetch_in_progress_.load(std::memory_order_acquire)) return false;
+        EnsureAvatarPendingLock();
+        if (avatar_pending_lock_ == nullptr) return false;
+        if (xSemaphoreTake(avatar_pending_lock_, portMAX_DELAY) == pdTRUE) {
+            avatar_pending_.has_face = false;
+            avatar_pending_.face_name.clear();
+            avatar_pending_.has_off = true;
+            xSemaphoreGive(avatar_pending_lock_);
+        }
+        ESP_LOGI(TAG, "SetAvatarOff deferred (avatar fetch in progress)");
+        return true;
+    }
+
+    bool DeferAvatarMouthIfFetching(const char* shape) {
+        if (!avatar_fetch_in_progress_.load(std::memory_order_acquire)) return false;
+        EnsureAvatarPendingLock();
+        if (avatar_pending_lock_ == nullptr) return false;
+        if (xSemaphoreTake(avatar_pending_lock_, portMAX_DELAY) == pdTRUE) {
+            avatar_pending_.has_mouth = true;
+            avatar_pending_.mouth_shape = (shape != nullptr) ? shape : "";
+            xSemaphoreGive(avatar_pending_lock_);
+        }
+        ESP_LOGI(TAG, "SetMouthShape('%s') deferred (avatar fetch in progress)",
+                 shape != nullptr ? shape : "(null)");
+        return true;
+    }
+
+    bool DeferAvatarBlinkIfFetching(bool enabled) {
+        if (!avatar_fetch_in_progress_.load(std::memory_order_acquire)) return false;
+        EnsureAvatarPendingLock();
+        if (avatar_pending_lock_ == nullptr) return false;
+        if (xSemaphoreTake(avatar_pending_lock_, portMAX_DELAY) == pdTRUE) {
+            avatar_pending_.has_blink = true;
+            avatar_pending_.blink_enabled = enabled;
+            xSemaphoreGive(avatar_pending_lock_);
+        }
+        ESP_LOGI(TAG, "set_blink(%d) deferred (avatar fetch in progress)", (int)enabled);
+        return true;
+    }
+
+    // Drain avatar_pending_ and apply it. Called from the avatar_fetch
+    // worker task after AvatarSet::Load returns (regardless of success);
+    // the caller must have already cleared avatar_fetch_in_progress_ so
+    // that the public SetAvatarExpression / SetMouthShape / set_blink
+    // paths invoked here run their live LVGL writes instead of looping
+    // back through the defer helpers.
+    void ApplyPendingAvatarAfterFetch() {
+        PendingAvatarState pending;
+        EnsureAvatarPendingLock();
+        if (avatar_pending_lock_ == nullptr) return;
+        if (xSemaphoreTake(avatar_pending_lock_, portMAX_DELAY) == pdTRUE) {
+            pending = avatar_pending_;
+            avatar_pending_ = PendingAvatarState{};
+            xSemaphoreGive(avatar_pending_lock_);
+        }
+        if (pending.has_off) {
+            SetAvatarOff();
+            return;
+        }
+        if (pending.has_face) {
+            SetAvatarExpression(pending.face_name.c_str());
+        }
+        if (pending.has_mouth) {
+            SetMouthShape(pending.mouth_shape.c_str());
+        }
+        if (pending.has_blink) {
+            if (pending.blink_enabled) {
+                StartBlinkTimer();
+            } else {
+                StopBlinkTimer();
+            }
+        }
+    }
+
     // Create avatar_img_ on the active LVGL screen, scaled to fill the LCD.
     // Caller must hold the LVGL/display lock. Returns true on success or
     // when avatar_img_ already exists.
@@ -3776,6 +3942,12 @@ private:
             ESP_LOGW(TAG, "SetAvatarExpression('%s') ignored: display_ not ready", face);
             return false;
         }
+        // Avatar set fetch in progress — record the request and return
+        // success. ApplyPendingAvatarAfterFetch() will replay the latest
+        // captured face when the fetch completes.
+        if (DeferAvatarFaceIfFetching(face)) {
+            return true;
+        }
         bool was_off = (current_avatar_face_ == "off");
         bool ok;
         {
@@ -3811,6 +3983,9 @@ private:
         if (display_ == nullptr) {
             ESP_LOGW(TAG, "SetAvatarOff() ignored: display_ not ready");
             return false;
+        }
+        if (DeferAvatarOffIfFetching()) {
+            return true;
         }
         // Capture the previous blink state only on the first transition
         // into "off". A repeated set_avatar("off") while already off must
@@ -3920,9 +4095,10 @@ private:
             ESP_LOGW(TAG, "SetMouthShape('%s') ignored: display_ not ready", shape);
             return false;
         }
-        const lv_image_dsc_t* dsc = MouthImageFor(shape);
-        if (dsc == nullptr) {
-            return false;
+        const int idx = MouthShapeToIndex(shape);
+        if (idx < 0) return false;
+        if (DeferAvatarMouthIfFetching(shape)) {
+            return true;
         }
         DisplayLockGuard lock(display_);
         return SetPartImageLocked(dsc);
@@ -5050,9 +5226,17 @@ private:
             PropertyList({Property("enabled", kPropertyTypeBoolean)}),
             [this](const PropertyList& properties) -> ReturnValue {
                 bool enabled = properties["enabled"].value<bool>();
+                // blink_desired_ stays in sync with the user's intent
+                // regardless of which deferral path applies, so the
+                // mouth-sequence task and the avatar-fetch apply-pending
+                // path both see the latest value at their respective
+                // restore points.
                 blink_desired_.store(enabled, std::memory_order_release);
-                bool deferred = mouth_seq_active_.load(std::memory_order_acquire);
-                if (!deferred) {
+                bool deferred_by_fetch =
+                    DeferAvatarBlinkIfFetching(enabled);
+                bool deferred_by_mouth_seq =
+                    mouth_seq_active_.load(std::memory_order_acquire);
+                if (!deferred_by_fetch && !deferred_by_mouth_seq) {
                     if (enabled) {
                         StartBlinkTimer();
                     } else {
@@ -5062,11 +5246,15 @@ private:
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddBoolToObject(root, "enabled", enabled);
                 cJSON_AddBoolToObject(root, "ok", true);
-                if (deferred) {
+                if (deferred_by_fetch || deferred_by_mouth_seq) {
                     cJSON_AddBoolToObject(root, "deferred", true);
                 }
-                ESP_LOGI(TAG, "set_blink: enabled=%d deferred=%d",
-                         (int)enabled, deferred ? 1 : 0);
+                ESP_LOGI(TAG,
+                         "set_blink: enabled=%d deferred_by_fetch=%d "
+                         "deferred_by_mouth_seq=%d",
+                         (int)enabled,
+                         deferred_by_fetch ? 1 : 0,
+                         deferred_by_mouth_seq ? 1 : 0);
                 return root;
             });
 
@@ -5864,6 +6052,32 @@ public:
             return;
         }
 
+        // Take the in-progress guard. exchange(true) returns the previous
+        // value, so if another fetch was already running we reject this
+        // request rather than racing on avatar_set_'s PSRAM swap. The
+        // pending lock is created lazily (the defer helpers do the same;
+        // create it here so both producer and consumer share the same
+        // mutex instance).
+        if (avatar_fetch_in_progress_.exchange(true, std::memory_order_acq_rel)) {
+            ESP_LOGW(TAG, "OnAvatarSetFetch: another fetch already in progress");
+            SendAvatarSetLoadedError("", "fetch_in_progress");
+            return;
+        }
+        EnsureAvatarPendingLock();
+        if (avatar_pending_lock_ != nullptr &&
+            xSemaphoreTake(avatar_pending_lock_, portMAX_DELAY) == pdTRUE) {
+            avatar_pending_ = PendingAvatarState{};
+            xSemaphoreGive(avatar_pending_lock_);
+        }
+        // Quiesce every autonomous LVGL writer so no set_src lands while
+        // AvatarSet::Load atomically swaps the PSRAM buffer backing each
+        // lv_image_dsc_t. The schedule timers / state machines restart
+        // from ApplyPendingAvatarAfterFetch (blink) or the next tts.start
+        // (TTS lipsync) once the fetch resolves.
+        StopTtsLipSync();
+        RequestMouthSequenceCancel();
+        StopBlinkTimer();
+
         auto* context = new AvatarFetchContext;
         context->board = this;
         context->url = url->valuestring;
@@ -5882,6 +6096,7 @@ public:
         if (ok != pdPASS) {
             ESP_LOGE(TAG, "OnAvatarSetFetch: failed to create avatar_fetch task");
             delete context;
+            avatar_fetch_in_progress_.store(false, std::memory_order_release);
             SendAvatarSetLoadedError("", "task_create_failed");
         }
     }
@@ -5915,13 +6130,29 @@ public:
                 SendAvatarSetLoaded(ok, actual_checksum, error_code);
             });
 
+        // Fetch finished (success or failure). Clear the in-progress flag
+        // BEFORE replaying pending state — otherwise the public
+        // SetAvatarExpression / SetMouthShape / StartBlinkTimer calls
+        // inside ApplyPendingAvatarAfterFetch would loop back into the
+        // defer helpers and the pending state would never be drained.
+        avatar_fetch_in_progress_.store(false, std::memory_order_release);
+
         // After a successful Load the previously displayed face is still
         // pointing into the freed static-table data via avatar_img_; force a
-        // refresh so the new AvatarSet entry is picked up by AvatarImageFor.
-        // Skipped on failure (the old image is still valid).
+        // refresh so the new AvatarSet entry is picked up by the next
+        // RenderAvatarLocked() call. Skipped on failure (the old static
+        // image is still valid since AvatarSet::Load preserves the
+        // previous buffer on size/allocation errors).
         if (avatar_set_.is_loaded()) {
             SetAvatarExpressionIfActive(current_avatar_face_.c_str());
         }
+
+        // Replay the latest face / mouth / blink intent the user expressed
+        // while the fetch was running. Order: "off" wins over a face if
+        // both were issued (mutually exclusive on the face axis); blink
+        // restoration happens last so a successful fetch doesn't restart
+        // blink if the user disabled it mid-fetch.
+        ApplyPendingAvatarAfterFetch();
     }
 
     static void SendAvatarSetLoaded(

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -4095,8 +4095,10 @@ private:
             ESP_LOGW(TAG, "SetMouthShape('%s') ignored: display_ not ready", shape);
             return false;
         }
-        const int idx = MouthShapeToIndex(shape);
-        if (idx < 0) return false;
+        const lv_image_dsc_t* dsc = MouthImageFor(shape);
+        if (dsc == nullptr) {
+            return false;
+        }
         if (DeferAvatarMouthIfFetching(shape)) {
             return true;
         }

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -30,6 +30,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #endif
 #include "avatar_images.h"
 #include "avatar_set.h"
+#include "avatar_set_fetcher.h"
 
 #include <smooth_ui_toolkit.hpp>
 #include <esp_log.h>
@@ -5826,6 +5827,129 @@ public:
     virtual void OnTtsStop() override {
         StopTtsLipSync();
     }
+
+    // Phase 4.5 avatar (saiverse-stackchan-addon): handle the gateway's
+    // `avatar_set_fetch` WS message. Parse url/token/mode/checksum/
+    // expected_size, spawn a worker task that performs HTTP GET + SHA256
+    // verify + AvatarSet::Load, then send `avatar_set_loaded` back via
+    // the protocol. Runs on the protocol receive task; the actual fetch
+    // is delegated to a FreeRTOS task to avoid blocking the receive loop
+    // while the LCD-sized payload flows in.
+    virtual void OnAvatarSetFetch(const cJSON* root) override {
+        if (root == nullptr) {
+            ESP_LOGW(TAG, "OnAvatarSetFetch: root is null");
+            return;
+        }
+        auto url      = cJSON_GetObjectItem(root, "url");
+        auto token    = cJSON_GetObjectItem(root, "token");
+        auto mode_j   = cJSON_GetObjectItem(root, "mode");
+        auto checksum = cJSON_GetObjectItem(root, "checksum");
+        auto size_j   = cJSON_GetObjectItem(root, "expected_size");
+
+        if (!cJSON_IsString(url) || !cJSON_IsString(token) ||
+            !cJSON_IsString(mode_j) || !cJSON_IsNumber(size_j)) {
+            ESP_LOGW(TAG, "OnAvatarSetFetch: missing required fields");
+            SendAvatarSetLoadedError("", "missing_fields");
+            return;
+        }
+
+        AvatarSet::Mode mode_enum;
+        if (strcmp(mode_j->valuestring, "layered") == 0) {
+            mode_enum = AvatarSet::Mode::kLayered;
+        } else if (strcmp(mode_j->valuestring, "matrix") == 0) {
+            mode_enum = AvatarSet::Mode::kMatrix;
+        } else {
+            ESP_LOGW(TAG, "OnAvatarSetFetch: unknown mode '%s'", mode_j->valuestring);
+            SendAvatarSetLoadedError("", "unknown_mode");
+            return;
+        }
+
+        auto* context = new AvatarFetchContext;
+        context->board = this;
+        context->url = url->valuestring;
+        context->token = token->valuestring;
+        context->mode = mode_enum;
+        context->expected_size = static_cast<size_t>(size_j->valuedouble);
+        context->expected_sha256 = cJSON_IsString(checksum) ? checksum->valuestring : "";
+
+        BaseType_t ok = xTaskCreate(
+            &StackChanBoard::AvatarFetchTaskTrampoline,
+            "avatar_fetch",
+            8192,
+            context,
+            tskIDLE_PRIORITY + 2,
+            nullptr);
+        if (ok != pdPASS) {
+            ESP_LOGE(TAG, "OnAvatarSetFetch: failed to create avatar_fetch task");
+            delete context;
+            SendAvatarSetLoadedError("", "task_create_failed");
+        }
+    }
+
+    // ---- Phase 4.5 avatar helpers --------------------------------------
+
+    struct AvatarFetchContext {
+        StackChanBoard* board;
+        std::string url;
+        std::string token;
+        AvatarSet::Mode mode;
+        size_t expected_size;
+        std::string expected_sha256;
+    };
+
+    static void AvatarFetchTaskTrampoline(void* arg) {
+        auto* ctx = static_cast<AvatarFetchContext*>(arg);
+        ctx->board->RunAvatarFetch(ctx);
+        delete ctx;
+        vTaskDelete(nullptr);
+    }
+
+    void RunAvatarFetch(const AvatarFetchContext* ctx) {
+        AvatarSetFetcher::Fetch(
+            avatar_set_,
+            ctx->url, ctx->token,
+            ctx->mode, ctx->expected_size, ctx->expected_sha256,
+            [](bool ok,
+               const std::string& actual_checksum,
+               const std::string& error_code) {
+                SendAvatarSetLoaded(ok, actual_checksum, error_code);
+            });
+
+        // After a successful Load the previously displayed face is still
+        // pointing into the freed static-table data via avatar_img_; force a
+        // refresh so the new AvatarSet entry is picked up by AvatarImageFor.
+        // Skipped on failure (the old image is still valid).
+        if (avatar_set_.is_loaded()) {
+            SetAvatarExpressionIfActive(current_avatar_face_.c_str());
+        }
+    }
+
+    static void SendAvatarSetLoaded(
+        bool ok, const std::string& checksum, const std::string& error_code) {
+        cJSON* root = cJSON_CreateObject();
+        if (root == nullptr) return;
+        cJSON_AddStringToObject(root, "type", "avatar_set_loaded");
+        cJSON_AddStringToObject(root, "checksum", checksum.c_str());
+        cJSON_AddBoolToObject(root, "ok", ok);
+        if (ok || error_code.empty()) {
+            cJSON_AddNullToObject(root, "error");
+        } else {
+            cJSON_AddStringToObject(root, "error", error_code.c_str());
+        }
+        char* str = cJSON_PrintUnformatted(root);
+        if (str != nullptr) {
+            Application::GetInstance().SendJsonString(std::string(str));
+            cJSON_free(str);
+        }
+        cJSON_Delete(root);
+    }
+
+    static void SendAvatarSetLoadedError(
+        const std::string& checksum, const std::string& error_code) {
+        SendAvatarSetLoaded(false, checksum, error_code);
+    }
+
+    // --------------------------------------------------------------------
 
     virtual Backlight *GetBacklight() override {
         static CustomBacklight backlight(pmic_);

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -6054,7 +6054,18 @@ public:
         if (strcmp(mode_j->valuestring, "layered") == 0) {
             mode_enum = AvatarSet::Mode::kLayered;
         } else if (strcmp(mode_j->valuestring, "matrix") == 0) {
-            mode_enum = AvatarSet::Mode::kMatrix;
+            // Matrix-mode rendering is wired in PR #211 (PR-E2). This PR
+            // (PR-E1) exposes only the layered render path: AvatarImageFor()
+            // consumes the dynamic set for kLayered only, and the matrix
+            // lookup (face × eyes × mouth) is not present yet. Accepting a
+            // matrix load here would succeed at AdoptOwnedBuffer but never
+            // render — the display lookup falls through to the static
+            // avatar_images tables — handing the gateway a false success
+            // signal. Reject explicitly until #211 wires the matrix lookup
+            // and lifts this guard.
+            ESP_LOGW(TAG, "OnAvatarSetFetch: matrix mode not supported until PR #211");
+            SendAvatarSetLoadedError(req_checksum, "matrix_mode_unsupported");
+            return;
         } else {
             ESP_LOGW(TAG, "OnAvatarSetFetch: unknown mode '%s'", mode_j->valuestring);
             SendAvatarSetLoadedError(req_checksum, "unknown_mode");

--- a/firmware/main/protocols/protocol.h
+++ b/firmware/main/protocols/protocol.h
@@ -82,6 +82,12 @@ public:
     virtual void SendAbortSpeaking(AbortReason reason);
     virtual void SendMcpMessage(const std::string& message);
 
+    // Phase 4.5 avatar: expose SendText so boards / Application can send
+    // ad-hoc JSON notifications (e.g. avatar_set_loaded) without going
+    // through the MCP wrapper. Concrete subclasses already implement this
+    // for the audio / MCP paths; making it public is a no-op for them.
+    virtual bool SendText(const std::string& text) = 0;
+
 protected:
     std::function<void(const cJSON* root)> on_incoming_json_;
     std::function<void(std::unique_ptr<AudioStreamPacket> packet)> on_incoming_audio_;
@@ -97,7 +103,6 @@ protected:
     std::string session_id_;
     std::chrono::time_point<std::chrono::steady_clock> last_incoming_time_;
 
-    virtual bool SendText(const std::string& text) = 0;
     virtual void SetError(const std::string& message);
     virtual bool IsTimeout() const;
 };

--- a/gateway/stackchan_mcp/capture_server.py
+++ b/gateway/stackchan_mcp/capture_server.py
@@ -10,10 +10,14 @@ can view the image via the Read tool.
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import logging
 import os
+import secrets
 import time
+from dataclasses import dataclass
 
 from aiohttp import web
 
@@ -21,6 +25,24 @@ logger = logging.getLogger(__name__)
 
 CAPTURE_DIR = os.path.expanduser("~/.stackchan/captures")
 CAPTURE_TOKEN_KEY = web.AppKey("capture_token", str)
+
+# Phase 4.5 avatar (saiverse-stackchan-addon): in-memory staging for
+# one-time avatar set downloads. See docs/intent/stackchan_avatar_pipeline.md
+# §C-2 in the SAIVerse repository.
+AVATAR_SETS_KEY = web.AppKey("avatar_sets", dict)
+AVATAR_SETS_LOCK_KEY = web.AppKey("avatar_sets_lock", asyncio.Lock)
+
+# A staging entry is GC'd if it hasn't been fetched within this window.
+AVATAR_SET_STAGING_TTL_SEC = 120.0
+
+
+@dataclass(frozen=True)
+class _AvatarStaging:
+    token: str
+    mode: str
+    payload: bytes
+    sha256: str
+    created_at: float
 
 
 def _is_authorized(auth_header: str, expected_token: str) -> bool:
@@ -83,9 +105,96 @@ async def handle_capture(request: web.Request) -> web.Response:
     )
 
 
+async def stage_avatar_set(
+    app: web.Application,
+    mode: str,
+    payload: bytes,
+) -> tuple[str, str, str]:
+    """Stage an avatar set for one-time HTTP download.
+
+    Returns (short_id, token, sha256). The caller hands these to the
+    device via WS avatar_set_fetch; the device performs a GET against
+    /avatar_set/{short_id} with Authorization: Bearer <token>.
+
+    The staging entry is consumed on the first successful fetch and
+    GC'd after AVATAR_SET_STAGING_TTL_SEC if never fetched.
+    """
+    if mode not in ("layered", "matrix"):
+        raise ValueError(f"unknown avatar mode: {mode}")
+
+    short_id = secrets.token_hex(8)
+    token = secrets.token_urlsafe(32)
+    sha256 = "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    staging = _AvatarStaging(
+        token=token,
+        mode=mode,
+        payload=payload,
+        sha256=sha256,
+        created_at=time.time(),
+    )
+
+    sets = app[AVATAR_SETS_KEY]
+    async with app[AVATAR_SETS_LOCK_KEY]:
+        # Best-effort GC of stale entries before inserting.
+        now = time.time()
+        expired = [
+            k for k, v in sets.items()
+            if now - v.created_at > AVATAR_SET_STAGING_TTL_SEC
+        ]
+        for k in expired:
+            sets.pop(k, None)
+        sets[short_id] = staging
+
+    logger.info(
+        "Staged avatar set: short_id=%s mode=%s bytes=%d sha256=%s",
+        short_id, mode, len(payload), sha256,
+    )
+    return short_id, token, sha256
+
+
+async def handle_avatar_set_fetch(request: web.Request) -> web.Response:
+    """Serve a staged avatar set (one-time)."""
+    short_id = request.match_info.get("short_id", "")
+    if not short_id:
+        return web.Response(status=400, text="missing short_id")
+
+    sets = request.app[AVATAR_SETS_KEY]
+    async with request.app[AVATAR_SETS_LOCK_KEY]:
+        staging = sets.pop(short_id, None)
+
+    if staging is None:
+        return web.Response(status=404, text="not_found_or_consumed")
+
+    if time.time() - staging.created_at > AVATAR_SET_STAGING_TTL_SEC:
+        return web.Response(status=410, text="staging_expired")
+
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {staging.token}":
+        logger.warning("Avatar set fetch auth rejected for short_id=%s", short_id)
+        return web.Response(status=401, text="unauthorized")
+
+    logger.info(
+        "Serving avatar set: short_id=%s mode=%s bytes=%d",
+        short_id, staging.mode, len(staging.payload),
+    )
+    return web.Response(
+        body=staging.payload,
+        content_type="application/octet-stream",
+        headers={
+            "X-Avatar-Mode": staging.mode,
+            "X-Avatar-Sha256": staging.sha256,
+            "Content-Length": str(len(staging.payload)),
+        },
+    )
+
+
 def create_capture_app(capture_token: str = "") -> web.Application:
     """Create the HTTP capture application."""
     app = web.Application()
     app[CAPTURE_TOKEN_KEY] = capture_token
+    app[AVATAR_SETS_KEY] = {}
+    app[AVATAR_SETS_LOCK_KEY] = asyncio.Lock()
     app.router.add_post("/capture", handle_capture)
+    app.router.add_get("/avatar_set/{short_id}", handle_avatar_set_fetch)
     return app

--- a/gateway/stackchan_mcp/capture_server.py
+++ b/gateway/stackchan_mcp/capture_server.py
@@ -160,19 +160,30 @@ async def handle_avatar_set_fetch(request: web.Request) -> web.Response:
         return web.Response(status=400, text="missing short_id")
 
     sets = request.app[AVATAR_SETS_KEY]
+    # Validate the request fully (existence, TTL, auth) before consuming
+    # the staged entry. An unauthenticated probe must not be able to
+    # invalidate a legitimate transfer just by guessing the short_id,
+    # and a real fetch that fails auth due to a transient header issue
+    # must still find the entry on retry.
     async with request.app[AVATAR_SETS_LOCK_KEY]:
-        staging = sets.pop(short_id, None)
+        staging = sets.get(short_id)
+        if staging is None:
+            return web.Response(status=404, text="not_found_or_consumed")
 
-    if staging is None:
-        return web.Response(status=404, text="not_found_or_consumed")
+        if time.time() - staging.created_at > AVATAR_SET_STAGING_TTL_SEC:
+            # Expired — drop the slot so it doesn't linger.
+            sets.pop(short_id, None)
+            return web.Response(status=410, text="staging_expired")
 
-    if time.time() - staging.created_at > AVATAR_SET_STAGING_TTL_SEC:
-        return web.Response(status=410, text="staging_expired")
+        auth = request.headers.get("Authorization", "")
+        if auth != f"Bearer {staging.token}":
+            logger.warning(
+                "Avatar set fetch auth rejected for short_id=%s", short_id
+            )
+            return web.Response(status=401, text="unauthorized")
 
-    auth = request.headers.get("Authorization", "")
-    if auth != f"Bearer {staging.token}":
-        logger.warning("Avatar set fetch auth rejected for short_id=%s", short_id)
-        return web.Response(status=401, text="unauthorized")
+        # Auth confirmed: consume the one-time entry now.
+        sets.pop(short_id, None)
 
     logger.info(
         "Serving avatar set: short_id=%s mode=%s bytes=%d",

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -67,6 +67,10 @@ class ESP32Connection:
         self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
         self._connected = True
         self._initialized = False
+        # Phase 4.5 avatar: pending load_avatar_set calls waiting for the
+        # device's `avatar_set_loaded` reply. Keyed by expected checksum
+        # so that overlapping fetches (different sets) can be discriminated.
+        self._avatar_set_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
         # Device-declared WebSocket protocol version (from the hello
         # message). Defaults to 1, which matches the firmware's default
         # (firmware/main/protocols/websocket_protocol.h: ``version_ = 1``)
@@ -171,6 +175,64 @@ class ESP32Connection:
         return await self.send_mcp_request(
             "tools/call", {"name": name, "arguments": arguments}
         )
+
+    async def send_avatar_set_fetch(
+        self,
+        url: str,
+        token: str,
+        mode: str,
+        checksum: str,
+        expected_size: int,
+        timeout: float = 60.0,
+    ) -> dict[str, Any]:
+        """Send avatar_set_fetch notification and wait for avatar_set_loaded.
+
+        Returns the device's reply dict ({ok, checksum, error}). Returns a
+        synthesized {ok: False, error: ...} dict on timeout or send failure.
+        """
+        if not self._connected:
+            return {"ok": False, "checksum": checksum, "error": "not_connected"}
+
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+        # Last-writer-wins on duplicate checksum: cancel the previous waiter
+        # so the same set being re-pushed doesn't strand callers.
+        previous = self._avatar_set_waiters.pop(checksum, None)
+        if previous is not None and not previous.done():
+            previous.cancel()
+        self._avatar_set_waiters[checksum] = future
+
+        msg = {
+            "type": "avatar_set_fetch",
+            "url": url,
+            "token": token,
+            "mode": mode,
+            "checksum": checksum,
+            "expected_size": expected_size,
+        }
+        try:
+            await self._ws.send(json.dumps(msg))
+            result = await asyncio.wait_for(future, timeout=timeout)
+            return result
+        except asyncio.TimeoutError:
+            self._avatar_set_waiters.pop(checksum, None)
+            return {"ok": False, "checksum": checksum, "error": "device_timeout"}
+        except asyncio.CancelledError:
+            return {"ok": False, "checksum": checksum, "error": "superseded"}
+        except Exception as exc:
+            self._avatar_set_waiters.pop(checksum, None)
+            return {"ok": False, "checksum": checksum, "error": f"send_failed: {exc}"}
+
+    def handle_avatar_set_loaded(self, payload: dict[str, Any]) -> None:
+        """Resolve a pending send_avatar_set_fetch by checksum."""
+        checksum = payload.get("checksum", "")
+        future = self._avatar_set_waiters.pop(checksum, None)
+        if future is not None and not future.done():
+            future.set_result(payload)
+        else:
+            logger.warning(
+                "avatar_set_loaded for unknown checksum=%s (no pending waiter)",
+                checksum,
+            )
 
     def handle_response(self, payload: dict[str, Any]) -> None:
         """Handle an incoming MCP response from ESP32."""
@@ -497,6 +559,13 @@ class ESP32Manager:
                     payload = data.get("payload", {})
                     connection.handle_response(payload)
 
+                elif msg_type == "avatar_set_loaded":
+                    # Phase 4.5 avatar (saiverse-stackchan-addon): device
+                    # reports the result of a load_avatar_set fetch (see
+                    # docs/intent/stackchan_avatar_pipeline.md §C-3 in
+                    # the SAIVerse repository).
+                    connection.handle_avatar_set_loaded(data)
+
                 else:
                     logger.debug("ESP32 message type=%s (ignored)", msg_type)
 
@@ -574,6 +643,28 @@ class ESP32Manager:
             if connection is not self._connection or not connection.connected:
                 return None, {"code": -32000, "message": "ESP32 not connected"}
             return await connection.call_tool(name, arguments)
+
+    async def send_avatar_set_fetch(
+        self,
+        url: str,
+        token: str,
+        mode: str,
+        checksum: str,
+        expected_size: int,
+        timeout: float = 60.0,
+    ) -> dict[str, Any]:
+        """Forward an avatar_set_fetch to the device and await the reply.
+
+        Phase 4.5 avatar (saiverse-stackchan-addon). Returns a dict with
+        keys {ok, checksum, error}; ok=False is returned with a synthetic
+        error when no device is connected (rather than raising) so the
+        MCP tool surfaces a clean error JSON to the caller.
+        """
+        if not self._connection or not self._connection.connected:
+            return {"ok": False, "checksum": checksum, "error": "no_device"}
+        return await self._connection.send_avatar_set_fetch(
+            url, token, mode, checksum, expected_size, timeout
+        )
 
     async def send_audio_frame(self, opus_frame: bytes) -> None:
         """Push a single Opus frame to the connected device.

--- a/gateway/stackchan_mcp/gateway.py
+++ b/gateway/stackchan_mcp/gateway.py
@@ -12,7 +12,7 @@ import os
 
 from aiohttp import web
 
-from .capture_server import create_capture_app
+from .capture_server import create_capture_app, stage_avatar_set
 from .esp32_client import ESP32Manager
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,9 @@ class Gateway:
         self.esp32 = ESP32Manager()
         self._running = False
         self._http_runner: web.AppRunner | None = None
+        # Phase 4.5 avatar: kept so load_avatar_set can stage payloads
+        # against the same web.Application that serves /avatar_set/{id}.
+        self._capture_app: web.Application | None = None
 
     @property
     def vision_url(self) -> str:
@@ -88,8 +91,10 @@ class Gateway:
             vision_token=self.vision_token,
         )
 
-        # Start HTTP capture server
+        # Start HTTP capture server. Same web.Application also serves
+        # the Phase 4.5 avatar /avatar_set/{short_id} endpoint.
         app = create_capture_app(capture_token=self.vision_token)
+        self._capture_app = app
         self._http_runner = web.AppRunner(app)
         await self._http_runner.setup()
         site = web.TCPSite(self._http_runner, host, capture_port)
@@ -107,8 +112,79 @@ class Gateway:
         if self._http_runner:
             await self._http_runner.cleanup()
             self._http_runner = None
+        self._capture_app = None
         await self.esp32.stop()
         logger.info("Gateway stopped")
+
+    # ---- Phase 4.5 avatar (saiverse-stackchan-addon) ------------------
+
+    @property
+    def avatar_set_base_url(self) -> str:
+        """Base URL the device should hit for /avatar_set/{short_id}.
+
+        Reuses vision_url so the device reaches this gateway over the
+        same network path it already uses for camera POSTs (VISION_HOST
+        / VISION_URL). The trailing /capture component is stripped.
+        """
+        url = self.vision_url
+        if url.endswith("/capture"):
+            return url[: -len("/capture")]
+        return url
+
+    async def load_avatar_set(
+        self,
+        archive_path: str,
+        mode: str,
+        timeout: float = 60.0,
+    ) -> dict:
+        """Stage an avatar set + notify the device + await its reply.
+
+        See docs/intent/stackchan_avatar_pipeline.md §C in the SAIVerse
+        repository for the protocol. ``archive_path`` is the path to a
+        local file containing the raw RGB565 payload (gateway expects
+        the addon to have already converted PNG/PIL output to RGB565).
+        """
+        if self._capture_app is None:
+            return {"ok": False, "error": "gateway_not_started"}
+        if not os.path.exists(archive_path):
+            return {"ok": False, "error": f"archive_not_found: {archive_path}"}
+
+        with open(archive_path, "rb") as f:
+            payload = f.read()
+
+        kimg_bytes = 160 * 120 * 2  # 38_400 — matches AvatarSet::kImageBytes
+        expected = {
+            "layered": 14 * kimg_bytes,   # 537_600
+            "matrix":  90 * kimg_bytes,   # 3_456_000
+        }.get(mode)
+        if expected is None:
+            return {"ok": False, "error": f"unknown_mode: {mode}"}
+        if len(payload) != expected:
+            return {
+                "ok": False,
+                "error": f"size_mismatch: got={len(payload)} expected={expected} (mode={mode})",
+            }
+
+        try:
+            short_id, token, sha256 = await stage_avatar_set(
+                self._capture_app, mode, payload
+            )
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}
+
+        url = f"{self.avatar_set_base_url}/avatar_set/{short_id}"
+        result = await self.esp32.send_avatar_set_fetch(
+            url=url,
+            token=token,
+            mode=mode,
+            checksum=sha256,
+            expected_size=len(payload),
+            timeout=timeout,
+        )
+        # Surface the staging metadata for caller-side observability.
+        result.setdefault("checksum", sha256)
+        result["bytes_transferred"] = len(payload) if result.get("ok") else 0
+        return result
 
 
 # Singleton gateway instance, shared between stdio server and ESP32 manager

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -581,135 +581,49 @@ def create_server() -> Server:
                 },
             ),
             Tool(
-                name="i2c_scan",
+                name="load_avatar_set",
                 description=(
-                    "Scan the external I2C bus on Grove Port A and return "
-                    "all 7-bit addresses (probe range 0x08..0x77, "
-                    "excluding I2C reserved ranges) that ACK a probe. Use "
-                    "this to discover attached M5Stack Unit modules "
-                    "(ENV III, ToF, gas sensor, PaHub, etc.). On-board ICs "
-                    "on the internal bus are NOT included (this tool "
-                    "operates on a physically separate bus). Returns "
-                    "{\"ok\": true, \"addresses\": [...]}."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {},
-                },
-            ),
-            Tool(
-                name="i2c_read",
-                description=(
-                    "Read n_bytes from an I2C device at 7-bit address "
-                    "`addr` on Grove Port A. Use this for protocols that "
-                    "read the device's current register / output without "
-                    "a preceding write. For typical 'write register "
-                    "address, then read' patterns, use `i2c_write_read` "
-                    "instead. Returns "
-                    "{\"ok\": true, \"bytes\": [...]} or "
-                    "{\"ok\": false, \"error\": \"ESP_ERR_TIMEOUT\"} on NACK."
+                    "Load a dynamic avatar set onto the connected ESP32 "
+                    "(Phase 4.5 avatar pipeline). The gateway stages the "
+                    "payload on its HTTP server, notifies the device via "
+                    "WebSocket, and the device fetches + SHA256-verifies + "
+                    "loads it into PSRAM. ``archive_path`` must point to a "
+                    "raw RGB565 file on the gateway host: layered mode = "
+                    "14 frames (face 6 + eyes 3 + mouth 5) totalling "
+                    "537,600 bytes; matrix mode = 90 frames (6 × 3 × 5) "
+                    "totalling 3,456,000 bytes. Returns ok / checksum / "
+                    "bytes_transferred / error."
                 ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "addr": {
-                            "type": "integer",
+                        "archive_path": {
+                            "type": "string",
                             "description": (
-                                "7-bit I2C address; range 0x08..0x77 "
-                                "(I2C reserved ranges excluded — matches "
-                                "the i2c_scan probe range)."
+                                "Filesystem path on the gateway host to "
+                                "the raw RGB565 payload."
                             ),
-                            "minimum": 8,
-                            "maximum": 119,
                         },
-                        "n_bytes": {
-                            "type": "integer",
-                            "description": "Bytes to read (1..256).",
-                            "minimum": 1,
-                            "maximum": 256,
+                        "mode": {
+                            "type": "string",
+                            "enum": ["layered", "matrix"],
+                            "description": (
+                                "'layered' (14 frames, ~525 KB) or "
+                                "'matrix' (90 frames, ~3.3 MB)."
+                            ),
+                        },
+                        "timeout": {
+                            "type": "number",
+                            "description": (
+                                "Max seconds to wait for the device's "
+                                "avatar_set_loaded reply."
+                            ),
+                            "default": 60.0,
+                            "minimum": 5.0,
+                            "maximum": 300.0,
                         },
                     },
-                    "required": ["addr", "n_bytes"],
-                },
-            ),
-            Tool(
-                name="i2c_write",
-                description=(
-                    "Write bytes to an I2C device at 7-bit address `addr` "
-                    "on Grove Port A. `bytes` is an array of integers "
-                    "(0..255). This tool operates on the external Port A "
-                    "bus only; on-board ICs (PMIC, AW9523, touch, etc.) "
-                    "on the internal bus are not reachable."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "addr": {
-                            "type": "integer",
-                            "description": (
-                                "7-bit I2C address; range 0x08..0x77 "
-                                "(I2C reserved ranges excluded — matches "
-                                "the i2c_scan probe range)."
-                            ),
-                            "minimum": 8,
-                            "maximum": 119,
-                        },
-                        "bytes": {
-                            "type": "array",
-                            "description": "Bytes to write (each 0..255).",
-                            "items": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 255,
-                            },
-                        },
-                    },
-                    "required": ["addr", "bytes"],
-                },
-            ),
-            Tool(
-                name="i2c_write_read",
-                description=(
-                    "Write `write_bytes` to an I2C device at 7-bit address "
-                    "`addr` on Grove Port A, then read `n_bytes` back in a "
-                    "single Repeated Start transaction. Common 'set "
-                    "register pointer, then read' idiom: pass "
-                    "write_bytes=[reg_addr] to read from a specific "
-                    "register."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "addr": {
-                            "type": "integer",
-                            "description": (
-                                "7-bit I2C address; range 0x08..0x77 "
-                                "(I2C reserved ranges excluded — matches "
-                                "the i2c_scan probe range)."
-                            ),
-                            "minimum": 8,
-                            "maximum": 119,
-                        },
-                        "write_bytes": {
-                            "type": "array",
-                            "description": (
-                                "Bytes to write before reading "
-                                "(each 0..255)."
-                            ),
-                            "items": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 255,
-                            },
-                        },
-                        "n_bytes": {
-                            "type": "integer",
-                            "description": "Bytes to read (1..256).",
-                            "minimum": 1,
-                            "maximum": 256,
-                        },
-                    },
-                    "required": ["addr", "write_bytes", "n_bytes"],
+                    "required": ["archive_path", "mode"],
                 },
             ),
         ]
@@ -760,6 +674,32 @@ def create_server() -> Server:
                         text=json.dumps({"error": str(exc)}),
                     )
                 ]
+            return [TextContent(type="text", text=json.dumps(result))]
+
+        if name == "load_avatar_set":
+            # Phase 4.5 avatar: stage the raw RGB565 payload and notify
+            # the device via WS avatar_set_fetch; the device performs the
+            # HTTP fetch + SHA256 verify + AvatarSet::Load and replies
+            # with avatar_set_loaded. All orchestration lives in
+            # Gateway.load_avatar_set; this branch is a thin wrapper that
+            # parses arguments and returns the dict-result as MCP JSON.
+            archive_path = arguments.get("archive_path", "")
+            mode = arguments.get("mode", "")
+            try:
+                timeout = float(arguments.get("timeout", 60.0))
+            except (TypeError, ValueError):
+                timeout = 60.0
+            if not archive_path or not isinstance(archive_path, str):
+                return [TextContent(
+                    type="text",
+                    text=json.dumps({"ok": False, "error": "archive_path is required"}),
+                )]
+            if mode not in ("layered", "matrix"):
+                return [TextContent(
+                    type="text",
+                    text=json.dumps({"ok": False, "error": f"unknown mode: {mode}"}),
+                )]
+            result = await gw.load_avatar_set(archive_path, mode, timeout)
             return [TextContent(type="text", text=json.dumps(result))]
 
         if not gw.esp32.device_connected:

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -581,6 +581,138 @@ def create_server() -> Server:
                 },
             ),
             Tool(
+                name="i2c_scan",
+                description=(
+                    "Scan the external I2C bus on Grove Port A and return "
+                    "all 7-bit addresses (probe range 0x08..0x77, "
+                    "excluding I2C reserved ranges) that ACK a probe. Use "
+                    "this to discover attached M5Stack Unit modules "
+                    "(ENV III, ToF, gas sensor, PaHub, etc.). On-board ICs "
+                    "on the internal bus are NOT included (this tool "
+                    "operates on a physically separate bus). Returns "
+                    "{\"ok\": true, \"addresses\": [...]}."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {},
+                },
+            ),
+            Tool(
+                name="i2c_read",
+                description=(
+                    "Read n_bytes from an I2C device at 7-bit address "
+                    "`addr` on Grove Port A. Use this for protocols that "
+                    "read the device's current register / output without "
+                    "a preceding write. For typical 'write register "
+                    "address, then read' patterns, use `i2c_write_read` "
+                    "instead. Returns "
+                    "{\"ok\": true, \"bytes\": [...]} or "
+                    "{\"ok\": false, \"error\": \"ESP_ERR_TIMEOUT\"} on NACK."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "addr": {
+                            "type": "integer",
+                            "description": (
+                                "7-bit I2C address; range 0x08..0x77 "
+                                "(I2C reserved ranges excluded — matches "
+                                "the i2c_scan probe range)."
+                            ),
+                            "minimum": 8,
+                            "maximum": 119,
+                        },
+                        "n_bytes": {
+                            "type": "integer",
+                            "description": "Bytes to read (1..256).",
+                            "minimum": 1,
+                            "maximum": 256,
+                        },
+                    },
+                    "required": ["addr", "n_bytes"],
+                },
+            ),
+            Tool(
+                name="i2c_write",
+                description=(
+                    "Write bytes to an I2C device at 7-bit address `addr` "
+                    "on Grove Port A. `bytes` is an array of integers "
+                    "(0..255). This tool operates on the external Port A "
+                    "bus only; on-board ICs (PMIC, AW9523, touch, etc.) "
+                    "on the internal bus are not reachable."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "addr": {
+                            "type": "integer",
+                            "description": (
+                                "7-bit I2C address; range 0x08..0x77 "
+                                "(I2C reserved ranges excluded — matches "
+                                "the i2c_scan probe range)."
+                            ),
+                            "minimum": 8,
+                            "maximum": 119,
+                        },
+                        "bytes": {
+                            "type": "array",
+                            "description": "Bytes to write (each 0..255).",
+                            "items": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 255,
+                            },
+                        },
+                    },
+                    "required": ["addr", "bytes"],
+                },
+            ),
+            Tool(
+                name="i2c_write_read",
+                description=(
+                    "Write `write_bytes` to an I2C device at 7-bit address "
+                    "`addr` on Grove Port A, then read `n_bytes` back in a "
+                    "single Repeated Start transaction. Common 'set "
+                    "register pointer, then read' idiom: pass "
+                    "write_bytes=[reg_addr] to read from a specific "
+                    "register."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "addr": {
+                            "type": "integer",
+                            "description": (
+                                "7-bit I2C address; range 0x08..0x77 "
+                                "(I2C reserved ranges excluded — matches "
+                                "the i2c_scan probe range)."
+                            ),
+                            "minimum": 8,
+                            "maximum": 119,
+                        },
+                        "write_bytes": {
+                            "type": "array",
+                            "description": (
+                                "Bytes to write before reading "
+                                "(each 0..255)."
+                            ),
+                            "items": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 255,
+                            },
+                        },
+                        "n_bytes": {
+                            "type": "integer",
+                            "description": "Bytes to read (1..256).",
+                            "minimum": 1,
+                            "maximum": 256,
+                        },
+                    },
+                    "required": ["addr", "write_bytes", "n_bytes"],
+                },
+            ),
+            Tool(
                 name="load_avatar_set",
                 description=(
                     "Load a dynamic avatar set onto the connected ESP32 "


### PR DESCRIPTION
## Summary

Adds a runtime-loadable avatar pipeline for stack-chan: a new `AvatarSet`
type that holds layered face / eyes / mouth frames in PSRAM, an HTTP
fetcher that streams a raw RGB565 payload from the gateway into PSRAM
without an intermediate copy, and a new `avatar_set_fetch` WebSocket
control protocol. Replaces the build-time `avatar_images.cc` table for
boards that opt into it. Matrix mode (90 frames, ~3.3 MB) is **not** in
this PR — that lives on a follow-up stacked PR.

## Why

The existing `avatar_images.cc` table is a baked-in code table — a new
avatar set requires reflashing. For stack-chan we want personas to swap
their face / eyes / mouth set at runtime, and we want to avoid bloating
the firmware partition with multiple sets.

This PR ships the transfer pipeline only. Default behavior is unchanged
until something on the firmware side calls into the new code path.

## How

- **Avatar payload format**: raw RGB565, packed in a fixed layout
  (face 6 frames × 320×240 × 2 bytes + eyes 3 + mouth 5 = 537,600 bytes
  for layered mode). No PNG decoder needed in firmware — the gateway
  delivers the pre-rendered bytes, sidestepping `CONFIG_LV_USE_PNG`
  partition pressure.
- **AvatarSetFetcher** (`firmware/main/boards/stackchan/avatar_set_fetcher.cc`):
  HTTP GET from the gateway's capture server, SHA256-validates against
  a checksum sent over WS, then hands the buffer to `AvatarSet` via
  `AdoptOwnedBuffer(uint8_t*, size_t)`. **No `memcpy`** — the staging
  buffer becomes the AvatarSet's storage, so the PSRAM peak is just
  `old_set + new_set` instead of `old_set + staging + new_set`. This
  matters for matrix mode (PR-E2), where the staging copy was
  overflowing 8 MB PSRAM and producing
  `Load: PSRAM allocation failed (size=3456000)`.
- **WS protocol**: gateway sends
  `{\"type\":\"avatar_set_fetch\",\"url\":...,\"checksum\":...,\"size\":...,\"mode\":...}`,
  device replies with `{\"type\":\"avatar_set_loaded\",\"ok\":...,\"checksum\":...,\"bytes_transferred\":...}`.
- **Expression-change deferral**: any `set_avatar_expression` arriving
  while a fetch is in progress is held until the new set is committed,
  so the display does not flicker between the old set and the partially
  loaded new set.
- **Gateway-side tooling**: new `load_avatar_set` MCP tool that takes
  a filesystem `archive_path` (not inline bytes — MCP JSON stays
  multi-MB-base64-free), stages it on the capture HTTP server with a
  short-lived Bearer-token-protected GET endpoint, and orchestrates
  the WS notify + reply wait.
- **Small `%zu` → `%u` fix** in two ESP_LOG sites. ESP-IDF's
  nano-printf cannot parse `%zu` (and crashes on it); using `%u` after
  casting to `unsigned int` is the safe pattern.
- **`Protocol::SendText` made public** so board-side code (the fetcher)
  can push the `avatar_set_loaded` reply over the active WS without
  re-implementing protocol plumbing. No behavior change for existing
  callers.

## Compatibility

- Default OFF. The new path is opt-in — boards that do not call into
  `AvatarSet` continue to use the existing `avatar_images.cc`
  approach. Stack-chan's existing layered face / eyes / mouth display
  works unchanged until something stages an AvatarSet over WS.
- The `avatar_set_fetch` message type is new; existing handlers ignore
  unknown types.
- New gateway endpoints are confined to a new HTTP route and a new MCP
  tool. Existing MCP tools (including `i2c_*`, `set_avatar*`,
  `set_leds`, motion tools) are unchanged.

## Test plan

- [x] Builds clean with ESP-IDF v5.5.2 (CI Docker image).
- [x] End-to-end verified on hardware (stack-chan board): a gateway-
      side `load_avatar_set` call with a layered-mode RGB565 file
      stages the bytes, the device fetches, validates, and commits the
      new set, and the LCD swaps to the new face / eyes / mouth on the
      next expression change.
- [x] Expression-change deferral verified — toggling
      `set_avatar_expression` while a fetch is in progress holds the
      change until completion, no partial-set flicker.
- [x] Repeated swaps work (no PSRAM leak across loads).

## Follow-up

PR-E2 (separate, will be opened off of this branch) adds **matrix
mode** (90 frames, ~3.3 MB) on top of this layered-mode foundation.
Kept separate so the matrix-mode rendering review can stay focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)