### PR TITLE
fix(gateway): order mDNS advertised addresses by LAN reachability, drop network/broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,20 @@ documented-only.
 
 ### Gateway
 
+- Fixed: mDNS now advertises the host's IPv4 addresses ordered by LAN
+  reachability instead of in interface-enumeration order. On a host with
+  multiple interfaces (a CGNAT `100.64.0.0/10` overlay address, several LAN
+  segments), the firmware tries candidates in advertised order and could spend
+  several seconds timing out on an unreachable candidate before reaching a
+  LAN-reachable one. Addresses are now stably sorted so RFC1918 private ranges
+  (`192.168.0.0/16`, `10.0.0.0/8`, `172.16.0.0/12`) are tried first and
+  everything else follows; no reachable address is dropped. Subnet network and
+  broadcast addresses (e.g. a `.0` network address or `.255`-style broadcast),
+  which are never valid host endpoints, are now excluded when the interface
+  prefix is known — guarded so `/31` and `/32` host addresses are never
+  dropped. Contributed via
+  [PR #232](https://github.com/kisaragi-mochi/stackchan-mcp/pull/232).
+
 - Added: the gateway now advertises `_stackchan-mcp._tcp.local.` over mDNS/DNS-SD by default so fresh firmware can discover the WebSocket endpoint on the local network. A new `--no-mdns` flag disables advertising.
 
 - Added: `send_pcm_audio(gateway, pcm, source_rate=...)` helper

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -16,6 +16,20 @@ SERVICE_NAME = f"{DEFAULT_INSTANCE}.{SERVICE_TYPE}"
 FALLBACK_SERVICE_HOSTNAME = f"{DEFAULT_INSTANCE}.local."
 TXT_VERSION = "1"
 
+# Private (RFC1918) IPv4 ranges. Addresses inside these ranges are the most
+# likely to be reachable from a same-LAN device, so they are advertised first.
+# Anything outside is still advertised, just ordered after these.
+_PRIVATE_NETWORKS = (
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+)
+
+# Only prefixes shorter than /31 have a distinct network and broadcast address.
+# A /31 (point-to-point) or /32 (host) address must never be treated as a
+# network or broadcast address, since that would drop a legitimate host IP.
+_MAX_NETWORK_BROADCAST_PREFIX = 30
+
 
 @dataclass(frozen=True)
 class MdnsAdvertisement:
@@ -50,6 +64,65 @@ def _is_usable_ipv4(address: str) -> bool:
     )
 
 
