### PR TITLE
fix(firmware): keep idle after tts.stop, remove auto-listening recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,28 @@ documented-only.
 
 ### Firmware
 
+- Changed: the device no longer auto-enters Listening after a TTS
+  utterance ends. The `Application::OnIncomingJson` handler for the
+  `tts.stop` event used to fall through to
+  `SetDeviceState(kDeviceStateListening)` whenever `listening_mode_`
+  was anything other than `kListeningModeManualStop`, mirroring the
+  upstream xiaozhi conversational-agent UX. In an MCP-gateway
+  deployment that auto-listening path is a footgun: when the TTS
+  pipeline stalls (we observed `audio_input` task watchdog timeouts
+  firing every 10 s for over two minutes during long playback), the
+  deferred `tts.stop` event arrives long after the user expected the
+  conversation to be quiescent, and the device then records ~30 s of
+  ambient room audio that the gateway happily posts as a user
+  utterance — repeatedly per session. With this change `tts.stop`
+  unconditionally returns the device to Idle; listening is now started
+  only by the user (touch / button / external command) or by the AI
+  (gateway-issued `StartListening`). Loop-style `Listening → Speaking
+  → Listening` flows belong on the gateway side, where the gateway
+  can reason about the conversation's actual state. Avatar mouth
+  animation cleanup via `OnTtsStop()` still fires unconditionally.
+  Contributed via
+  [PR #225](https://github.com/kisaragi-mochi/stackchan-mcp/pull/225).
+
 - Added: `self.port_b.ws2812.{init, set_pixel, set_strip, refresh, clear}`
   MCP tools — five generic tools to drive any WS2812-compatible LED
   strip attached to the official kit's Port B (CoreS3 HY2.0-4P digital

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -529,11 +529,28 @@ void Application::InitializeProtocol() {
             } else if (strcmp(state->valuestring, "stop") == 0) {
                 Schedule([this, &board]() {
                     if (GetDeviceState() == kDeviceStateSpeaking) {
-                        if (listening_mode_ == kListeningModeManualStop) {
-                            SetDeviceState(kDeviceStateIdle);
-                        } else {
-                            SetDeviceState(kDeviceStateListening);
-                        }
+                        // stackchan-mcp is an MCP gateway, not a standalone
+                        // xiaozhi-style conversational agent. Listening must
+                        // be triggered explicitly — either by the user
+                        // (touch / button / external command) or by the
+                        // AI (gateway-issued StartListening). The upstream
+                        // xiaozhi behaviour of automatically re-entering
+                        // listening after every TTS utterance is a footgun
+                        // here: when the firmware's TTS pipeline stalls
+                        // (e.g. audio_input task watchdog timeouts during
+                        // long playback) the deferred tts.stop event lands
+                        // long after the user expected the conversation to
+                        // be quiescent, and the device then records ~30 s
+                        // of ambient room audio that the gateway happily
+                        // posts as a user utterance.
+                        //
+                        // Returning to Idle here forces the listening
+                        // boundary to be set explicitly by whoever wants
+                        // to continue the conversation (user touch,
+                        // gateway-driven push-to-talk, etc.). Loop-style
+                        // Listening→Speaking→Listening flows belong on
+                        // the gateway side, not in this firmware.
+                        SetDeviceState(kDeviceStateIdle);
                     }
                     // Phase 4 audio (Issue #76): stop the avatar mouth
                     // animation unconditionally on tts.stop. A wake-word /


### PR DESCRIPTION
## Summary

When the stack-chan TTS pipeline stalls, the deferred `tts.stop` event currently lands long after the user expected the conversation to be quiescent, and the device drops into Listening mode for up to 30 s. The gateway picks up the ambient room audio and posts it as a user utterance. This PR removes the auto-listening fallback after `tts.stop` so the device returns to Idle and the listening boundary is set explicitly by whoever wants to continue the conversation.

## Why

`stackchan-mcp` is an MCP gateway, not a standalone xiaozhi-style conversational agent. Listening must be triggered explicitly — either by the user (touch / button / external command) or by the AI (gateway-issued `StartListening`). Loop-style `Listening → Speaking → Listening` flows belong on the gateway side, where the gateway can reason about the conversation's actual state.

The upstream xiaozhi behaviour of auto-entering Listening after every TTS utterance is incompatible with this model. Concretely:

- In a long playback I observed `task_wdt` timeouts on CPU 0 (`audio_input`) firing every 10 s for over 2 minutes. When the pipeline finally recovered the deferred `tts.stop` event arrived, and the existing `listening_mode_ != kListeningModeManualStop` branch sent the device into Listening with a 30 s timeout.
- `GetDefaultListeningMode()` returns `kListeningModeAutoStop` (no-AEC) or `kListeningModeRealtime` (AEC on) — never `kListeningModeManualStop`. So in the gateway-driven path, the `ManualStop` guard is effectively dead and the auto-listening branch always runs.
- The 30 s of recorded ambient room audio gets posted to the gateway as a user utterance, multiple times per session, with predictably confusing downstream effects.

The existing comment around `HandleStartListeningEvent()` already calls out that "Manual-stop is also the right default for gateway-driven capture: the gateway controls the exact stop boundary" — this PR brings the `tts.stop` path in line with that intent.

## Change

`application.cc`, the `Schedule` callback for `tts.stop`:
- Before: branch on `listening_mode_ == kListeningModeManualStop` → `Idle`, else `Listening`.
- After: unconditional `SetDeviceState(kDeviceStateIdle)` when leaving `Speaking`.

The `OnTtsStop()` board callback is unchanged (still fires unconditionally so the avatar mouth animation stops even when an external abort moved the device out of Speaking before `tts.stop` arrived).

## Test plan

- [x] Built and flashed on a CoreS3 + Si12T stack-chan unit (ESP-IDF 5.5.4) and observed `StateMachine: State: speaking -> idle` on every `tts.stop` for several long playbacks.
- [x] Confirmed no further runaway ~30 s ambient-audio captures after the fix (over a multi-hour session that previously produced 3+ such events per hour).
- [ ] Real-device acceptance from someone running a standalone xiaozhi-style UX (not me — I only run the MCP gateway path; would appreciate a sanity check from anyone who relies on auto-listening for that use case).

## Notes for review

Happy to gate this behind a `CONFIG_*` opt-in if the auto-listening behaviour is load-bearing for non-gateway users; let me know which direction you'd prefer. My read is that the gateway-driven path is the more common one for stack-chan deployments, but you have a much better sample of users than I do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)