### PR TITLE
feat: add tracked AGENTS.md with review guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ venv/
 .env
 .env.local
 *.local
-AGENTS.md
+AGENTS.local.md
 CLAUDE.md
 
 # Captures (user photos)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# stackchan-mcp
+
+MCP (Model Context Protocol) gateway and ESP32 firmware for **stack-chan**, the super-kawaii communication robot originated by [Shinya Ishikawa](https://github.com/stack-chan/stack-chan) in 2021.
+
+## Review guidelines
+
+These guidelines apply to all automated and human code reviews in this repository.
+
+- **User-first, not infra-first.** This is a single-user hobby product running on a home LAN. A finding that matters for a 10k-RPS SaaS is noise here. Focus on: does the feature work for the person sitting next to the robot?
+- **Main path correctness over edge-case hardening.** If the happy path is broken, that is P0. If a rare race condition could theoretically cause a retry, that is P2 at most.
+- **DoS / resource-exhaustion findings stay low priority.** There is one user, one device, one LAN. Denial-of-service is not a meaningful threat model. Do not escalate these to P0/P1.
+- **Be kind to contributors.** This project welcomes first-time and hobbyist contributors. Frame review comments as suggestions, not demands. Explain *why* a change matters, not just *what* to change. If a finding is stylistic rather than functional, mark it explicitly as non-blocking.
+- **Respect the existing architecture.** The gateway (Python, stdio MCP) and firmware (ESP32, C++) are intentionally separate processes communicating over WebSocket. Do not suggest merging them or adding cross-layer coupling unless there is a concrete functional reason.
+
+## Repository structure
+
+```
+stackchan-mcp/
+  gateway/          Python MCP gateway (stdio server, PyPI: stackchan-mcp)
+  firmware/         ESP32 firmware (xiaozhi-esp32 fork, stackchan board)
+    main/
+      boards/
+        stackchan/  Board-specific code (servo, touch, avatar, audio)
+    scripts/        Build helpers (release.py, avatar_convert/)
+  docs/             Additional documentation
+  CONTRIBUTING.md   Contribution guide, license boundary, release steps
+  CHANGELOG.md      Release history
+  LICENSE           MIT (see CONTRIBUTING.md for GPL-3.0 island)
+```
+
+## Getting started
+
+| Task | Where to look | Key commands |
+|---|---|---|
+| Install the gateway | `README.md` Quick Start | `pipx install stackchan-mcp` |
+| Build firmware | `firmware/AGENTS.md` | `docker run ... python ./scripts/release.py stackchan` |
+| Flash firmware | `firmware/AGENTS.md` | `esptool.py ... write_flash 0x20000 build/xiaozhi.bin` |
+| Run gateway tests | `gateway/AGENTS.md` | `cd gateway && uv run pytest && uv run ruff check .` |
+| Understand the board | `firmware/main/boards/stackchan/AGENTS.md` | Hardware specs, servo/touch/avatar details |
+| Prepare for release | `CONTRIBUTING.md` Per-release steps | Version bump + CHANGELOG promote + tag push |
+
+## Dual-language documentation
+
+`README.md` (English) and `README.ja.md` (Japanese) must stay in sync. When changing one, update the other in the same commit.
+
+## License boundary
+
+The repository is MIT-licensed, with one exception: 8 files under `firmware/main/boards/stackchan/` originating from SCServo_lib are GPL-3.0. See `CONTRIBUTING.md` for the full list and boundary rules. The gateway (Python) is a separate process and is not affected by the GPL island.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,17 @@ documented-only.
   rather than a functional gap. Tool descriptions now state the
   constraint explicitly.
 
+### Docs
+
+- Added: tracked `AGENTS.md` files at four levels (root, `gateway/`,
+  `firmware/`, `firmware/main/boards/stackchan/`) with review guidelines
+  for automated code review and public developer guides covering build,
+  flash, troubleshooting, servo/touch behavior, layer architecture,
+  license boundary, and attribution. Previously all `AGENTS.md` files
+  were gitignored; personal local configuration now uses
+  `AGENTS.local.md` (gitignored). Added migration guide and review
+  priorities section to `CONTRIBUTING.md`.
+
 ## [firmware-v1.8.0] - 2026-05-20
 
 ### Firmware

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,23 @@ Significant firmware changes should receive especially careful review for race
 conditions, resource lifetime, boot behavior, NVS compatibility, and hardware
 failure modes.
 
+### Review priorities
+
+This is a single-user hobby product on a home LAN, not a multi-tenant SaaS.
+Reviews (both human and automated) should reflect that context:
+
+- **User-first**: does the feature work for the person sitting next to the
+  robot? That matters more than theoretical edge cases.
+- **Main path correctness over edge-case hardening**: a broken happy path is
+  P0; a rare race condition is P2 at most.
+- **DoS / resource-exhaustion stays low priority**: one user, one device, one
+  LAN — denial-of-service is not a meaningful threat model here.
+- **Be kind**: frame comments as suggestions, explain *why*, and mark
+  stylistic preferences as non-blocking.
+
+These priorities are also encoded in the `## Review guidelines` section of
+`AGENTS.md` so automated review tools follow the same approach.
+
 ## Documentation Language
 
 The top-level user guide is maintained in both English and Japanese:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,28 @@ Use placeholder examples in documentation instead. Firmware developers can put
 personal Kconfig overrides in `firmware/sdkconfig.defaults.local`; it is ignored
 by git and loaded by the firmware build.
 
+## AGENTS.md and AGENTS.local.md
+
+This repository provides tracked `AGENTS.md` files at multiple levels (root,
+`gateway/`, `firmware/`, `firmware/main/boards/stackchan/`). These contain
+review guidelines and public developer guides that automated tools (such as
+Codex) and contributors can use.
+
+If you need **personal local configuration** (custom paths, local tokens,
+environment-specific notes), create an `AGENTS.local.md` file in the same
+directory. It is gitignored and will not be committed.
+
+**Migration note:** Before this change, `AGENTS.md` was gitignored. If you
+already have a local `AGENTS.md` with your own configuration, rename it:
+
+```bash
+mv AGENTS.md AGENTS.local.md
+# repeat for any subdirectory where you had one
+```
+
+After renaming, `git pull` will bring in the tracked `AGENTS.md` without
+conflict, and your personal settings continue to work as `AGENTS.local.md`.
+
 ## License Boundary
 
 Most of this repository is MIT licensed. The SCServo-lib-derived files under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,11 @@ If you need **personal local configuration** (custom paths, local tokens,
 environment-specific notes), create an `AGENTS.local.md` file in the same
 directory. It is gitignored and will not be committed.
 
-**Migration note:** Before this change, `AGENTS.md` was gitignored. If you
-already have a local `AGENTS.md` with your own configuration, rename it:
+**Migration note:** Before this change, `AGENTS.md` was gitignored, so you
+may have created your own local `AGENTS.md` with personal configuration.
+We apologize for the inconvenience — we needed to provide repository-level
+review guidelines through tracked `AGENTS.md` files, and this unfortunately
+changes the convention. To migrate, simply rename your existing file:
 
 ```bash
 mv AGENTS.md AGENTS.local.md
@@ -242,6 +245,8 @@ mv AGENTS.md AGENTS.local.md
 
 After renaming, `git pull` will bring in the tracked `AGENTS.md` without
 conflict, and your personal settings continue to work as `AGENTS.local.md`.
+We chose the `.local.md` suffix specifically so this transition is a simple
+rename with no loss of your configuration.
 
 ## License Boundary
 

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -1,0 +1,215 @@
+# firmware/ AGENTS.md (stackchan-mcp)
+
+ESP32 firmware (xiaozhi-esp32 based, stackchan board) developer guide covering **build, flash, device operations, and common troubleshooting**.
+
+For board-specific behavior (SCS0009 servo, Si12T touch, WS lifecycle, license boundary), see `firmware/main/boards/stackchan/AGENTS.md`.
+
+## 1. Hardware specification
+
+| Component | Specification |
+|---|---|
+| MCU | M5Stack CoreS3 (ESP32-S3, 16 MB Flash, **8 MB Octal PSRAM**) |
+| Neck servos | SCS0009 x2 (TX=GPIO6, RX=GPIO7, yaw_id=1, pitch_id=2) — details in `boards/stackchan/AGENTS.md` |
+| Camera | GC0308 (DVP, 320x240) |
+| Touch | FT6336 (LCD screen) / Si12T (head top, I2C 0x68) — distinction matters, details in `boards/stackchan/AGENTS.md` |
+| Display | ILI9342 (SPI, 320x240) |
+
+## 2. Host environment (reference)
+
+- **ESP-IDF**: Docker `espressif/idf:v5.5.2` via OrbStack (or any Docker host). **No native `idf.py` — always use Docker**.
+- **esptool**: Host-installed `esptool.py` (v5.2.0+)
+- **pyserial**: Host Python with `import serial` available (for serial monitor)
+- **USB serial**: `/dev/cu.usbmodem*` (macOS) or equivalent
+
+## 3. Pre-testing checklist (6 items)
+
+Before starting any device verification session, confirm **all paths are live**. Skipping this leads to compound failures (gateway not running → WS connection fails → ESP32 enters idle → auto sleep → USB CDC port disappears).
+
+Run these checks in parallel:
+
+```bash
+# 1. USB serial connected
+ls /dev/cu.usbmodem*
+
+# 2. Gateway process listening (most common oversight)
+lsof -i :8765 | grep LISTEN
+pgrep -fl stackchan_mcp
+
+# 3. Network path to gateway (if using remote access)
+# Verify your chosen access method (Tailscale Funnel, LAN direct, etc.)
+
+# 4. Docker runtime (if building firmware)
+orbctl status    # or equivalent Docker host check
+
+# 5. sdkconfig.defaults.local URL/token alignment
+cat firmware/sdkconfig.defaults.local | head -5
+
+# 6. Build artifact freshness
+git log -1 --format="%h %s"
+ls -lh firmware/build/xiaozhi.bin 2>&1
+```
+
+| Failed check | Resolution |
+|---|---|
+| (1) No USB | Connect USB cable + PMIC short-press ON |
+| (2) No gateway | Start gateway process manually |
+| (3) Network path down | Reconfigure remote access, or fall back to LAN direct |
+| (4) Docker stopped | `orbctl start` (skip if not building) |
+| (5) Config mismatch | Update `sdkconfig.defaults.local` (personal settings, gitignored) |
+| (6) Stale build | `rm -rf build releases/*.zip` → rebuild with `release.py stackchan` |
+
+**All 6 OK** before proceeding to flash/monitor/device operations.
+
+## 4. Build / Flash essentials
+
+### Correct build command
+
+```bash
+cd firmware
+docker run --rm --cpus=4 --ulimit nofile=65536:65536 \
+  -v "$PWD":/project -w /project espressif/idf:v5.5.2 \
+  python ./scripts/release.py stackchan
+```
+
+`release.py stackchan` sets the correct board type (`BOARD_TYPE_STACKCHAN` = M5Stack CoreS3 + Servo). **The `stackchan` argument is mandatory.**
+
+**Do NOT use** `idf.py set-target esp32s3 && idf.py build` — this selects the wrong default board (`BREAD_COMPACT_WIFI`), producing firmware that causes PSRAM mode mismatch boot loops.
+
+`--cpus=4` prevents OOM during LVGL/emoji font compilation on macOS Docker hosts. `--ulimit nofile=65536:65536` prevents `Too many open files` in the same phase.
+
+### Flash (routine iteration)
+
+**Flash `xiaozhi.bin` to `0x20000` to preserve NVS**:
+
+```bash
+esptool.py --chip esp32s3 --port /dev/cu.usbmodemXXXX -b 460800 \
+  --before default_reset --after hard_reset \
+  write_flash 0x20000 build/xiaozhi.bin
+```
+
+**Do NOT flash `merged-binary.bin` to `0x0` in routine work** — this overwrites bootloader through partition table and risks NVS data loss.
+
+### Serial monitor (post-flash)
+
+```python
+import serial, time
+s = serial.Serial('/dev/cu.usbmodemXXXX', 115200, timeout=1)
+end = time.time() + 15
+while time.time() < end:
+    line = s.readline()
+    if line: print(line.decode('utf-8', errors='replace').rstrip())
+s.close()
+```
+
+Do NOT toggle DTR/RTS (this puts the chip into download mode). If USB CDC resets (`Errno 6`), retry with a 1-2 second delay.
+
+## 5. MCP device testing pitfalls
+
+### NVS WS URL override
+
+Devices previously used with other firmware may have stale WS URLs in NVS. The Kconfig fallback (`CONFIG_DEFAULT_WEBSOCKET_URL`) only applies when NVS is empty. To override:
+
+Add to `firmware/sdkconfig.defaults.local` (gitignored):
+
+```
+CONFIG_DEFAULT_WEBSOCKET_URL="ws://<your-gateway-ip>:8765/"
+CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=y
+CONFIG_DEFAULT_WEBSOCKET_TOKEN="<same-token-as-gateway-.env>"
+```
+
+**Never commit these settings to `sdkconfig.defaults`** — they contain personal network configuration that would break other users' builds.
+
+### Gateway restart does not trigger ESP32 reconnect
+
+The ESP32 firmware attempts WS connection at boot time. After starting a new gateway, **hard reset the ESP32** to initiate a fresh connection.
+
+### Token mismatch symptoms
+
+If gateway `.env` token and sdkconfig token don't match: the device connects briefly, then disconnects after ~8 seconds (`EspTcp: TCP receive failed: -1`). Align both tokens and restart.
+
+## 6. LAN IP changes
+
+DHCP environments cause IP drift. If `sdkconfig.defaults.local` contains a hardcoded LAN IP:
+
+1. Check current IP: `ipconfig getifaddr en0` (macOS) or equivalent
+2. Update `sdkconfig.defaults.local`
+3. Rebuild and reflash
+
+For a permanent solution, use DHCP reservation or remote access (see `docs/remote-access.md`).
+
+## 7. Auto sleep behavior (WS disconnected)
+
+When the ESP32 cannot establish a WS connection, it enters progressive sleep:
+
+| Time from boot | Behavior |
+|---|---|
+| 0-30s | Boot + WiFi + first WS attempt |
+| 30-100s | Idle with periodic retry |
+| ~100s | `PowerSaveTimer: Enabling power save mode` + backlight dim |
+| 100-180s | Progressive deep sleep, eventual USB CDC disconnect |
+
+**Recovery**: USB reconnect or PMIC short-press. Note: PMIC short-press is a full ESP32 POWERON reset (SRAM wiped), not a light wake.
+
+**Strategy**: Establish WS connection before starting verification to suppress the sleep timer.
+
+## 8. ESP32 reconnect after auth failure (Issue #61)
+
+After a gateway-side auth rejection, the ESP32 does not retry reconnection. The workaround is a hard reset:
+
+```bash
+esptool.py --before default_reset --after hard_reset chip_id
+```
+
+This is tracked as Issue #61.
+
+## 9. Updating the device to latest main
+
+After merging firmware changes to main, the physical device needs a rebuild + reflash:
+
+```bash
+cd firmware
+rm -rf build releases/*.zip
+docker run --rm --cpus=4 --ulimit nofile=65536:65536 \
+  -v "$PWD":/project -w /project espressif/idf:v5.5.2 \
+  python ./scripts/release.py stackchan
+esptool.py --chip esp32s3 --port /dev/cu.usbmodemXXXX -b 460800 \
+  --before default_reset --after hard_reset \
+  write_flash 0x20000 build/xiaozhi.bin
+```
+
+Check `git log HEAD..origin/main --stat` — if only `gateway/` changed, no reflash needed.
+
+## 10. Device validation responsibilities
+
+For PRs touching device-facing MCP tools (`get_head_angles`, `move_head`, `set_avatar`, etc.):
+
+**Maintainer responsibilities** (can be done remotely):
+- Docker build, build artifact inspection
+- USB serial port discovery, flash, serial monitor
+- Boot log analysis, MCP tool behavioral verification
+- PR validation checklist completion
+
+**Device owner responsibilities** (physical access required):
+- USB cable connect/disconnect
+- PMIC power button operation (long-press 6s OFF / short-press ON)
+- Physical device repositioning
+- Manual head hold for snap-suppress testing
+
+**Destructive action announcement** is the gate condition — always announce before flashing or resetting.
+
+## 11. Common failure patterns
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Boot loop `octal_psram: PSRAM chip is not connected` | Built with wrong board (default instead of stackchan) | Rebuild with `release.py stackchan` |
+| `OSError: [Errno 6] Device not configured` | USB CDC reset after flash | Retry with 1-2s delay |
+| Serial monitor shows 0 lines | Monitor started after boot completed | Hard reset → immediate monitor |
+| WS connects to `wss://api.tenclass.net/...` | Stale NVS URL from previous firmware | Add Force mode to `sdkconfig.defaults.local` (§ 5) |
+| MCP tools 0 / `connected=false` | Token mismatch between gateway and firmware | Align tokens, restart gateway, hard reset ESP32 |
+| `address already in use ('0.0.0.0', 8765)` | Another gateway process running | `lsof -i :8765` to identify, then kill |
+| `releases/*.zip already exists` | Stale build artifact | `rm -rf build releases/*.zip` |
+| `Cannot allocate memory` during LVGL build | Docker OOM on macOS | Use `--cpus=4 --ulimit nofile=65536:65536` |
+| WS connects then disconnects after ~8s | Token mismatch or gateway not restarted after `.env` edit | Align tokens, restart, hard reset |
+| No reconnect after `listening → idle` | Auth-failure disconnect bug (Issue #61) | Hard reset ESP32 |
+| Stale LAN IP in sdkconfig | DHCP lease renewal | Update `sdkconfig.defaults.local`, rebuild, reflash (§ 6) |
+| MCP tools disappear after gateway kill | stdio MCP design — no auto-restart | Restart host or reconnect |

--- a/firmware/main/boards/stackchan/AGENTS.md
+++ b/firmware/main/boards/stackchan/AGENTS.md
@@ -183,8 +183,8 @@ See `README.md` `## Trademarks` for the public specification. This section cover
 ### Pre-commit check
 
 ```bash
-# Personal fork link should not appear
-grep -nE 'mongonta0716/stack-chan(?!-arduino)' <file>
+# Personal fork link should not appear (exclude the -arduino repo)
+grep -n 'mongonta0716/stack-chan' <file> | grep -v 'stackchan-arduino'
 grep -nE 'タカヲ|mongonta555' <file>
 
 # Trademarks section sanity

--- a/firmware/main/boards/stackchan/AGENTS.md
+++ b/firmware/main/boards/stackchan/AGENTS.md
@@ -1,0 +1,208 @@
+# firmware/main/boards/stackchan/ AGENTS.md
+
+Board-specific knowledge for the stackchan configuration (CoreS3 + SCS0009 + Si12T + ILI9342). Covers **servo behavior, touch event classification, WS lifecycle, layer architecture, license boundary, and attribution**.
+
+For general ESP32 build/flash/troubleshooting, see `firmware/AGENTS.md`.
+
+## 1. SCS0009 servo behavior
+
+### Wake-up latency after VM_EN HIGH
+
+After `Servo power ENABLED via PY32 pin 0 (VM EN HIGH confirmed)` (~tick 1275), the SCS0009 needs ~200 ms to wake up. During this window, `ReadPos` and `WritePos` return `-1`. This is **not** a bus hang — it self-clears after 250-350 ms.
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| Bus startup latency | VM_EN HIGH → ~200 ms wake-up | Wait 250-350 ms, self-clears |
+| Bus hang (Issue #100) | Servo internal protection mode (end-stop contact / stall current) | PMIC long-press 6s OFF/ON required |
+
+Boot-early `Boot pre-init ReadPos: yaw_raw=-1 pitch_raw=-1` (at ~tick 140) is within this latency window. The retry mechanism (5x50 ms, 250 ms total, Issue #138 / PR #139) absorbs this.
+
+### `MotionState::current_deg = 0` initial value pitfall
+
+If `MotionState::current_deg` stays at `0` (ReadPos failed without fallback), subsequent `WriteHeadAngles(0, 45, 4000)` interpolation walks through the end-stop region (pos ~620), causing the "boot snap" sound. Fix (PR #139): ReadPos retry + fallback seed `current_deg = BOOT_INIT_PITCH_DEG (=45)`.
+
+### Physical intervention: hand-hold method
+
+During PMIC ON, holding the head at ~45° by hand while the boot-init climb completes (5-6 seconds) is 100% effective — SCS0009 torque is well below human hand resistance. This is the hardware-level fallback until firmware-side fixes fully eliminate the snap.
+
+## 2. Si12T touch event classification
+
+`TouchPollTick()` polls the Si12T (12-channel capacitive touch IC, I2C 0x68) at 10 Hz, classifying events by duration:
+
+### Thresholds
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `TOUCH_POLL_MS` | 100 | Poll interval (10 Hz) |
+| Press confirm | 2 samples (200 ms) | Rising edge confirmation |
+| Release confirm | 4 samples (400 ms) | Falling edge confirmation (absorbs Si12T recalibration gaps) |
+| `TAP_MAX_MS` | 400 | Maximum hold for TAP |
+| `STROKE_MIN_MS` | **400** (was 600) | Minimum hold for STROKE |
+| `REACTION_HOLD_MS` | 3000 | Reaction face display duration |
+| `COOLDOWN_MS` | 800 | Post-reaction touch suppression |
+| `SERVO_WOBBLE_STEP_MS` | 350 (was 200) | Wobble step duration (extended for SCS0009 bus timing) |
+| `SERVO_WOBBLE_AMPLITUDE_DEG` | 20 | Wobble amplitude (yaw ±20°) |
+
+### Event classification (determined at falling edge)
+
+| Hold duration | Event | Reaction |
+|---|---|---|
+| < 200 ms | (debounced) | Nothing |
+| 200 ≤ d < 400 ms | **TAP** | face=`surprised` only |
+| d ≥ 400 ms | **STROKE** | face=`embarrassed` + servo wobble |
+
+### Touch guidance for hardware testing
+
+- The touch sensor is the **Si12T on the head top** (not the LCD screen FT6336)
+- Capacitive — use finger pad, not fingernail
+- STROKE requires holding ≥ 0.4 seconds — a quick tap triggers TAP only
+- Cooldown is 800 ms — space consecutive tests at least 1 second apart
+- Describe as "hold/pet" rather than "tap" to avoid misclassification during testing
+
+### Wobble behavior (post PR #176 fix)
+
+`ServoWobbleStepAdvance()` drives 4 yaw steps: `-A → +A → -A → 0` (A=20°). **Pitch is held at `pitch_motion_.current_deg`** (PR #176 fix). Prior to this fix, `target_pitch = 0` was hardcoded, driving pitch toward the end-stop.
+
+Wobble is **staged** in `StartServoWobble()` (sets flags under `motion_mutex_`) and **executed** in `ServoTaskMain` tick — this avoids races between the touch poll callback (`ESP_TIMER_TASK`) and the servo motion task.
+
+## 3. WebSocket lifecycle pitfalls
+
+### Listening-state touch triggers WS disconnect
+
+In `application.cc`, a touch during `kDeviceStateListening` calls `CloseAudioChannel()` → `websocket_.reset()`, disconnecting the WebSocket. This is problematic for MCP control use cases where the WS should remain open. PR #136 addresses this.
+
+### Boot-time WS auto-connect
+
+`OpenAudioChannel()` is only triggered by user interaction (touch, wake word). Boot does NOT auto-connect. PR #197 adds a boot-time WS auto-connect path.
+
+### LCD display initial state
+
+The avatar is **not shown at boot** — it only appears after a `set_avatar(<face>)` call. Default post-boot/reconnect state is a blank screen. This is tracked as Issue #77 (enhancement: auto-show idle avatar on connect).
+
+## 3.5. Layer architecture (xiaozhi standard vs stackchan overrides)
+
+The stackchan board (`class StackChanBoard : public WifiBoard`, `stackchan.cc:499`) mixes custom implementations with xiaozhi standard passthrough:
+
+### Layer override / passthrough mapping
+
+| Layer | xiaozhi standard | stackchan behavior | Effect |
+|---|---|---|---|
+| Display backend | `Board::GetDisplay()` | Override → `SpiLcdDisplay` (ILI9342 320x240) | Standard LVGL rendering |
+| Status bar | `SetStatus(...)` | Passthrough | Chinese status text, hidden by avatar when active |
+| Emotion icon | `SetEmotion(...)` | Passthrough | Hidden by avatar when active |
+| **Avatar (custom)** | N/A | `avatar_img_` LVGL image, foreground, 320x240 | Covers all standard UI when active |
+| **LED** | `GetLed()` → `NoLed` | No override → NoLed passthrough | **LED does not reflect state** |
+| **Mouth animation (custom)** | N/A | `OnTtsStart/Stop` → lip-sync | Active during speaking only |
+| **Touch reactive face (custom)** | N/A | `TouchPollTick` → surprised/embarrassed | 3-second face change on touch |
+| Backlight | `GetBacklight()` → `nullptr` | Override → `CustomBacklight(pmic_)` | Auto-dim via PowerSaveLevel |
+| Camera | `GetCamera()` → `nullptr` | Override → `camera_` | MCP `take_photo` |
+| Audio codec | `GetAudioCodec()` → `nullptr` | Override → AW88298 + ES7210 | TTS + mic |
+
+### State observation guide
+
+| State | Deterministic observation | NOT reliable |
+|---|---|---|
+| idle / listening | MCP `get_device_status` state field, serial log | LCD avatar (no auto-switch), LED (NoLed) |
+| speaking | Serial log `tts.start`/`tts.stop`, mouth animation | LED |
+| touch reaction | LCD avatar (surprised/embarrassed), serial `touch event:` | LED, MCP state (unchanged) |
+| WS connection | Serial log `WS connected/disconnected`, gateway `/health` | Avatar-covered LCD status |
+
+**Central rule**: deterministic state observation uses **MCP `get_device_status` + serial monitor log**. LCD and LED are supplementary only.
+
+### Placeholder avatar ("Chinese face" symptom)
+
+If `avatar_images.local.cc` was not generated before build, the placeholder (1x1 black pixel) is used. The avatar layer renders as 2x2 pixels, exposing the xiaozhi default Chinese UI underneath. Fix:
+
+```bash
+cd firmware
+python scripts/avatar_convert/convert_avatars.py
+rm -rf build releases/*.zip
+# rebuild and reflash
+```
+
+The `sanity_check.sh` Step 7 detects this before flash.
+
+## 4. License boundary (GPL-3.0 vs MIT)
+
+See `CONTRIBUTING.md` for the full public specification. This section covers the operational check procedure.
+
+### GPL-3.0 files (8, SCServo_lib)
+
+```
+firmware/main/boards/stackchan/INST.h
+firmware/main/boards/stackchan/SCS.cc
+firmware/main/boards/stackchan/SCS.h
+firmware/main/boards/stackchan/SCSCL.cc
+firmware/main/boards/stackchan/SCSCL.h
+firmware/main/boards/stackchan/SCSerial.cc
+firmware/main/boards/stackchan/SCSerial.h
+firmware/main/boards/stackchan/SCServo.h
+```
+
+### Pre-edit check
+
+```bash
+# Verify license headers present
+grep -nE 'GPL-3.0|GNU General Public License' firmware/main/boards/stackchan/*.{cc,h} | head -20
+
+# Check if target file is GPL or MIT
+grep -l 'GPL-3.0\|GNU General' firmware/main/boards/stackchan/<target-file>
+```
+
+### Rules
+
+- **Never remove GPL headers** from the 8 files
+- **Never include MIT code from GPL files** (reverse-direction include risks viral effect)
+- **No new GPL code** — new servo control code uses the MIT `feetech_scs` component
+- Phase A (PR #83): canonical build uses MIT path by default, GPL is opt-in fallback
+- Phase B (Issue #144, pending): remove SCServo_lib 8 files entirely
+
+### Gateway boundary
+
+`gateway/` (Python, MIT) communicates via WebSocket — a separate process with no GPL contamination risk.
+
+## 5. stack-chan project attribution
+
+See `README.md` `## Trademarks` for the public specification. This section covers the check procedure.
+
+### Canonical credits
+
+| Item | Value |
+|---|---|
+| **Creator** | Shinya Ishikawa, 2021 |
+| **Official org** | `stack-chan/stack-chan` (Apache-2.0) |
+| **Trademark** | "StackChan" / "スタックチャン" = registered trademark of Shinya Ishikawa (defensive registration for OSS protection) |
+| **Arduino servo lib** | `stack-chan/stackchan-arduino` (MIT, maintainer: Takao Akaki / mongonta0716) |
+
+### Common misspellings to avoid
+
+- ~~`mongonta0716/stack-chan`~~ → use `stack-chan/stack-chan` (org, not personal fork)
+- ~~`mongonta555`~~ → `mongonta0716`
+- ~~タカヲ~~ → **タカオ** (Takao)
+
+### Pre-commit check
+
+```bash
+# Personal fork link should not appear
+grep -nE 'mongonta0716/stack-chan(?!-arduino)' <file>
+grep -nE 'タカヲ|mongonta555' <file>
+
+# Trademarks section sanity
+grep -A 3 '^## Trademarks' README.md
+grep -A 3 '^## 商標' README.ja.md
+```
+
+## 6. Board-specific failure patterns
+
+For general failures (build/NVS/WS/sleep), see `firmware/AGENTS.md`. These are servo/touch/WS-lifecycle specific:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Boot `ReadPos: yaw_raw=-1 pitch_raw=-1` | SCS0009 wake-up latency | ReadPos retry (PR #139). See § 1 |
+| End-stop walk during boot climb | `current_deg = 0` without ReadPos fallback | ReadPos fallback seed (PR #139). See § 1 |
+| "snap" sound + bus hang at boot | PMIC OFF/ON without snap-suppress | Hand-hold at 45° during boot. See § 1 |
+| Touch triggers WS disconnect | `CloseAudioChannel()` in listening state | PR #136 (pending). See § 3 |
+| Quick tap doesn't trigger wobble | TAP (< 400 ms) vs STROKE (≥ 400 ms) | Hold ≥ 0.4s. See § 2 |
+| Wobble drives pitch to end-stop | `target_pitch = 0` hardcode bug | Fixed in PR #176. See § 2 |
+| Chinese UI visible instead of avatar | `avatar_images.local.cc` not generated | Run `convert_avatars.py`, rebuild. See § 3.5 |
+| `smooth_ui_toolkit` component missing | Submodule not initialized in worktree | `git submodule update --init firmware/components/smooth_ui_toolkit` |

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -1,0 +1,79 @@
+# gateway/ AGENTS.md (stackchan-mcp)
+
+Python MCP gateway (`stackchan_mcp` package) developer guide.
+
+For ESP32 firmware build/flash/device operations, see `firmware/AGENTS.md`. For board-specific behavior (servo, touch, avatar), see `firmware/main/boards/stackchan/AGENTS.md`.
+
+## 1. stdio MCP constraint
+
+The gateway runs as a **stdio MCP server** — it lives as long as the host process keeps stdin/stdout open.
+
+- Editing `.env` does NOT reload the running process. **MCP process restart is required** (restart the host application or reconnect).
+- Killing the gateway process directly does NOT auto-restart it. The host must reconnect.
+
+### Verifying token configuration
+
+```bash
+grep "^STACKCHAN_TOKEN=" gateway/.env
+grep "^BEARER_TOKEN=" gateway/.env    # legacy alias
+```
+
+## 2. `STACKCHAN_TOKEN` vs `BEARER_TOKEN` priority
+
+```python
+expected = os.getenv("STACKCHAN_TOKEN") or os.getenv("BEARER_TOKEN")
+```
+
+**`STACKCHAN_TOKEN` takes priority**; `BEARER_TOKEN` is a legacy alias checked only when the primary is empty. Keep both set to the same value as insurance.
+
+The ESP32 firmware token (`CONFIG_DEFAULT_WEBSOCKET_TOKEN` in sdkconfig) must match — see `firmware/AGENTS.md` for details.
+
+## 3. Gateway status check
+
+```bash
+# Process check
+lsof -i :8765 | grep LISTEN          # python LISTEN = OK
+pgrep -fl stackchan_mcp              # process list
+
+# Port conflict check
+lsof -i :8765                        # ESTABLISHED sockets are MCP client connections, not conflicts
+```
+
+If `address already in use ('0.0.0.0', 8765)` occurs, identify the existing process with `lsof` before killing.
+
+## 4. LAN IP changes (gateway side)
+
+The gateway listens on `0.0.0.0:8765`, so LAN IP changes do not directly affect it. The issue is on the ESP32 side — see `firmware/AGENTS.md` for details.
+
+## 5. Validation commands (pre-PR)
+
+```bash
+cd gateway
+uv sync                 # resolve dependencies
+uv run pytest           # tests must pass
+uv run ruff check .     # lint must pass
+```
+
+CI runs the same three commands. A local failure means CI will also fail.
+
+## 6. PyPI publishing
+
+- Bump `version` in `gateway/pyproject.toml`
+- Promote `CHANGELOG.md` `[Unreleased]` Gateway subsection to `[X.Y.Z] - YYYY-MM-DD`
+- Tag push (`git tag vX.Y.Z && git push origin vX.Y.Z`) triggers Trusted Publishing
+- Verify with `pipx install --force stackchan-mcp` after publishing
+
+## 7. `.env` edit checklist
+
+```bash
+# 1. Verify values
+grep "^STACKCHAN_TOKEN=" gateway/.env
+
+# 2. Restart MCP process (host restart or /mcp reconnect)
+
+# 3. Verify reconnection
+# In host: get_status → connected: true / tools_count: 14+
+
+# 4. If token mismatch, also update ESP32 sdkconfig
+#    See firmware/AGENTS.md for token alignment procedure
+```


### PR DESCRIPTION
## Summary

- Split `AGENTS.md` into two layers: tracked (public) and `.local.md` (gitignored, personal)
- Added `## Review guidelines` section to root `AGENTS.md` for automated code review guidance
- Created public developer guides at all four levels (root, gateway, firmware, boards/stackchan)
- Updated `.gitignore` to ignore `AGENTS.local.md` instead of `AGENTS.md`
- Added migration guide to `CONTRIBUTING.md`

## Motivation

Automated code review (codex-connector) reads tracked `AGENTS.md` files but had no repository-specific guidance — review findings defaulted to generic SaaS-scale priorities that don't fit this single-user hobby product. The review guidelines section addresses this by instructing reviewers to:

- Prioritize user-facing correctness over edge-case hardening
- Keep DoS/resource-exhaustion findings low priority (single user, single device, single LAN)
- Be kind to contributors (hobby project welcoming first-time contributors)

The public developer guides provide build, flash, troubleshooting, and board-specific knowledge that benefits both automated tools and external contributors, without exposing personal development environment details.

## Migration for existing contributors

Previously, `AGENTS.md` was gitignored and contributors could place their own local configuration there. This PR tracks `AGENTS.md` (public guidelines) and gitignores `AGENTS.local.md` (personal config) instead.

If you have an existing local `AGENTS.md`, rename it before pulling:

```bash
mv AGENTS.md AGENTS.local.md
# repeat for subdirectories if needed
```

See the new section in `CONTRIBUTING.md` for details.

## What changed

| File | Content |
|---|---|
| `.gitignore` | `AGENTS.md` → `AGENTS.local.md` |
| `AGENTS.md` (root) | Review guidelines + repo structure + getting started |
| `gateway/AGENTS.md` | stdio MCP constraints, token config, validation commands |
| `firmware/AGENTS.md` | Build/flash essentials, pre-testing checklist, common failures |
| `firmware/main/boards/stackchan/AGENTS.md` | Servo behavior, touch classification, WS lifecycle, layer architecture, license boundary, attribution |
| `CONTRIBUTING.md` | Migration guide for AGENTS.md → AGENTS.local.md |

## Test plan

- [ ] Verify codex-connector reads the review guidelines on the next contributor PR
- [ ] Verify local codex reads the tracked AGENTS.md correctly
- [ ] Verify `AGENTS.local.md` files remain gitignored and functional for local development
- [ ] Verify no personal paths, names, or internal references leaked into tracked files