### PR TITLE
fix(gateway): #244 prevent host-OS hostname interference, warn on mDNS rename, graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,26 @@ documented-only.
 
 ### Gateway
 
+- Fixed: mDNS advertiser no longer interferes with the host OS Bonjour
+  hostname. The SRV `server` field is now a fixed `stackchan-mcp.local.`
+  instead of the system hostname, so the Python zeroconf library does
+  not register A records that overlap with the OS Bonjour responder
+  (previously this could cause macOS to change the user's
+  `LocalHostName`, e.g. `MacBook-Pro` -> `MacBook-Pro-2`).
+
+- Fixed: when zeroconf assigns a modified instance name (e.g. a stale
+  registration from an ungraceful shutdown is still visible on the
+  network), the advertiser now logs a clear WARNING instead of silently
+  renaming. The firmware browses by service type so the advertisement
+  remains discoverable; the warning surfaces operationally so the stale
+  state is visible to the operator.
+
+- Added: SIGTERM signal handler in the CLI entry point so `kill <pid>`
+  triggers graceful shutdown and mDNS unregistration via
+  `gateway.stop()`. Previously SIGTERM bypassed the `try/finally` that
+  unregisters the mDNS service, leaving stale registrations on the
+  network until their TTL expired.
+
 - Added: optional device-driven listen audio capture forwarding via
   `STACKCHAN_AUDIO_HOOK_URL`. When set, inbound device-initiated
   listen captures (wake-word, button, LCD touch — any path that calls

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -580,10 +580,22 @@ def _run_preflight() -> int:
 
 async def _run(*, advertise_mdns: bool = True) -> None:
     """Start both the ESP32 WebSocket server and the stdio MCP server."""
+    import signal
+
     from .gateway import get_gateway
     from .stdio_server import run_stdio_server
 
     gateway = get_gateway()
+
+    loop = asyncio.get_running_loop()
+    main_task = asyncio.current_task()
+
+    def _handle_sigterm() -> None:
+        if main_task and not main_task.done():
+            main_task.cancel()
+
+    if sys.platform != "win32":
+        loop.add_signal_handler(signal.SIGTERM, _handle_sigterm)
 
     await gateway.start(advertise_mdns=advertise_mdns)
     logger.info("Gateway started, waiting for ESP32 connections...")
@@ -591,6 +603,8 @@ async def _run(*, advertise_mdns: bool = True) -> None:
     try:
         # Run stdio MCP server (blocks until MCP client disconnects)
         await run_stdio_server()
+    except asyncio.CancelledError:
+        logger.info("Received termination signal, shutting down...")
     finally:
         await gateway.stop()
 

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -51,15 +51,6 @@ def _load_zeroconf_classes() -> tuple[type[Any], type[Any]]:
     return AsyncZeroconf, ServiceInfo
 
 
-def _load_non_unique_name_exception() -> type[Exception]:
-    try:
-        from zeroconf import NonUniqueNameException
-    except ImportError:  # pragma: no cover - compatibility with older zeroconf
-        from zeroconf._exceptions import NonUniqueNameException
-
-    return NonUniqueNameException
-
-
 def _is_usable_ipv4(address: str) -> bool:
     try:
         ip = ipaddress.ip_address(address)
@@ -287,26 +278,27 @@ class MdnsAdvertiser:
             server=advertisement.server,
             parsed_addresses=advertisement.parsed_addresses,
         )
-        name_conflict_exception = _load_non_unique_name_exception()
         try:
-            await zeroconf.async_register_service(info, allow_name_change=False)
-        except name_conflict_exception:
-            logger.warning(
-                "mDNS service name conflict detected (a previous gateway instance "
-                "may not have shut down cleanly). mDNS advertisement disabled for "
-                "this session. The ESP32 will fall back to the configured "
-                "WebSocket URL."
-            )
-            await zeroconf.async_close()
-            return
+            await zeroconf.async_register_service(info, allow_name_change=True)
         except Exception:
             await zeroconf.async_close()
             raise
         self._zeroconf = zeroconf
         self._service_info = info
+        registered_name = getattr(info, "name", advertisement.service_name)
+        if registered_name != advertisement.service_name:
+            logger.warning(
+                "mDNS service registered under a modified name %s (requested %s). "
+                "A previous gateway instance may not have shut down cleanly and its "
+                "registration is still visible on the network. The ESP32 still "
+                "discovers this gateway by service type, so auto-discovery keeps "
+                "working; the stale entry clears when its mDNS TTL expires.",
+                registered_name,
+                advertisement.service_name,
+            )
         logger.info(
             "mDNS advertising %s on port %d with addresses %s",
-            getattr(info, "name", advertisement.service_name),
+            registered_name,
             advertisement.port,
             ", ".join(advertisement.parsed_addresses),
         )

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -51,6 +51,15 @@ def _load_zeroconf_classes() -> tuple[type[Any], type[Any]]:
     return AsyncZeroconf, ServiceInfo
 
 
