### PR TITLE
fix(firmware/ws): guard StopReconnectTimer with per-candidate atomic flag against hello-then-disconnect race (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ documented-only.
 
 ### Firmware
 
+- Fixed: a server-side close arriving between the WebSocket server
+  hello and the main task resuming no longer cancels the reconnect
+  timer that the per-socket `OnDisconnected` lambda just armed.
+  `OpenAudioChannelInternal()` now re-checks `websocket_->IsConnected()`
+  immediately after `xEventGroupWaitBits()` returns the server-hello
+  event, and bails out with `return false` before the success-path
+  `StopReconnectTimer()`. The reconnect-timer caller observes the
+  false return and waits for the already-armed retry. Happy path
+  (no concurrent close) is unchanged. Closes
+  [#189](https://github.com/kisaragi-mochi/stackchan-mcp/issues/189).
+
 - Fixed: WebSocket candidate fallback is now fail-fast when a server
   hello is malformed (missing/non-string `transport`, missing/empty
   `session_id`, or unsupported `transport`). A new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,17 @@ documented-only.
 - Fixed: a server-side close arriving between the WebSocket server
   hello and the main task resuming no longer cancels the reconnect
   timer that the per-socket `OnDisconnected` lambda just armed.
-  `OpenAudioChannelInternal()` now re-checks `websocket_->IsConnected()`
+  `OpenAudioChannelInternal()` now uses a per-candidate
+  acquire/release atomic flag captured by `OnDisconnected` (stored
+  with release before `ScheduleReconnect()`, loaded with acquire
   immediately after `xEventGroupWaitBits()` returns the server-hello
-  event, and bails out with `return false` before the success-path
-  `StopReconnectTimer()`. The reconnect-timer caller observes the
-  false return and waits for the already-armed retry. Happy path
-  (no concurrent close) is unchanged. Closes
+  event) and bails out with `return false` before the success-path
+  `StopReconnectTimer()`. The earlier `websocket_->IsConnected()`
+  guard was insufficient because the underlying `connected_` is a
+  plain bool with no acquire/release ordering against the close-side
+  callback path. The reconnect-timer caller observes the false return
+  and waits for the already-armed retry. Happy path (no concurrent
+  close) is unchanged. Closes
   [#189](https://github.com/kisaragi-mochi/stackchan-mcp/issues/189).
 
 - Fixed: WebSocket candidate fallback is now fail-fast when a server

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -505,6 +505,21 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             continue;
         }
 
+        // A server-side close arriving between ParseServerHello() setting the
+        // wait bit and this main-task resume runs the OnDisconnected lambda on
+        // the WS task with notify_disconnect already armed, so the lambda has
+        // already called ScheduleReconnect() to arm the reconnect timer.
+        // Returning into the success path below would unconditionally call
+        // StopReconnectTimer() and cancel that just-armed retry, returning
+        // true to the reconnect-timer caller and leaving the transport dead
+        // with no retry scheduled (#189). Bail out early instead and let the
+        // already-armed timer drive the next attempt; the reconnect-timer
+        // caller logs the false return and waits for the timer fire.
+        if (websocket_ == nullptr || !websocket_->IsConnected()) {
+            ESP_LOGW(TAG, "Connection dropped between hello and main-task resume; leaving reconnect scheduled");
+            return false;
+        }
+
         // ParseServerHello() already armed notify_disconnect on the WS
         // task (before setting the wait bit) so a near-simultaneous close
         // is handled by the lambda's reconnect path. Mirror it into the

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -345,6 +345,18 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             continue;
         }
         auto notify_disconnect = std::make_shared<std::atomic<bool>>(false);
+        // Per-candidate flag flipped by the OnDisconnected lambda (on the WS
+        // task) the moment a live, post-handshake server-side close has
+        // already armed a reconnect via ScheduleReconnect(). The main task
+        // loads this with acquire semantics immediately after
+        // xEventGroupWaitBits() returns the server-hello event, before any
+        // success-path mutation. Using a per-socket atomic captured by the
+        // lambda gives us a synchronised handshake between the WS task's
+        // close path and the main task's resume — unlike reading
+        // WebSocket::IsConnected(), whose underlying `connected_` is a
+        // plain bool mutated by the WS/TCP callback path with no acquire/
+        // release ordering. See #189 round-2 review for the race window.
+        auto disconnected_after_hello = std::make_shared<std::atomic<bool>>(false);
 
         if (!token.empty()) {
             websocket_->SetHeader("Authorization", token.c_str());
@@ -431,7 +443,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             last_incoming_time_ = std::chrono::steady_clock::now();
         });
 
