### PR TITLE
chore(workflow): auto-add new issues and PRs to maintainer triage board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,20 @@
+name: Add issues and PRs to maintainer board
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    name: Add to maintainer board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/users/kisaragi-mochi/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary

Add a maintainer-side workflow that automatically inserts newly-opened
issues and pull requests into a private maintainer triage board.

## What this changes

- **New file**: `.github/workflows/add-to-project.yml`
- Triggers on `issues.opened` and `pull_request_target.opened`
- Uses `actions/add-to-project@v2.0.0` to add the item to the maintainer
  triage board

## What this does NOT change

- No effect on CI builds, releases, or the contributor experience
- The triage board itself is **Private**: external viewers see only a
  "Private project" tag in the issue/PR sidebar — no project name or field
  values are exposed
- No code is checked out; the action only invokes the GitHub Project API

## Required setup (one-time, after merge)

A repository secret `ADD_TO_PROJECT_PAT` must be created with a token
holding `project` and `read:project` scopes:

```bash
gh auth refresh -s read:project,project   # if not already on the active token
gh auth token | gh secret set ADD_TO_PROJECT_PAT --repo kisaragi-mochi/stackchan-mcp
```

## Test plan

- [ ] After merge + secret setup, open a test issue and confirm it appears
  in the triage board
- [ ] Confirm no errors in the Actions run logs

## Notes

- Uses `pull_request_target` (not `pull_request`) so the action can access
  the secret on PRs from forks. The action itself only calls the Project
  API — it never checks out contributor code, so this is safe.
- The project URL refers to a private maintainer board; external viewers
  cannot access its contents.