+def _load_non_unique_name_exception() -> type[Exception]:
+    try:
+        from zeroconf import NonUniqueNameException
+    except ImportError:  # pragma: no cover - compatibility with older zeroconf
+        from zeroconf._exceptions import NonUniqueNameException
+
+    return NonUniqueNameException
+
+
 def _is_usable_ipv4(address: str) -> bool:
     try:
         ip = ipaddress.ip_address(address)
@@ -132,16 +141,13 @@ def _is_wildcard_host(host: str) -> bool:
 
 
 def _build_service_hostname() -> str:
-    label = socket.gethostname().split(".", 1)[0]
-    safe_label = "".join(
-        char.lower()
-        if char.isascii() and (char.isalnum() or char == "-")
-        else "-"
-        for char in label
-    ).strip("-")
-    if not safe_label:
-        return FALLBACK_SERVICE_HOSTNAME
-    return f"{safe_label}.local."
+    """Return a service-specific mDNS hostname for the SRV record.
+
+    Uses a fixed name to avoid advertising A records that overlap with
+    the system's own Bonjour hostname registration, which can trigger
+    macOS to change the user's LocalHostName.
+    """
+    return FALLBACK_SERVICE_HOSTNAME
 
 
 def _iter_ifaddr_ipv4_addresses() -> list[tuple[str, int | None]]:
@@ -281,8 +287,18 @@ class MdnsAdvertiser:
             server=advertisement.server,
             parsed_addresses=advertisement.parsed_addresses,
         )
+        name_conflict_exception = _load_non_unique_name_exception()
         try:
-            await zeroconf.async_register_service(info, allow_name_change=True)
+            await zeroconf.async_register_service(info, allow_name_change=False)
+        except name_conflict_exception:
+            logger.warning(
+                "mDNS service name conflict detected (a previous gateway instance "
+                "may not have shut down cleanly). mDNS advertisement disabled for "
+                "this session. The ESP32 will fall back to the configured "
+                "WebSocket URL."
+            )
+            await zeroconf.async_close()
+            return
         except Exception:
             await zeroconf.async_close()
             raise

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -7,7 +7,9 @@ covered by ``test_stdio_server.py`` and ``test_gateway.py``.
 
 from __future__ import annotations
 
+import asyncio
 import os
+import signal
 import socket
 from pathlib import Path
 
