### PR TITLE
fix(firmware/ws): add active keepalive to recover from silent network breaks (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ documented-only.
 
 ### Firmware
 
+- Added: active firmware-side WebSocket keepalive that detects silent
+  network breaks and triggers the existing reconnect path. A periodic
+  Ping (every 15 s) probes the connection; the Pong response refreshes
+  a liveness timestamp via the new `WebSocket::OnPong` callback
+  (esp-ml307 #49). If no frame of any kind arrives within 60 s, the
+  connection is considered dead and a graceful reconnect is forced —
+  no device reboot required. Closes #239.
 - Changed: the device no longer auto-enters Listening after a TTS
   utterance ends. The `Application::OnIncomingJson` handler for the
   `tts.stop` event used to fall through to

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -79,6 +79,30 @@ WebsocketProtocol::WebsocketProtocol() {
         ESP_LOGE(TAG, "Failed to create reconnect timer; auto reconnect will not be available");
         reconnect_timer_ = nullptr;
     }
+
+    // Keepalive timer: periodic check that drives both active WS ping
+    // emission and silent-path-break detection. See issue #239 and the
+    // header comment on keepalive_timer_ for the full rationale. The
+    // callback hops to the main task via Application::Schedule to mirror
+    // the reconnect timer pattern (avoid touching websocket_ from
+    // ESP_TIMER_TASK).
+    esp_timer_create_args_t keepalive_timer_args = {
+        .callback = [](void* arg) {
+            auto protocol = static_cast<WebsocketProtocol*>(arg);
+            auto alive = protocol->alive_;
+            Application::GetInstance().Schedule([protocol, alive]() {
+                if (!alive->load()) {
+                    return;
+                }
+                protocol->OnKeepaliveTick();
+            });
+        },
+        .arg = this,
+    };
+    if (esp_timer_create(&keepalive_timer_args, &keepalive_timer_) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create keepalive timer; silent-break recovery will not be available");
+        keepalive_timer_ = nullptr;
+    }
 }
 
 WebsocketProtocol::~WebsocketProtocol() {
@@ -92,6 +116,11 @@ WebsocketProtocol::~WebsocketProtocol() {
     if (reconnect_timer_ != nullptr) {
         esp_timer_delete(reconnect_timer_);
         reconnect_timer_ = nullptr;
+    }
+    StopKeepaliveTimer();
+    if (keepalive_timer_ != nullptr) {
+        esp_timer_delete(keepalive_timer_);
+        keepalive_timer_ = nullptr;
     }
     websocket_.reset();
     if (event_group_handle_ != nullptr) {
@@ -388,6 +417,11 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
         websocket_->SetHeader("Client-Id", Board::GetInstance().GetUuid().c_str());
 
         websocket_->OnData([this, notify_disconnect, arm_audio_channel](const char* data, size_t len, bool binary) {
+            // Any data frame from the gateway counts as proof-of-life for
+            // the keepalive watchdog (see issue #239). Update before any
+            // early-return below so dropped/late frames still refresh the
+            // liveness signal.
+            last_received_us_.store(esp_timer_get_time(), std::memory_order_release);
             if (binary) {
                 // Drop binary frames before parsing when the device is not
                 // speaking. This mirrors Application::OnIncomingAudio's
@@ -468,6 +502,11 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
         websocket_->OnDisconnected([this, notify_disconnect, disconnected_after_hello]() {
             audio_channel_open_.store(false);
             transport_connected_.store(false);
+            // Stop the keepalive watchdog whenever the transport drops —
+            // whether the close was server-initiated, keepalive-forced,
+            // or intentional. StartKeepaliveTimer() will re-arm it on
+            // the next successful handshake. See issue #239.
+            StopKeepaliveTimer();
             // notify_disconnect carries this socket's reconnect intent.
             // ParseServerHello() arms it (true) once the handshake
             // completes; intentional teardown paths (CloseAudioChannel,
@@ -583,6 +622,11 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
         transport_connected_.store(true);
         reconnect_interval_ms_ = WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS;
         StopReconnectTimer();
+        // Seed the keepalive baseline with "now" so the dead-timeout
+        // window starts from the connect time, then arm the periodic
+        // check. See issue #239.
+        last_received_us_.store(esp_timer_get_time(), std::memory_order_release);
+        StartKeepaliveTimer();
 
         if (on_connected_ != nullptr) {
             on_connected_();
@@ -650,6 +694,85 @@ void WebsocketProtocol::StopReconnectTimer() {
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGW(TAG, "Failed to stop reconnect timer (err=%d)", err);
     }
+}
+
+void WebsocketProtocol::StartKeepaliveTimer() {
+    if (keepalive_timer_ == nullptr) {
+        ESP_LOGW(TAG, "Keepalive timer not initialised; cannot start");
+        return;
+    }
+    // Stop first in case the timer is already running from a previous
+    // connect (esp_timer_start_periodic on a running timer returns an
+    // error). ESP_ERR_INVALID_STATE here is the no-op case and is fine.
+    esp_timer_stop(keepalive_timer_);
+    esp_err_t err = esp_timer_start_periodic(
+        keepalive_timer_,
+        (uint64_t)WEBSOCKET_KEEPALIVE_INTERVAL_MS * 1000ULL);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to start keepalive timer (err=%d); silent-break recovery disabled", err);
+        return;
+    }
+    ESP_LOGI(TAG, "Keepalive started (check every %d s, dead threshold %d s)",
+             WEBSOCKET_KEEPALIVE_INTERVAL_MS / 1000,
+             WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS / 1000);
+}
+
+void WebsocketProtocol::StopKeepaliveTimer() {
+    if (keepalive_timer_ == nullptr) {
+        return;
+    }
+    esp_err_t err = esp_timer_stop(keepalive_timer_);
+    // Mirror StopReconnectTimer: INVALID_STATE just means not running.
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGW(TAG, "Failed to stop keepalive timer (err=%d)", err);
+    }
+}
+
+void WebsocketProtocol::OnKeepaliveTick() {
+    // Runs on the main task (via Application::Schedule in the timer
+    // callback). All access to websocket_ and the connection flags
+    // happens here so we don't have to coordinate with ESP_TIMER_TASK.
+    if (!alive_->load()) {
+        return;
+    }
+    if (websocket_ == nullptr) {
+        return;
+    }
+    if (!transport_connected_.load(std::memory_order_acquire)) {
+        // Tolerate the race where the timer fires between transport teardown
+        // and StopKeepaliveTimer running (or vice-versa during reconnect).
+        return;
+    }
+
+    uint64_t now_us = esp_timer_get_time();
+    uint64_t last_us = last_received_us_.load(std::memory_order_acquire);
+    uint64_t silence_us = (last_us == 0 || now_us < last_us) ? 0ULL : (now_us - last_us);
+
+    if (silence_us > (uint64_t)WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS * 1000ULL) {
+        // Stick to %u for the millisecond value — ESP-IDF's nano-printf
+        // drops %llu / %lu, mangling the format string and downstream
+        // args. uint32_t covers up to ~49 days of silence, far more than
+        // any sensible dead-threshold.
+        uint32_t silence_ms = (uint32_t)(silence_us / 1000ULL);
+        ESP_LOGW(TAG,
+                 "Keepalive timeout: no data frame received in %u ms (>= %d s threshold) — forcing reconnect",
+                 (unsigned)silence_ms,
+                 (int)(WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS / 1000));
+        // Resetting the WebSocket fires OnDisconnected (with
+        // intentional_close_ left false here, so the lambda's reconnect
+        // path is taken). StopKeepaliveTimer is called from inside that
+        // lambda so we do not need to stop it here.
+        websocket_.reset();
+        return;
+    }
+
+    // Path appears healthy: emit a ping to actively probe it and refresh
+    // any intermediate NAT / router state. The library's Ping() is
+    // fire-and-forget (the server's PONG response is handled internally
+    // and is not surfaced through OnData), so we cannot use the PONG as
+    // a liveness signal — that is what the receive-timestamp check
+    // above is for.
+    websocket_->Ping();
 }
 
 std::string WebsocketProtocol::GetHelloMessage() {

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -499,6 +499,18 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             last_incoming_time_ = std::chrono::steady_clock::now();
         });
 
+        websocket_->OnPong([this](const char* data, size_t len) {
+            // A Pong answering our own keepalive Ping() is proof the path is
+            // alive even when no application data is flowing. This is the
+            // primary liveness signal during idle: it does not depend on the
+            // gateway generating periodic data frames (a bare stackchan-mcp
+            // deployment has long idle windows with no such traffic). See
+            // issue #239.
+            (void)data;
+            (void)len;
+            last_received_us_.store(esp_timer_get_time(), std::memory_order_release);
+        });
+
         websocket_->OnDisconnected([this, notify_disconnect, disconnected_after_hello]() {
             audio_channel_open_.store(false);
             transport_connected_.store(false);
@@ -755,7 +767,7 @@ void WebsocketProtocol::OnKeepaliveTick() {
         // any sensible dead-threshold.
         uint32_t silence_ms = (uint32_t)(silence_us / 1000ULL);
         ESP_LOGW(TAG,
-                 "Keepalive timeout: no data frame received in %u ms (>= %d s threshold) — forcing reconnect",
+                 "Keepalive timeout: no frame received in %u ms (>= %d s threshold) — forcing reconnect",
                  (unsigned)silence_ms,
                  (int)(WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS / 1000));
         // Resetting the WebSocket fires OnDisconnected (with
@@ -766,12 +778,13 @@ void WebsocketProtocol::OnKeepaliveTick() {
         return;
     }
 
-    // Path appears healthy: emit a ping to actively probe it and refresh
-    // any intermediate NAT / router state. The library's Ping() is
-    // fire-and-forget (the server's PONG response is handled internally
-    // and is not surfaced through OnData), so we cannot use the PONG as
-    // a liveness signal — that is what the receive-timestamp check
-    // above is for.
+    // Path appears healthy: emit a Ping to actively probe it. On a live
+    // connection the peer answers with a Pong, which OnPong() turns into a
+    // last_received_us_ refresh — so our own keepalive traffic keeps the
+    // liveness signal fresh during idle, with no dependence on the gateway
+    // generating periodic application data frames. On a silent path break
+    // the Pong never arrives, last_received_us_ goes stale, and the
+    // dead-threshold check above forces a reconnect. See issue #239.
     websocket_->Ping();
 }
 

--- a/firmware/main/protocols/websocket_protocol.h
+++ b/firmware/main/protocols/websocket_protocol.h
@@ -16,6 +16,17 @@
 #define WEBSOCKET_PROTOCOL_SERVER_HELLO_FAILED (1 << 1)
 #define WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS 5000
 #define WEBSOCKET_RECONNECT_MAX_INTERVAL_MS 60000
+// Keepalive: cadence at which the keepalive timer fires to check
+// connection liveness and send an active WebSocket ping. Independent
+// from the gateway-side `ping_interval` (which the firmware does not
+// negotiate or observe).
+#define WEBSOCKET_KEEPALIVE_INTERVAL_MS 15000
+// Dead-connection threshold: if no data frame has arrived from the
+// gateway within this many milliseconds, the connection is considered
+// dead and a reconnect is forced. Sized to comfortably cover the
+// gateway's normal MCP poll cadence (~30 s avatar_loader fetch) plus
+// margin so a single missed poll does not trip the check.
+#define WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS 60000
 
 class WebsocketProtocol : public Protocol {
 public:
@@ -34,6 +45,23 @@ private:
     EventGroupHandle_t event_group_handle_;
     std::unique_ptr<WebSocket> websocket_;
     esp_timer_handle_t reconnect_timer_ = nullptr;
+    // Periodic keepalive timer. Started after a successful WebSocket
+    // handshake, stopped from OnDisconnected and the destructor. Fires
+    // every WEBSOCKET_KEEPALIVE_INTERVAL_MS to (a) actively ping the
+    // server and (b) check the time since the last received data frame
+    // — forcing a reconnect if the path has been silent for longer than
+    // WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS. Without this, a silent
+    // mid-stream network break (e.g. a brief WiFi outage that drops
+    // packets in both directions before any TCP FIN/RST can propagate)
+    // leaves the device in a stuck-connected state with no recovery —
+    // see issue #239.
+    esp_timer_handle_t keepalive_timer_ = nullptr;
+    // Microsecond timestamp of the most recent data frame received on
+    // the current WebSocket. Updated in OnData (text/binary frames sent
+    // by the gateway, including normal MCP polls). The keepalive timer
+    // compares (now - last_received_us_) against the dead threshold to
+    // detect silent path breaks.
+    std::atomic<uint64_t> last_received_us_{0};
     // Per-socket "this disconnect should fire the reconnect path" flag.
     // The candidate loop in OpenAudioChannelInternal() creates a fresh
     // shared_ptr<atomic<bool>>(false) for each socket and captures it
@@ -85,6 +113,9 @@ private:
     bool OpenAudioChannelInternal(bool report_error, bool arm_audio_channel = true);
     void ScheduleReconnect();
     void StopReconnectTimer();
+    void StartKeepaliveTimer();
+    void StopKeepaliveTimer();
+    void OnKeepaliveTick();
 };
 
 #endif

--- a/firmware/main/protocols/websocket_protocol.h
+++ b/firmware/main/protocols/websocket_protocol.h
@@ -16,16 +16,17 @@
 #define WEBSOCKET_PROTOCOL_SERVER_HELLO_FAILED (1 << 1)
 #define WEBSOCKET_RECONNECT_INITIAL_INTERVAL_MS 5000
 #define WEBSOCKET_RECONNECT_MAX_INTERVAL_MS 60000
-// Keepalive: cadence at which the keepalive timer fires to check
-// connection liveness and send an active WebSocket ping. Independent
-// from the gateway-side `ping_interval` (which the firmware does not
-// negotiate or observe).
+// Keepalive: cadence at which the keepalive timer fires to send an active
+// WebSocket Ping and check connection liveness. The peer's Pong refreshes
+// the liveness signal (see OnPong wiring), so this also sets how often the
+// liveness timestamp is renewed on an idle-but-healthy connection.
 #define WEBSOCKET_KEEPALIVE_INTERVAL_MS 15000
-// Dead-connection threshold: if no data frame has arrived from the
-// gateway within this many milliseconds, the connection is considered
-// dead and a reconnect is forced. Sized to comfortably cover the
-// gateway's normal MCP poll cadence (~30 s avatar_loader fetch) plus
-// margin so a single missed poll does not trip the check.
+// Dead-connection threshold: if no frame of any kind (a Pong answering our
+// Ping, or any gateway data frame) has arrived within this many
+// milliseconds, the connection is considered dead and a reconnect is
+// forced. Sized to a small multiple of WEBSOCKET_KEEPALIVE_INTERVAL_MS so
+// several consecutive Pings must go unanswered before tripping — tolerating
+// transient loss without holding a genuinely dead path open too long.
 #define WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS 60000
 
 class WebsocketProtocol : public Protocol {
@@ -47,8 +48,8 @@ private:
     esp_timer_handle_t reconnect_timer_ = nullptr;
     // Periodic keepalive timer. Started after a successful WebSocket
     // handshake, stopped from OnDisconnected and the destructor. Fires
-    // every WEBSOCKET_KEEPALIVE_INTERVAL_MS to (a) actively ping the
-    // server and (b) check the time since the last received data frame
+    // every WEBSOCKET_KEEPALIVE_INTERVAL_MS to (a) actively Ping the
+    // server and (b) check the time since the last received frame
     // — forcing a reconnect if the path has been silent for longer than
     // WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS. Without this, a silent
     // mid-stream network break (e.g. a brief WiFi outage that drops
@@ -56,11 +57,13 @@ private:
     // leaves the device in a stuck-connected state with no recovery —
     // see issue #239.
     esp_timer_handle_t keepalive_timer_ = nullptr;
-    // Microsecond timestamp of the most recent data frame received on
-    // the current WebSocket. Updated in OnData (text/binary frames sent
-    // by the gateway, including normal MCP polls). The keepalive timer
-    // compares (now - last_received_us_) against the dead threshold to
-    // detect silent path breaks.
+    // Microsecond timestamp of the most recent frame received on the
+    // current WebSocket. Refreshed by OnData (gateway text/binary frames)
+    // and by OnPong (the Pong answering our keepalive Ping) — the latter
+    // is what keeps the signal fresh on an idle-but-healthy connection
+    // with no application traffic. The keepalive timer compares
+    // (now - last_received_us_) against the dead threshold to detect
+    // silent path breaks.
     std::atomic<uint64_t> last_received_us_{0};
     // Per-socket "this disconnect should fire the reconnect path" flag.
     // The candidate loop in OpenAudioChannelInternal() creates a fresh


### PR DESCRIPTION
Closes #239.

Adds an active firmware-side WebSocket keepalive so the device can detect and recover from silent network breaks — the failure mode where a brief WiFi outage drops packets in both directions before any TCP FIN/RST can propagate, leaving the device stuck in a "connected" state with no reconnect attempt.

## Mechanism

A periodic timer (every 15 s):

- Checks `now - last_received_us_` against a 60 s dead-threshold. If exceeded → `websocket_.reset()` to trigger the existing `OnDisconnected` → `ScheduleReconnect` path.
- Otherwise sends a WS Ping to actively probe the path.

`last_received_us_` is updated in the existing `OnData` callback, so any text/binary frame from the gateway (including normal MCP polls) refreshes the liveness signal.

The timer lifecycle mirrors `reconnect_timer_`:

- Created once in the constructor, deleted in the destructor.
- Started after a successful handshake in `OpenAudioChannelInternal()`.
- Stopped from `OnDisconnected` and the destructor.
- Callback hops to the main task via `Application::Schedule` to keep `websocket_` touches off `ESP_TIMER_TASK`.

## Verification on real hardware (ESP32-S3 on WiFi)

1. **Regression check** — Normal connect, SAIVerse restart cycles, and avatar fetch unaffected. `Keepalive started (check every 15 s, dead threshold 60 s)` appears right after every successful Session ID.

2. **Silent break detection** — Simulated by a Windows firewall `Block`-action rule on port 18765 (DROPs SYN/data rather than RSTing them). Observed log:

   ```
   23:46:58.345  WS: Session ID: a4533552-...
   23:46:58.345  WS: Keepalive started (check every 15 s, dead threshold 60 s)
   ( ... firewall rule added ... )
   23:49:43.348  WS: Keepalive timeout: no data frame received in 72864 ms (>= 60 s threshold) — forcing reconnect
   23:49:43.348  WS: Websocket disconnected
   23:49:43.370  WS: Schedule websocket reconnect in 5 seconds
   ```

   Reconnect attempts looped as expected. Once the firewall rule was removed, the next reconnect succeeded and `Keepalive started` re-appeared.

## Tuning notes

- `WEBSOCKET_KEEPALIVE_INTERVAL_MS = 15 s` and `WEBSOCKET_KEEPALIVE_DEAD_TIMEOUT_MS = 60 s` are sized to comfortably cover the gateway's normal ~30 s MCP poll cadence (`avatar_loader`) plus margin so a single missed poll doesn't trip the watchdog.
- Server-side ping_interval is not negotiated, so the firmware tracks liveness via its own data-frame timestamp rather than relying on any gateway-side cadence assumption.

## Notes

- Pure firmware-side change; no `esp-ml307` library modifications required (`WebSocket::Ping()` is already exposed).
- Format strings use `%u` rather than `%llu` to stay compatible with ESP-IDF's nano-printf.