+def _is_network_or_broadcast_address(address: str, prefix: int | None) -> bool:
+    """Return ``True`` when ``address`` is the subnet network or broadcast address.
+
+    Requires the subnet prefix: without it (e.g. the socket-based source) the
+    network/broadcast endpoints cannot be derived, so callers pass ``None`` and
+    the address is kept. Host prefixes (/31, /32) have no distinct network or
+    broadcast address and are never excluded here.
+    """
+    if prefix is None or prefix > _MAX_NETWORK_BROADCAST_PREFIX:
+        return False
+    try:
+        interface = ipaddress.ip_interface(f"{address}/{prefix}")
+    except ValueError:
+        return False
+    network = interface.network
+    return interface.ip in (network.network_address, network.broadcast_address)
+
+
+def _is_private_lan_address(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return any(ip in network for network in _PRIVATE_NETWORKS)
+
+
+def _lan_reachability_tier(address: str) -> int:
+    """Sort key: private (RFC1918) LAN addresses first, everything else after.
+
+    Returns a 2-value tier so a stable sort preserves the original enumeration
+    order within each tier.
+    """
+    return 0 if _is_private_lan_address(address) else 1
+
+
+def _select_advertised_addresses(
+    candidates: list[tuple[str, int | None]],
+) -> list[str]:
+    """Filter, de-duplicate and order candidate addresses for advertisement.
+
+    Excludes only clearly-unusable addresses (loopback/multicast/unspecified via
+    :func:`_is_usable_ipv4`, plus network/broadcast addresses when a prefix is
+    known). All remaining addresses are kept and ordered by LAN-reachability
+    likelihood (RFC1918 private ranges first) using a stable sort, so addresses
+    a same-LAN device can reach are tried before overlay/global/edge-case ones.
+    """
+    seen: set[str] = set()
+    usable: list[str] = []
+    for address, prefix in candidates:
+        if address in seen or not _is_usable_ipv4(address):
+            continue
+        if _is_network_or_broadcast_address(address, prefix):
+            continue
+        seen.add(address)
+        usable.append(address)
+    usable.sort(key=_lan_reachability_tier)
+    return usable
+
+
 def _is_wildcard_host(host: str) -> bool:
     try:
         ip = ipaddress.ip_address(host)
@@ -71,22 +144,34 @@ def _build_service_hostname() -> str:
     return f"{safe_label}.local."
 
 
-def _iter_ifaddr_ipv4_addresses() -> list[str]:
+def _iter_ifaddr_ipv4_addresses() -> list[tuple[str, int | None]]:
+    """Enumerate host IPv4 addresses with their subnet prefix length.
+
+    The prefix (``ip.network_prefix``) lets the caller drop network/broadcast
+    addresses; it is ``None`` only if ifaddr reports a non-integer prefix.
+    """
     try:
         import ifaddr
     except ImportError:
         return []
 
-    addresses: list[str] = []
+    addresses: list[tuple[str, int | None]] = []
     for adapter in ifaddr.get_adapters():
         for ip in adapter.ips:
             if not isinstance(ip.ip, str):
                 continue
-            addresses.append(ip.ip)
+            prefix = ip.network_prefix if isinstance(ip.network_prefix, int) else None
+            addresses.append((ip.ip, prefix))
     return addresses
 
 
-def _iter_socket_ipv4_addresses() -> list[str]:
+def _iter_socket_ipv4_addresses() -> list[tuple[str, int | None]]:
+    """Enumerate host IPv4 addresses via socket resolution.
+
+    This source carries no subnet prefix, so each entry pairs the address with
+    ``None``; network/broadcast addresses therefore cannot be (and are not)
+    excluded from this source.
+    """
     addresses: set[str] = set()
     hostnames = {socket.gethostname(), socket.getfqdn()}
 
@@ -109,18 +194,13 @@ def _iter_socket_ipv4_addresses() -> list[str]:
     finally:
         sock.close()
 
-    return sorted(addresses)
+    return [(address, None) for address in sorted(addresses)]
 
 
 def _enumerate_usable_ipv4_addresses() -> list[str]:
-    seen: set[str] = set()
-    usable: list[str] = []
-    for address in [*_iter_ifaddr_ipv4_addresses(), *_iter_socket_ipv4_addresses()]:
-        if address in seen or not _is_usable_ipv4(address):
-            continue
-        seen.add(address)
-        usable.append(address)
-    return usable
+    return _select_advertised_addresses(
+        [*_iter_ifaddr_ipv4_addresses(), *_iter_socket_ipv4_addresses()]
+    )
 
 
 def _resolve_concrete_host_ipv4_addresses(host: str) -> list[str]:
@@ -135,14 +215,9 @@ def _resolve_concrete_host_ipv4_addresses(host: str) -> list[str]:
     else:
         addresses = [str(ip)]
 
-    seen: set[str] = set()
-    usable: list[str] = []
-    for address in addresses:
-        if address in seen or not _is_usable_ipv4(address):
-            continue
-        seen.add(address)
-        usable.append(address)
-    return usable
+    # A concrete HOST carries no subnet prefix, so network/broadcast addresses
+    # cannot be derived; pair each address with ``None`` to keep them.
+    return _select_advertised_addresses([(address, None) for address in addresses])
 
 
 def build_advertisement(

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -29,18 +29,154 @@ def test_wildcard_host_advertises_all_usable_non_loopback_ipv4(
     monkeypatch.setattr(
         mdns,
         "_iter_ifaddr_ipv4_addresses",
-        lambda: ["127.0.0.1", "192.0.2.10", "0.0.0.0"],
+        lambda: [("127.0.0.1", 8), ("192.0.2.10", 24), ("0.0.0.0", 24)],
     )
     monkeypatch.setattr(
         mdns,
         "_iter_socket_ipv4_addresses",
-        lambda: ["192.0.2.10", "10.0.0.5"],
+        lambda: [("192.0.2.10", None), ("10.0.0.5", None)],
     )
 
     advertisement = build_advertisement(host="0.0.0.0", port=8765)
 
     assert advertisement is not None
-    assert advertisement.parsed_addresses == ["192.0.2.10", "10.0.0.5"]
+    # 10.0.0.5 is RFC1918 (tier 1) and sorts ahead of the public 192.0.2.10.
+    assert advertisement.parsed_addresses == ["10.0.0.5", "192.0.2.10"]
+
+
+def test_rfc1918_addresses_are_advertised_before_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mdns,
+        "_iter_ifaddr_ipv4_addresses",
+        lambda: [
+            ("203.0.113.7", 24),  # public, tier 2
+            ("192.168.0.10", 24),  # RFC1918, tier 1
+            ("10.1.2.3", 8),  # RFC1918, tier 1
+            ("172.16.5.6", 12),  # RFC1918, tier 1
+        ],
+    )
+    monkeypatch.setattr(mdns, "_iter_socket_ipv4_addresses", lambda: [])
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    # All kept; the three private addresses move ahead of the public one, and
+    # within each tier the original enumeration order is preserved.
+    assert advertisement.parsed_addresses == [
+        "192.168.0.10",
+        "10.1.2.3",
+        "172.16.5.6",
+        "203.0.113.7",
+    ]
+
+
+def test_cgnat_address_is_kept_but_ordered_after_rfc1918(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Reproduces the real-device scenario from the issue: a CGNAT address
+    # (100.64.0.0/10, here as a /32 host address) must remain advertised but be
+    # tried only after the reachable LAN address.
+    monkeypatch.setattr(
+        mdns,
+        "_iter_ifaddr_ipv4_addresses",
+        lambda: [
+            ("100.64.10.20", 32),  # CGNAT, tier 2 (must NOT be dropped)
+            ("192.168.0.10", 24),  # RFC1918 LAN, tier 1
+        ],
+    )
+    monkeypatch.setattr(mdns, "_iter_socket_ipv4_addresses", lambda: [])
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    assert advertisement.parsed_addresses == ["192.168.0.10", "100.64.10.20"]
+
+
+def test_network_and_broadcast_addresses_are_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mdns,
+        "_iter_ifaddr_ipv4_addresses",
+        lambda: [
+            ("192.168.0.0", 24),  # network address -> excluded
+            ("192.168.0.255", 24),  # broadcast address -> excluded
+            ("192.168.0.10", 24),  # host address -> kept
+        ],
+    )
+    monkeypatch.setattr(mdns, "_iter_socket_ipv4_addresses", lambda: [])
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    assert advertisement.parsed_addresses == ["192.168.0.10"]
+
+
+def test_host_prefixes_are_not_treated_as_network_or_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # /31 and /32 have no distinct network/broadcast address; a legitimate host
+    # IP on such a prefix must not be dropped.
+    monkeypatch.setattr(
+        mdns,
+        "_iter_ifaddr_ipv4_addresses",
+        lambda: [("192.168.5.0", 32), ("10.0.0.0", 31)],
+    )
+    monkeypatch.setattr(mdns, "_iter_socket_ipv4_addresses", lambda: [])
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    assert advertisement.parsed_addresses == ["192.168.5.0", "10.0.0.0"]
+
+
+def test_addresses_without_prefix_are_not_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The socket source carries no prefix; a ".0"-looking address from it cannot
+    # be classified as a network address and must be kept (zero-regression).
+    monkeypatch.setattr(mdns, "_iter_ifaddr_ipv4_addresses", lambda: [])
+    monkeypatch.setattr(
+        mdns,
+        "_iter_socket_ipv4_addresses",
+        lambda: [("192.168.0.0", None), ("192.168.0.10", None)],
+    )
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    assert advertisement.parsed_addresses == ["192.168.0.0", "192.168.0.10"]
+
+
+def test_mixed_tier_ordering_preserves_within_tier_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ifaddr source (with prefixes) is enumerated before the socket source; the
+    # stable sort must keep that combined order within each tier.
+    monkeypatch.setattr(
+        mdns,
+        "_iter_ifaddr_ipv4_addresses",
+        lambda: [("198.51.100.4", 24), ("192.168.1.2", 24)],
+    )
+    monkeypatch.setattr(
+        mdns,
+        "_iter_socket_ipv4_addresses",
+        lambda: [("203.0.113.9", None), ("10.5.5.5", None)],
+    )
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    # tier 1 (private), original order: 192.168.1.2 then 10.5.5.5;
+    # tier 2 (other), original order: 198.51.100.4 then 203.0.113.9.
+    assert advertisement.parsed_addresses == [
+        "192.168.1.2",
+        "10.5.5.5",
+        "198.51.100.4",
+        "203.0.113.9",
+    ]
 
 
 @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])


