### PR TITLE
fix(firmware/ws): #61 reconnect post-handshake + keep loop alive on empty candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ documented-only.
 
 ### Firmware
 
+- Fixed: post-handshake WebSocket disconnects re-arm the existing reconnect timer without double-advancing backoff.
+
 - Changed: the device no longer auto-enters Listening after a TTS
   utterance ends. The `Application::OnIncomingJson` handler for the
   `tts.stop` event used to fall through to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ documented-only.
 
 ### Firmware
 
+- Fixed: empty WebSocket gateway discovery results now fall through to the shared reconnect failure path, clearing the intentional-close latch so retries continue after a gateway restart.
+
 - Fixed: post-handshake WebSocket disconnects re-arm the existing reconnect timer without double-advancing backoff.
 
 - Changed: the device no longer auto-enters Listening after a TTS

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -345,10 +345,14 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
     auto network = Board::GetInstance().GetNetwork();
     if (gateway_candidates.empty()) {
         ESP_LOGE(TAG, "WS_URL not configured: no websocket gateway URL candidates available");
-        if (report_error) {
-            SetError(Lang::Strings::SERVER_NOT_CONNECTED);
-        }
-        return false;
+        // Do not return early here: fall through to the shared failure exit so
+        // intentional_close_ is cleared and ScheduleReconnect() can arm the
+        // next retry. Returning here left the latch set from the prologue, so
+        // ScheduleReconnect() later refused the retry after a single mDNS
+        // 0-result on gateway restart (Issue #61 real-device finding). The
+        // loop below naturally performs zero iterations for an empty vector,
+        // and the shared exit reports SERVER_NOT_CONNECTED because
+        // server_hello_timed_out remains false on this path.
     }
 
     if (!token.empty() && token.find(" ") == std::string::npos) {

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -42,6 +42,7 @@ WebsocketProtocol::WebsocketProtocol() {
                 if (!alive->load()) {
                     return;
                 }
+                protocol->reconnect_timer_armed_.store(false);
                 // Re-check intent on the main task. esp_timer_stop() does
                 // not cancel work that the timer has already re-posted via
                 // Application::Schedule, so a CloseAudioChannel() or
@@ -475,7 +476,7 @@ bool WebsocketProtocol::OpenAudioChannelInternal(bool report_error, bool arm_aud
             // before resetting the socket. A false reading here means
             // either the candidate never completed handshake or the
             // close was intentional — neither should reconnect.
-            if (!notify_disconnect->load()) {
+            if (!notify_disconnect->load(std::memory_order_acquire)) {
                 ESP_LOGI(TAG, "Websocket disconnected (no reconnect: candidate failed or intentional close)");
                 return;
             }
@@ -627,10 +628,15 @@ void WebsocketProtocol::ScheduleReconnect() {
         ESP_LOGI(TAG, "Reconnect not scheduled (intentional close in progress)");
         return;
     }
+    bool expected = false;
+    if (!reconnect_timer_armed_.compare_exchange_strong(expected, true)) {
+        ESP_LOGI(TAG, "Reconnect already scheduled");
+        return;
+    }
 
-    StopReconnectTimer();
     esp_err_t err = esp_timer_start_once(reconnect_timer_, reconnect_interval_ms_ * 1000);
     if (err != ESP_OK) {
+        reconnect_timer_armed_.store(false);
         ESP_LOGW(TAG, "Failed to start reconnect timer (err=%d); reconnect not scheduled", err);
         return;
     }
@@ -639,6 +645,7 @@ void WebsocketProtocol::ScheduleReconnect() {
 }
 
 void WebsocketProtocol::StopReconnectTimer() {
+    reconnect_timer_armed_.store(false);
     if (reconnect_timer_ == nullptr) {
         return;
     }

--- a/firmware/main/protocols/websocket_protocol.h
+++ b/firmware/main/protocols/websocket_protocol.h
@@ -34,6 +34,10 @@ private:
     EventGroupHandle_t event_group_handle_;
     std::unique_ptr<WebSocket> websocket_;
     esp_timer_handle_t reconnect_timer_ = nullptr;
+    // True while reconnect_timer_ has a pending one-shot retry. This keeps
+    // independent failure/disconnect paths from double-arming the same retry
+    // and advancing reconnect_interval_ms_ more than once.
+    std::atomic<bool> reconnect_timer_armed_ = false;
     // Per-socket "this disconnect should fire the reconnect path" flag.
     // The candidate loop in OpenAudioChannelInternal() creates a fresh
     // shared_ptr<atomic<bool>>(false) for each socket and captures it


### PR DESCRIPTION
## Summary

Two firmware-side reconnect-loop fixes that together restore Issue #61's expected behavior: the device automatically retries the WebSocket connection after **any** post-handshake disconnect, with exponential backoff, indefinitely. Verified on real hardware.

## Background — Issue #61 was a two-headed bug

PR #35 covered reconnect after connecting-phase failures or proactive gateway restarts. Two failure modes remained:

1. **Post-handshake server-initiated close** — when the gateway disconnects after the handshake (token mismatch, gateway crash mid-session, network blip), the firmware logged the disconnect but did not re-arm the reconnect timer. The state machine transitioned `listening → idle` and stayed there indefinitely.

2. **Reconnect-loop death on empty discovery** — when `OpenAudioChannelInternal()` ran with NO gateway URL candidates (e.g. mDNS returned 0 results on a gateway restart with an empty NVS url), an early `return false` left `intentional_close_` latched at `true` (set in the prologue) and never reached `ScheduleReconnect()`. After a single mDNS miss the device armed no further retry and went idle → deep sleep, stranded until a hard reset.

The first commit addresses (1). Real-device verification of that commit then surfaced (2), which the second commit fixes.

## Changes

### Commit 1 — post-handshake disconnect re-arms the timer

Add a `reconnect_timer_armed_` atomic flag to `WebsocketProtocol`. After `OnDisconnected` clears its `notify_disconnect` token (i.e. a real post-handshake disconnect for this socket, past the `intentional_close_` and per-candidate guards from PR #197 / #219), if the timer is not already armed, arm it on the existing reconnect-timer infrastructure. The flag clears when the reconnect job actually starts on the main task, preventing:

- The connecting-phase failure path and the post-handshake disconnect path from double-arming the same retry (which would advance `reconnect_interval_ms_` more than once per cycle).
- The race where the timer is armed but the job has not yet started.

The `notify_disconnect` read is also explicitly upgraded to `memory_order_acquire` to pair with the release store from PR #219.

### Commit 2 — keep reconnect alive when gateway candidates are empty

Remove the early `return false` in the `gateway_candidates.empty()` branch so control falls through to the shared failure exit, which clears `intentional_close_` and arms the next reconnect. The candidate loop performs zero iterations on an empty vector, and the shared exit reports `SERVER_NOT_CONNECTED` (`server_hello_timed_out` stays false). The duplicate `SetError` is removed; the shared exit emits it.

Without this fix, commit 1's reconnect timer fires exactly once and then stops, because the second attempt enters `OpenAudioChannelInternal()`, finds the gateway not yet rediscovered via mDNS, and silently dies on the latch. With this fix, the latch is always released on the failure path, and `ScheduleReconnect()` always runs.

## Real-device verification (M5Stack CoreS3, 2026-05-31)

Reproduction: gateway running with mDNS advertisement only (no static NVS url), kill the gateway, observe the device for ~60 seconds without restarting the gateway:

```
I (235815) WS: Websocket disconnected
I (235815) WS: Schedule websocket reconnect in 5 seconds   ← retry 1 armed
I (240825) WS: Reconnecting to websocket server
I (242425) WS: No mDNS stackchan gateway services discovered
I (242435) WS: Schedule websocket reconnect in 10 seconds  ← retry 2 armed (this was the bug — silently lost before the fix)
I (252435) WS: Reconnecting to websocket server
I (254045) WS: No mDNS stackchan gateway services discovered
I (254055) WS: Schedule websocket reconnect in 20 seconds  ← retry 3 armed
I (274055) WS: Reconnecting to websocket server
I (275655) WS: No mDNS stackchan gateway services discovered
I (275665) WS: Schedule websocket reconnect in 40 seconds  ← retry 4 armed
I (315665) WS: Reconnecting to websocket server
I (317275) WS: No mDNS stackchan gateway services discovered
I (317285) WS: Schedule websocket reconnect in 60 seconds  ← retry 5 armed (capped at WEBSOCKET_RECONNECT_MAX_INTERVAL_MS)
```

Exponential backoff 5 → 10 → 20 → 40 → 60 s runs indefinitely. Pre-fix, retry 1 fired once and the loop died (no second `Schedule websocket reconnect` line).

End-to-end auto-reconnect (gateway up → device speaks again without a hard reset) was NOT fully observed in this session — see the Known limitations below.

## Scope

In scope: `firmware/main/protocols/websocket_protocol.{cc,h}`, CHANGELOG.

Out of scope (separate work):

- **Gateway-side mDNS hygiene** (silent rename, host-OS hostname interference, stale registrations) — PR #244.
- **ESP32 mDNS browse reliability** — captured as #245. During the verification above, the gateway was advertising and `dns-sd` on the host machine saw the advertisement on every interface, but the ESP32 returned 0 results from every `mdns_query_ptr` retry. This sits at the Wi-Fi multicast / ESP-IDF mDNS layer and is independent of the reconnect-loop fix in this PR — once #245 is resolved, the retry chain in this PR will land the actual reconnect.

## Known limitations

End-to-end reconnect (device speaking again post gateway-restart) was not demonstrated in this session because of #245 (the ESP32 browse layer cannot currently see the gateway's mDNS advertisement on Wi-Fi). The reconnect machinery in this PR is verified to be retrying correctly and will resume normal operation once #245 lands or once the device is configured with a static NVS url.

## Refs

- Closes #61
- Related landed: PR #35 (original reconnect after connecting-phase failure), PR #197 (persistent connect + sleep policy + `transport_connected_` atomic), PR #219 (per-candidate atomic guards for hello-then-disconnect race from #189)
- Companion: PR #244 (gateway-side mDNS hygiene)
- Carve-out: #245 (ESP32 mDNS browse 0 results when gateway is advertising)