-        websocket_->OnDisconnected([this, notify_disconnect]() {
+        websocket_->OnDisconnected([this, notify_disconnect, disconnected_after_hello]() {
             audio_channel_open_.store(false);
             transport_connected_.store(false);
             // notify_disconnect carries this socket's reconnect intent.
@@ -452,6 +464,14 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             if (on_audio_channel_closed_ != nullptr) {
                 on_audio_channel_closed_();
             }
+            // Publish "a live disconnect has already armed reconnect" to
+            // the main task BEFORE calling ScheduleReconnect(). The release
+            // here synchronises with the acquire load in
+            // OpenAudioChannelInternal() right after xEventGroupWaitBits(),
+            // ensuring the main task observes this store on every code
+            // path that would otherwise race in to cancel the just-armed
+            // timer via StopReconnectTimer() (#189 round-2 review).
+            disconnected_after_hello->store(true, std::memory_order_release);
             ScheduleReconnect();
         });
 
@@ -512,11 +532,21 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
         // Returning into the success path below would unconditionally call
         // StopReconnectTimer() and cancel that just-armed retry, returning
         // true to the reconnect-timer caller and leaving the transport dead
-        // with no retry scheduled (#189). Bail out early instead and let the
-        // already-armed timer drive the next attempt; the reconnect-timer
-        // caller logs the false return and waits for the timer fire.
-        if (websocket_ == nullptr || !websocket_->IsConnected()) {
-            ESP_LOGW(TAG, "Connection dropped between hello and main-task resume; leaving reconnect scheduled");
+        // with no retry scheduled (#189).
+        //
+        // Detect this race via the per-socket disconnected_after_hello flag
+        // captured by the OnDisconnected lambda: the lambda stores true with
+        // release semantics before ScheduleReconnect(), and the acquire load
+        // here establishes happens-before with that store. Unlike
+        // WebSocket::IsConnected() — whose `connected_` is a plain bool
+        // mutated by the WS/TCP callback path with no synchronisation — this
+        // ordering guarantees we observe the close that already armed the
+        // reconnect, instead of a stale "still connected" reading
+        // (#189 round-2 review). The websocket_ != nullptr check is kept as
+        // a defensive guard against unexpected teardown ordering.
+        if (websocket_ == nullptr ||
+            disconnected_after_hello->load(std::memory_order_acquire)) {
+            ESP_LOGW(TAG, "Server-side close raced with server hello; leaving reconnect to the per-socket disconnect handler");
             return false;
         }
 


### PR DESCRIPTION
## Summary

Fixes a sub-millisecond race in `WebsocketProtocol::OpenAudioChannelInternal()` where a server-side close arriving between `ParseServerHello()` setting the server-hello wait bit and the main task resuming from `xEventGroupWaitBits()` could cancel the reconnect timer that the per-socket `OnDisconnected` lambda had just armed, leaving the transport dead with no retry scheduled.

The fix introduces a per-candidate `std::shared_ptr<std::atomic<bool>>` flag (`disconnected_after_hello`) captured by both `OnDisconnected` (release store before `ScheduleReconnect()`) and the main task (acquire load immediately after `xEventGroupWaitBits()` returns the hello event, before any success-path state mutation). On a race trip, the main task bails out with `return false`, letting the reconnect-timer caller observe the failure signal and the already-armed retry drive the next attempt.

Closes #189.

## Background

This is the third in a series of follow-ups surfaced by Codex's adversarial review of PR #136 (the lifecycle change that introduced the reconnect path). The two siblings:

- #187 — session_id-based gating for stale-channel messages (closed via the firmware-side session_id retention work)
- #188 — `OnDisconnected` write-order race for `audio_channel_open_` (open, separate fix track)
- #189 — this PR

## Why two commits

The branch carries two commits to make the synchronisation rationale auditable:

- `76c01de` (round 1): initial guard using `websocket_->IsConnected()` placed immediately after `xEventGroupWaitBits()` returns the hello event, with `return false` on trip.
- `d12acf7` (round 2): adversarial review pointed out that `WebSocket::IsConnected()` reads `WebSocket::connected_`, which is a plain `bool` mutated by the WS/TCP callback path without acquire/release ordering. Under the targeted race, the main task could still observe a stale `true` and proceed into `StopReconnectTimer()`, defeating the fix. Round 2 replaces the `IsConnected()` predicate with a per-candidate `std::atomic<bool>` flag captured by `OnDisconnected`; the release/acquire pair establishes happens-before between the WS task's `ScheduleReconnect()` and the main task's exit. Round 1 is retained as the diff narrative so reviewers see why the predicate evolved.

The `websocket_ != nullptr` defensive null check is kept (it guards against unexpected teardown ordering, independent of the synchronisation question).

## Fix detail (after round 2)

`OpenAudioChannelInternal()` creates a per-candidate atomic flag alongside the existing `notify_disconnect` token:

```cpp
auto disconnected_after_hello = std::make_shared<std::atomic<bool>>(false);
```

`OnDisconnected` writes the flag with release ordering before calling `ScheduleReconnect()`:

```cpp
disconnected_after_hello->store(true, std::memory_order_release);
ScheduleReconnect();
```

The main task reads with acquire ordering immediately after the server-hello wait bit returns, before any success-path mutation:

```cpp
if (websocket_ == nullptr ||
    disconnected_after_hello->load(std::memory_order_acquire)) {
    ESP_LOGW(TAG, "Server-side close raced with server hello; leaving reconnect to the per-socket disconnect handler");
    return false;
}
```

The acquire/release pair establishes happens-before from `OnDisconnected`'s `ScheduleReconnect()` to the main task's exit, so the main task is guaranteed to observe the timer arm if the close ran first. A `false` return propagates to the reconnect-timer caller, which logs and waits for the already-armed retry to fire.

`managed_components/78__esp-ml307/` upstream code is **not** touched; the fix is local to `firmware/main/protocols/websocket_protocol.cc`.

## Acceptance criteria (Issue #189)

- [x] A server-side close arriving in the gap between `ParseServerHello` event-bit set and main-task resume does not cancel the reconnect timer (atomic flag captures the disconnect via release store before `ScheduleReconnect()`; main task observes via acquire load).
- [x] The main task returns `false` when the socket has been torn down before it could finalise the attempt, so the timer caller reschedules.
- [x] The existing happy-path (no concurrent close) continues to work — `StopReconnectTimer()` is still called when the connection is live (the flag stays `false` through to success path).

## Test plan

- [x] Firmware build passes via `python ./scripts/release.py stackchan` — `xiaozhi.bin` 3,466,928 bytes (+224 bytes over the no-fix baseline, attributable to the flag plumbing + comment block).
- [x] Codex adversarial review focused on memory ordering and race interleavings: clean after the atomic flag pattern revision.
- [ ] Real-device happy-path verification: boot, WebSocket connects to gateway, MCP control flow exercised (`set_avatar`, `move_head`, `set_all_leds`), no regression.
- [ ] CI: firmware build / gateway test / CHANGELOG check green.

The race itself is sub-millisecond and not directly reproducible on hardware; verification rests on the static review of the synchronisation invariants plus the happy-path regression check.

## Out of scope

- **#218** — Residual TOCTOU window between the round-2 acquire load and the
  success-path `StopReconnectTimer()` (filed as a follow-up so the latent
  bug is tracked rather than hidden). The remaining window is two to three
  orders of magnitude narrower than the original race fixed here, and
  eliminating it requires a generation-aware `StopReconnectTimer()` or a
  candidate state-machine reshape — out of scope for this PR per the
  "rare residual / real-world-impact low → defer" review policy.
- **#188** — Sibling `OnDisconnected` write-order race for
  `audio_channel_open_` in the same lambda; the atomic flag introduced here
  is ordered independently of that issue, separate fix track.

## Refs

- PR #136 (introduced the lifecycle that exposed this race)
- PR #205 (#191 fail-fast invalid hello — same `OpenAudioChannelInternal` SUCCESS / FAILED / NEITHER 3-way branch)
- #218 (follow-up: residual TOCTOU after round 2)
- #188 (sibling open issue, separate fix track)