### PR DESCRIPTION
## Summary

When the gateway advertises over mDNS (#26), it publishes every usable non-loopback IPv4 address of the host. On a host with multiple interfaces (a CGNAT `100.64.0.0/10` overlay address, multiple LAN segments, etc.), the firmware tries the advertised candidates in advertised order and can spend several seconds timing out on an unreachable candidate before falling through to a reachable LAN address (real-device measurement in #231: ~68 s total before connect when the reachable address landed last).

This is a **reorder-first** fix. The set of advertised addresses is essentially unchanged — addresses are kept, not dropped — they are just ordered so the most-likely-reachable candidates come first. The only addresses now removed are ones that can never be a valid host WebSocket endpoint.

### What changed

- **Reorder by LAN-reachability tier (stable sort):** RFC1918 private ranges (`192.168.0.0/16`, `10.0.0.0/8`, `172.16.0.0/12`) are advertised first; everything else (CGNAT, global, link-local) follows. Within each tier the original enumeration order is preserved. Classification uses the standard `ipaddress` module + the RFC1918 ranges (no vendor/product-specific logic).
- **Exclusion stays minimal (zero regression):** the existing loopback/multicast/unspecified filter is unchanged. Added: drop subnet **network** and **broadcast** addresses (e.g. a `.0` network address, a `.255`-style broadcast), which are never valid host endpoints.
  - Network/broadcast detection requires the subnet prefix, which is available from the `ifaddr` source (`ip.network_prefix`). It is guarded to prefixes `<= /30`, so `/31` and `/32` host addresses are never mistakenly dropped (for those, network == host).
  - The socket-resolution source carries no prefix, so network/broadcast cannot be derived there — those addresses are always kept (safe side).

### Zero-regression rationale

The guiding constraint was: never make an address that currently connects stop connecting. Reordering is order-preserving within tiers and drops nothing reachable; the only new exclusions are network/broadcast addresses (never connectable) and only when a prefix is present to prove it. When in doubt, the address is kept.

### Side benefit re: the firmware 8-candidate cap

The firmware tries advertised candidates in order and caps at 8. Because reachable LAN addresses now sort to the front, they are tried first and are never truncated out of the first 8 on a host with many interfaces.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (294 passed, 1 pre-existing skip)
- [x] gateway: `uv run ruff check .` (all checks passed)
- [ ] firmware: `python ./scripts/release.py stackchan` — not applicable (gateway-only change, firmware untouched)

Added unit tests cover: RFC1918 ordered first; CGNAT (`100.64.0.0/10`) kept but ordered after RFC1918; network/broadcast addresses excluded; `/31` and `/32` host addresses not dropped; addresses without a prefix (socket source) not excluded; mixed-tier ordering preserves within-tier order.

### Hardware

- [x] Not applicable / hardware not available: gateway-side mDNS address selection only; firmware unchanged. The advertised-order change is exercised by unit tests.

## Breaking changes

None. No MCP tool API, NVS schema, or build flag changes. Firmware unchanged.

## Related issues

Closes #231
Refs #26