### PR TITLE
chore(workflow): auto-set maintainer board Status=Done on close (#242)

### DIFF
--- a/.github/workflows/done-on-close.yml
+++ b/.github/workflows/done-on-close.yml
@@ -1,0 +1,178 @@
+name: Set closed issues and PRs to Done
+
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  done-on-close:
+    name: Set maintainer board status to Done
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          script: |
+            try {
+              const PROJECT_OWNER = "kisaragi-mochi";
+              const PROJECT_NUMBER = 2;
+              const STATUS_FIELD_NAME = "Status";
+              const DONE_OPTION_NAME = "Done";
+              const MAX_PAGES = 50;
+
+              const closedItem =
+                context.eventName === "issues"
+                  ? context.payload.issue
+                  : context.payload.pull_request;
+
+              if (!closedItem?.node_id) {
+                throw new Error(`Unsupported event payload for ${context.eventName}`);
+              }
+
+              const closedNodeId = closedItem.node_id;
+              const number = closedItem.number;
+
+              const projectResult = await github.graphql(
+                `
+                  query($owner: String!, $number: Int!) {
+                    user(login: $owner) {
+                      projectV2(number: $number) {
+                        id
+                        field(name: "Status") {
+                          __typename
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            options {
+                              id
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                `,
+                {
+                  owner: PROJECT_OWNER,
+                  number: PROJECT_NUMBER,
+                },
+              );
+
+              const project = projectResult.user?.projectV2;
+              if (!project?.id) {
+                throw new Error(`Project ${PROJECT_OWNER}/${PROJECT_NUMBER} was not found`);
+              }
+
+              const statusField = project.field;
+              if (statusField?.__typename !== "ProjectV2SingleSelectField" || !statusField.id) {
+                throw new Error(`Project field "${STATUS_FIELD_NAME}" is not a single-select field`);
+              }
+
+              const doneOption = statusField.options?.find((option) => option.name === DONE_OPTION_NAME);
+              if (!doneOption?.id) {
+                throw new Error(`Project field "${STATUS_FIELD_NAME}" has no "${DONE_OPTION_NAME}" option`);
+              }
+
+              let itemId = null;
+              let cursor = null;
+              let exhausted = false;
+
+              for (let page = 0; page < MAX_PAGES; page += 1) {
+                const itemsResult = await github.graphql(
+                  `
+                    query($projectId: ID!, $cursor: String) {
+                      node(id: $projectId) {
+                        ... on ProjectV2 {
+                          items(first: 100, after: $cursor) {
+                            pageInfo {
+                              hasNextPage
+                              endCursor
+                            }
+                            nodes {
+                              id
+                              content {
+                                ... on Issue {
+                                  id
+                                }
+                                ... on PullRequest {
+                                  id
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `,
+                  {
+                    projectId: project.id,
+                    cursor,
+                  },
+                );
+
+                const items = itemsResult.node?.items;
+                if (!items) {
+                  throw new Error(`Project ${PROJECT_OWNER}/${PROJECT_NUMBER} items could not be read`);
+                }
+
+                const matchingItem = items.nodes.find((item) => item.content?.id === closedNodeId);
+                if (matchingItem) {
+                  itemId = matchingItem.id;
+                  break;
+                }
+
+                if (!items.pageInfo.hasNextPage) {
+                  exhausted = true;
+                  break;
+                }
+
+                if (!items.pageInfo.endCursor) {
+                  throw new Error("Project item pagination did not return an end cursor");
+                }
+
+                cursor = items.pageInfo.endCursor;
+              }
+
+              if (!itemId && !exhausted) {
+                throw new Error(`Stopped after ${MAX_PAGES} project item pages without finding #${number}`);
+              }
+
+              if (!itemId) {
+                core.info(`Closed ${context.eventName} #${number} is not in the maintainer board; leaving it unchanged.`);
+                return;
+              }
+
+              await github.graphql(
+                `
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                    updateProjectV2ItemFieldValue(
+                      input: {
+                        projectId: $projectId
+                        itemId: $itemId
+                        fieldId: $fieldId
+                        value: { singleSelectOptionId: $optionId }
+                      }
+                    ) {
+                      projectV2Item {
+                        id
+                      }
+                    }
+                  }
+                `,
+                {
+                  projectId: project.id,
+                  itemId,
+                  fieldId: statusField.id,
+                  optionId: doneOption.id,
+                },
+              );
+
+              core.info(`Set Status=Done for ${context.eventName} #${number}`);
+            } catch (error) {
+              core.setFailed(error.message);
+            }


### PR DESCRIPTION
## Summary

Add `.github/workflows/done-on-close.yml`, the close-edge companion to PR #241 (auto-add). When an Issue or Pull Request is closed (any reason), the maintainer triage Project board's `Status` field is automatically transitioned to `Done` via a GraphQL `updateProjectV2ItemFieldValue` mutation. Closes #242.

## Design

| Aspect | Decision |
|---|---|
| Trigger | `issues: types: [closed]` + `pull_request_target: types: [closed]` (matches PR #241's security stance) |
| Action | `actions/github-script@v7` running an inline GraphQL script |
| Auth | Reuses the existing `ADD_TO_PROJECT_PAT` secret from PR #241 |
| Field / option IDs | Resolved at runtime via GraphQL field-configuration query (no hardcoded IDs — defensive against board reconfiguration) |
| Item lookup | `projectV2.items` paginated by `content.id == <closed node id>`, capped at 50 pages (5000 items) |
| Item-not-in-board | Clean exit via `core.info()` log line, no failure (matches Issue #242 acceptance) |
| Errors | Caught and surfaced via `core.setFailed()` so misconfigurations (missing `Done` option, expired PAT, etc.) are visible in the Actions tab |

## Why CHANGELOG is not touched

PR #241 (the companion auto-add workflow) was merged without a CHANGELOG entry — the maintainer triage Project board is internal maintainer tooling, not a user-facing or contributor-facing feature, so it does not belong in the user-visible CHANGELOG. This PR follows the same precedent.

## Verification plan

After merge:

1. The workflow will fire on the next Issue / PR close event on this repo.
2. Manually verifiable via the Actions tab: check the run logs for either `Set Status=Done for ...` (item moved) or `Closed ... is not in the maintainer board; leaving it unchanged.` (item never added to board).
3. Project board UI: closed items appear in the `Done` column instead of staying in `Doing` / `Waiting` / etc.

## Scope

In scope: `.github/workflows/done-on-close.yml` only.

Out of scope (explicitly):
- Reopen behaviour (closed → reopened): not handled here. A reopened item retains the Done status until manually changed. Carve-out if needed.
- Other Status transitions (Backlog → Doing / Next / Waiting): remain manual / proactive, governed by maintainer-side triage discipline.

## Refs

- Closes #242
- Companion to: PR #241 (auto-add workflow)