@@ -193,6 +195,47 @@ def test_main_no_mdns_disables_advertisement(
     main(["--no-mdns"])
 
     assert called == {"advertise_mdns": False}
+
+
+@pytest.mark.asyncio
+async def test_run_sigterm_handler_cancels_and_stops_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if cli.sys.platform == "win32":
+        pytest.skip("POSIX signal handlers are not registered on Windows")
+
+    from stackchan_mcp import gateway as gateway_module
+    from stackchan_mcp import stdio_server
+
+    events: list[object] = []
+    registered_handlers: dict[int, object] = {}
+
+    class FakeGateway:
+        async def start(self, *, advertise_mdns: bool = True) -> None:
+            events.append(("start", advertise_mdns))
+
+        async def stop(self) -> None:
+            events.append("stop")
+
+    async def fake_run_stdio_server() -> None:
+        events.append("stdio")
+        handler = registered_handlers[signal.SIGTERM]
+        assert callable(handler)
+        handler()
+        await asyncio.sleep(0)
+
+    def fake_add_signal_handler(signum: int, callback: object) -> None:
+        registered_handlers[signum] = callback
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "add_signal_handler", fake_add_signal_handler)
+    monkeypatch.setattr(gateway_module, "get_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(stdio_server, "run_stdio_server", fake_run_stdio_server)
+
+    await cli._run(advertise_mdns=False)
+
+    assert registered_handlers.keys() == {signal.SIGTERM}
+    assert events == [("start", False), "stdio", "stop"]
 
 
 def test_main_check_flag_remains_side_effect_free_with_no_mdns(

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -23,6 +23,10 @@ def test_service_type_and_txt_defaults() -> None:
     assert advertisement.parsed_addresses == ["192.0.2.10"]
 
 
+def test_service_hostname_is_service_specific() -> None:
+    assert mdns._build_service_hostname() == "stackchan-mcp.local."
+
+
 def test_wildcard_host_advertises_all_usable_non_loopback_ipv4(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -227,7 +231,7 @@ async def test_advertiser_registers_service(monkeypatch: pytest.MonkeyPatch) -> 
     zeroconf = instances[0]
     assert len(zeroconf.registered) == 1
     info, allow_name_change = zeroconf.registered[0]
-    assert allow_name_change is True
+    assert allow_name_change is False
     assert info.type == "_stackchan-mcp._tcp.local."
     assert info.name == "stackchan-mcp._stackchan-mcp._tcp.local."
     assert info.kwargs["port"] == 8765
@@ -238,6 +242,62 @@ async def test_advertiser_registers_service(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert zeroconf.unregistered == [info]
     assert zeroconf.closed is True
+
+
+@pytest.mark.asyncio
+async def test_advertiser_disables_mdns_when_service_name_conflicts(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    instances: list[ConflictingAsyncZeroconf] = []
+
+    class NameConflict(Exception):
+        pass
+
+    class FakeServiceInfo:
+        def __init__(self, service_type: str, service_name: str, **kwargs) -> None:
+            self.type = service_type
+            self.name = service_name
+            self.kwargs = kwargs
+
+    class ConflictingAsyncZeroconf:
+        def __init__(self) -> None:
+            self.registered = []
+            self.closed = False
+            instances.append(self)
+
+        async def async_register_service(
+            self, info: FakeServiceInfo, *, allow_name_change: bool = False
+        ) -> None:
+            self.registered.append((info, allow_name_change))
+            raise NameConflict("duplicate service name")
+
+        async def async_close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(
+        mdns,
+        "_load_zeroconf_classes",
+        lambda: (ConflictingAsyncZeroconf, FakeServiceInfo),
+    )
+    monkeypatch.setattr(
+        mdns, "_load_non_unique_name_exception", lambda: NameConflict
+    )
+    caplog.set_level("WARNING", logger=mdns.__name__)
+
+    advertiser = MdnsAdvertiser()
+    await advertiser.start(host="192.0.2.10", port=8765, path="/")
+
+    assert len(instances) == 1
+    zeroconf = instances[0]
+    assert len(zeroconf.registered) == 1
+    _info, allow_name_change = zeroconf.registered[0]
+    assert allow_name_change is False
+    assert zeroconf.closed is True
+    assert advertiser._zeroconf is None
+    assert advertiser._service_info is None
+    assert "mDNS service name conflict detected" in caplog.text
+
 
 @pytest.mark.asyncio
 async def test_advertiser_closes_zeroconf_when_registration_fails(

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -231,7 +231,7 @@ async def test_advertiser_registers_service(monkeypatch: pytest.MonkeyPatch) -> 
     zeroconf = instances[0]
     assert len(zeroconf.registered) == 1
     info, allow_name_change = zeroconf.registered[0]
-    assert allow_name_change is False
+    assert allow_name_change is True
     assert info.type == "_stackchan-mcp._tcp.local."
     assert info.name == "stackchan-mcp._stackchan-mcp._tcp.local."
     assert info.kwargs["port"] == 8765
@@ -245,14 +245,12 @@ async def test_advertiser_registers_service(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_advertiser_disables_mdns_when_service_name_conflicts(
+async def test_advertiser_warns_when_service_name_changes(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    instances: list[ConflictingAsyncZeroconf] = []
-
-    class NameConflict(Exception):
-        pass
+    instances: list[RenamingAsyncZeroconf] = []
+    renamed_service_name = "stackchan-mcp-2._stackchan-mcp._tcp.local."
 
     class FakeServiceInfo:
         def __init__(self, service_type: str, service_name: str, **kwargs) -> None:
@@ -260,9 +258,10 @@ async def test_advertiser_disables_mdns_when_service_name_conflicts(
             self.name = service_name
             self.kwargs = kwargs
 
-    class ConflictingAsyncZeroconf:
+    class RenamingAsyncZeroconf:
         def __init__(self) -> None:
             self.registered = []
+            self.unregistered = []
             self.closed = False
             instances.append(self)
 
@@ -270,7 +269,10 @@ async def test_advertiser_disables_mdns_when_service_name_conflicts(
             self, info: FakeServiceInfo, *, allow_name_change: bool = False
         ) -> None:
             self.registered.append((info, allow_name_change))
-            raise NameConflict("duplicate service name")
+            info.name = renamed_service_name
+
+        async def async_unregister_service(self, info: FakeServiceInfo) -> None:
+            self.unregistered.append(info)
 
         async def async_close(self) -> None:
             self.closed = True
@@ -278,10 +280,7 @@ async def test_advertiser_disables_mdns_when_service_name_conflicts(
     monkeypatch.setattr(
         mdns,
         "_load_zeroconf_classes",
-        lambda: (ConflictingAsyncZeroconf, FakeServiceInfo),
-    )
-    monkeypatch.setattr(
-        mdns, "_load_non_unique_name_exception", lambda: NameConflict
+        lambda: (RenamingAsyncZeroconf, FakeServiceInfo),
     )
     caplog.set_level("WARNING", logger=mdns.__name__)
 
@@ -291,12 +290,19 @@ async def test_advertiser_disables_mdns_when_service_name_conflicts(
     assert len(instances) == 1
     zeroconf = instances[0]
     assert len(zeroconf.registered) == 1
-    _info, allow_name_change = zeroconf.registered[0]
-    assert allow_name_change is False
+    info, allow_name_change = zeroconf.registered[0]
+    assert allow_name_change is True
+    assert info.name == renamed_service_name
+    assert zeroconf.closed is False
+    assert advertiser._zeroconf is zeroconf
+    assert advertiser._service_info is info
+    assert "modified name" in caplog.text
+    assert renamed_service_name in caplog.text
+
+    await advertiser.stop()
+
+    assert zeroconf.unregistered == [info]
     assert zeroconf.closed is True
-    assert advertiser._zeroconf is None
-    assert advertiser._service_info is None
-    assert "mDNS service name conflict detected" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three independent gateway-side mDNS fixes that together prevent the advertiser from interfering with the host OS network identity and from silently disappearing on a name conflict. Discovered during real-device verification of PR #243 (Issue #61). Closes #244.

## Background

The previous gateway used:
- `socket.gethostname()` as the mDNS `server` field, which caused the Python `zeroconf` library to register A records that overlap with the host OS's own Bonjour hostname. On macOS, this triggered a Bonjour name-conflict resolution that **changed the user's `LocalHostName`** (e.g. `MacBook-Pro` → `MacBook-Pro-2`) — an unacceptable side effect on the host machine.
- `allow_name_change=True` on `async_register_service`, so a stale registration from an ungraceful shutdown silently relabeled the service (`stackchan-mcp` → `stackchan-mcp-2`).
- No SIGTERM handler in the CLI entry point, so `kill <pid>` terminated the process without running `gateway.stop()` → mDNS unregistration. Stale registrations accumulated and only cleared after the mDNS TTL expired (typically 75 min+).

## Changes

### 1. Fixed service-specific hostname (`mdns_advertiser.py`)

`_build_service_hostname()` now returns the fixed `stackchan-mcp.local.` instead of deriving from `socket.gethostname()`. The mDNS `server` field is the SRV target and does not need to match the system hostname — using a service-specific name eliminates the host-OS hostname collision entirely.

This is the critical user-impact fix in this PR.

### 2. Detect rename, warn loudly, keep advertising (`mdns_advertiser.py`)

`allow_name_change=True` is kept (the firmware browses by service type, so a renamed instance is still discoverable, and combined with the firmware reconnect-retry fix the device tolerates the transient). Post-registration, if the registered name differs from the requested one, a WARNING is logged so operators can see when a stale registration is interfering. Earlier review iteration considered disabling mDNS on conflict (`allow_name_change=False`), but two reviewers correctly pointed out this would break auto-discovery for users without a fallback URL — keeping the advertisement live with a loud warning is strictly better.

### 3. SIGTERM graceful shutdown (`cli.py`)

`_run()` registers a SIGTERM handler (non-Windows) that cancels the main task, so the existing `try/finally` runs `gateway.stop()` → `mdns_advertiser.stop()` → `async_unregister_service()`. The `CancelledError` is caught at the CLI boundary so termination is a clean exit (no traceback).

This prevents stale mDNS registrations from accumulating on every restart.

## Real-device verification

Verified on M5Stack CoreS3 + macOS host (2026-05-31):

- ✅ Mac `LocalHostName` is no longer modified by gateway restart cycles (the original critical bug).
- ✅ `dns-sd -B _stackchan-mcp._tcp local.` sees the advertisement on all interfaces with `stackchan-mcp.local.:8765` resolution and full TXT records.
- ✅ When a stale registration lingers, the new gateway logs a WARNING and continues advertising under the modified instance name.
- ✅ `SIGKILL` of the parent `uv` process leaves an orphaned Python child holding the port — that is a process-tree issue unrelated to this PR. SIGTERM via direct `kill <python_child_pid>` was observed not to terminate the child in one trial; the SIGTERM handler logic is unit-tested but the end-to-end signal path needs follow-up if the failure recurs.

## Scope

In scope: `gateway/stackchan_mcp/mdns_advertiser.py`, `gateway/stackchan_mcp/cli.py`, gateway tests.

Out of scope:
- **ESP32-side mDNS browse reliability** — captured as #245. During the real-device verification, the gateway advertisement was visible to macOS on every interface but the ESP32 returned 0 results from `mdns_query_ptr`. This is independent of the gateway-side advertisement (which this PR fixes) and likely sits at the Wi-Fi multicast / ESP-IDF mDNS layer.
- Firmware reconnect-loop death on empty candidates — that fix lives in PR #243.

## Refs

- Closes #244
- Discovered during: #61 (PR #243) real-device verification
- Carve-out: #245 (ESP32 mDNS browse returns 0 results despite gateway advertising)
- Test plan: `cd gateway && uv run pytest` (passes) / `cd gateway && uv run ruff check .` (passes)