### PR TITLE
fix(firmware): #170 SCS0009 EnableTorque ACK loss recovery via kUncertain state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ documented-only.
 
 ### Firmware
 
+- Add `kUncertain` state to `TorqueState`: an `EnableTorque(OFF)` (or `ON`)
+  attempt that loses its ACK no longer publishes `kEngaged` from cached state.
+  Subsequent motion or manual `set_servo_torque(...)` calls now issue a real
+  bus frame instead of short-circuiting on stale state, guaranteeing forward
+  progress without requiring a PMIC OFF/ON cycle. Closes the Phase 4 ACK-loss
+  trade-off carved out from #168. (#170)
+
 - Changed: split `set_servo_torque` MCP response field `short_circuited` into orthogonal `idempotent_short_circuit` and `wait_exhausted` flags to distinguish degraded-bus wait-budget exhaustion (where no `EnableTorque` bus frame went out) from idempotent no-op success (where state already matched the request). The `ok` field now correctly returns `false` on wait-exhaustion. **Breaking change** for callers reading the old `short_circuited` field directly. (#171)
 
 - Fixed: empty WebSocket gateway discovery results now fall through to the shared reconnect failure path, clearing the intentional-close latch so retries continue after a gateway restart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,15 @@ documented-only.
 
 ### Firmware
 
-- Add `kUncertain` state to `TorqueState`: an `EnableTorque(OFF)` (or `ON`)
-  attempt that loses its ACK no longer publishes `kEngaged` from cached state.
-  Subsequent motion or manual `set_servo_torque(...)` calls now issue a real
-  bus frame instead of short-circuiting on stale state, guaranteeing forward
-  progress without requiring a PMIC OFF/ON cycle. Closes the Phase 4 ACK-loss
-  trade-off carved out from #168. (#170)
+- Add `kUncertain` state to `TorqueState`: an `EnableTorque(OFF)` (or
+  `ON`) attempt that loses its ACK no longer publishes `kEngaged` from
+  cached state. Subsequent motion or manual `set_servo_torque(...)`
+  calls now issue a real bus frame instead of short-circuiting on stale
+  state, guaranteeing forward progress without requiring a PMIC OFF/ON
+  cycle. The `kUncertain` publish itself is guarded by a
+  `compare_exchange` against a pre-bus state observation, so a
+  concurrent `MarkReleasing()` is not erased. Closes the Phase 4
+  ACK-loss trade-off carved out from #168. (#170)
 
 - Changed: split `set_servo_torque` MCP response field `short_circuited` into orthogonal `idempotent_short_circuit` and `wait_exhausted` flags to distinguish degraded-bus wait-budget exhaustion (where no `EnableTorque` bus frame went out) from idempotent no-op success (where state already matched the request). The `ok` field now correctly returns `false` on wait-exhaustion. **Breaking change** for callers reading the old `short_circuited` field directly. (#171)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,13 @@ documented-only.
   state, guaranteeing forward progress without requiring a PMIC OFF/ON
   cycle. The `kUncertain` publish itself is guarded by a
   `compare_exchange` against a pre-bus state observation, so a
-  concurrent `MarkReleasing()` is not erased. Closes the Phase 4
-  ACK-loss trade-off carved out from #168. (#170)
+  concurrent `MarkReleasing()` is not erased. The
+  `MaybeAutoReleaseTorque()` guard treats `kUncertain` as engaged so
+  the #168 Phase 4 cumulative-WritePos mitigation continues to retry
+  the OFF after an ACK loss rather than stranding torque physically
+  ON; the retry short-circuits via the idempotent path if the OFF was
+  actually delivered. Closes the Phase 4 ACK-loss trade-off carved
+  out from #168. (#170)
 
 - Changed: split `set_servo_torque` MCP response field `short_circuited` into orthogonal `idempotent_short_circuit` and `wait_exhausted` flags to distinguish degraded-bus wait-budget exhaustion (where no `EnableTorque` bus frame went out) from idempotent no-op success (where state already matched the request). The `ok` field now correctly returns `false` on wait-exhaustion. **Breaking change** for callers reading the old `short_circuited` field directly. (#171)
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -3512,10 +3512,17 @@ private:
             last_motion_end_valid_ = false;
         }
         // Keep the idle window scoped to the currently engaged interval.
-        // Released/partial/releasing/uncertain states must not age a stale
-        // timer into the next re-engage.
-        if (torque_state_.load(std::memory_order_acquire) !=
-            TorqueState::kEngaged) {
+        // Released/partial/releasing states must not age a stale timer
+        // into the next re-engage. kUncertain is treated as engaged for
+        // auto-release purposes: if the kAutoIdle OFF bus frame was lost
+        // on the UART path, the auto-release retry must continue so the
+        // device does not strand with torque physically ON; if the OFF
+        // was actually delivered, the next retry short-circuits via the
+        // idempotent path (Issue #170 follow-up).
+        auto current_state =
+            torque_state_.load(std::memory_order_acquire);
+        if (current_state != TorqueState::kEngaged &&
+            current_state != TorqueState::kUncertain) {
             last_motion_end_valid_ = false;
             return;
         }

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -774,6 +774,12 @@ private:
         kPartial = 1,
         kReleased = 2,
         kReleasing = 3,
+        // Published when InternalSetServoTorque cannot confirm bus success
+        // for both axes. Forward-progress invariant: the next motion / manual
+        // call issues a real bus frame instead of short-circuiting. Mirrors
+        // the WritePos retries-exhausted -> position_unknown convention for
+        // the torque domain.
+        kUncertain = 4,
     };
     std::atomic<TorqueState> torque_state_{TorqueState::kEngaged};
     std::atomic<uint32_t> torque_release_epoch_{0};
@@ -3207,6 +3213,24 @@ private:
             return result;
         };
 
+        auto publish_after_bus_attempt = [&]() {
+            const bool any_axis_bus_failed =
+                !result.yaw_ok || !result.pitch_ok;
+            if (!any_axis_bus_failed) {
+                PublishTorqueState();
+                return;
+            }
+            ESP_LOGW(TAG,
+                     "set_servo_torque (reason=%s): publishing kUncertain; "
+                     "bus confirmation failed for yaw_failed=%d (r=%d) "
+                     "pitch_failed=%d (r=%d)",
+                     ReleaseReasonName(reason),
+                     result.yaw_ok ? 0 : 1, result.yaw_bus_return,
+                     result.pitch_ok ? 0 : 1, result.pitch_bus_return);
+            torque_state_.store(TorqueState::kUncertain,
+                                std::memory_order_release);
+        };
+
         if (!servo_ok_ || scs_bus_mutex_ == nullptr) {
             // Servo subsystem unavailable: not a short-circuit and not a
             // wait timeout. yaw_ok/pitch_ok stay false, so ok is false.
@@ -3236,10 +3260,11 @@ private:
                         log_result(ExitKind::kWaitExhausted);
                         return result;
                     }
-                    // After the wait, state may be kEngaged (OFF failed and
-                    // rolled back) or kReleased (OFF succeeded). Fall through
-                    // to the existing (true, true) logic, which short-circuits
-                    // on kEngaged and proceeds normally on kReleased/kPartial.
+                    // After the wait, state may be kEngaged (OFF rolled
+                    // back), kReleased (OFF succeeded), or kUncertain (OFF
+                    // bus confirmation failed). Fall through to the existing
+                    // (true, true) logic, which short-circuits on kEngaged and
+                    // proceeds normally on kReleased/kPartial/kUncertain.
                 }
             }
 
@@ -3293,7 +3318,7 @@ private:
                 if (result.pitch_ok) {
                     pitch_torque_enabled_ = true;
                 }
-                PublishTorqueState();
+                publish_after_bus_attempt();
                 // Real bus write attempted; ok is governed by yaw_ok/pitch_ok.
                 log_result(ExitKind::kBusAction);
                 xSemaphoreGive(scs_bus_mutex_);
@@ -3394,7 +3419,7 @@ private:
             if (result.pitch_ok) {
                 pitch_torque_enabled_ = pitch_enabled;
             }
-            PublishTorqueState();
+            publish_after_bus_attempt();
             // Real bus write attempted; ok is governed by yaw_ok/pitch_ok.
             log_result(ExitKind::kBusAction);
             xSemaphoreGive(scs_bus_mutex_);
@@ -3425,7 +3450,8 @@ private:
             }
         }
 
-        // state is kPartial or kReleased -- safe to re-engage now.
+        // state is kPartial, kReleased, or kUncertain -- safe to
+        // re-engage now.
         InternalSetServoTorque(true, true, ReleaseReason::kReengagement);
     }
 
@@ -3465,8 +3491,8 @@ private:
             last_motion_end_valid_ = false;
         }
         // Keep the idle window scoped to the currently engaged interval.
-        // Released/partial/releasing states must not age a stale timer into
-        // the next re-engage.
+        // Released/partial/releasing/uncertain states must not age a stale
+        // timer into the next re-engage.
         if (torque_state_.load(std::memory_order_acquire) !=
             TorqueState::kEngaged) {
             last_motion_end_valid_ = false;

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -3213,22 +3213,39 @@ private:
             return result;
         };
 
-        auto publish_after_bus_attempt = [&]() {
+        auto publish_after_bus_attempt = [&](TorqueState pre_bus_state) {
             const bool any_axis_bus_failed =
                 !result.yaw_ok || !result.pitch_ok;
             if (!any_axis_bus_failed) {
+                // Success-path cached-state ownership is pre-existing and
+                // tracked separately under Issue #172.
                 PublishTorqueState();
                 return;
             }
-            ESP_LOGW(TAG,
-                     "set_servo_torque (reason=%s): publishing kUncertain; "
-                     "bus confirmation failed for yaw_failed=%d (r=%d) "
-                     "pitch_failed=%d (r=%d)",
-                     ReleaseReasonName(reason),
-                     result.yaw_ok ? 0 : 1, result.yaw_bus_return,
-                     result.pitch_ok ? 0 : 1, result.pitch_bus_return);
-            torque_state_.store(TorqueState::kUncertain,
-                                std::memory_order_release);
+            TorqueState expected = pre_bus_state;
+            if (torque_state_.compare_exchange_strong(
+                    expected,
+                    TorqueState::kUncertain,
+                    std::memory_order_release,
+                    std::memory_order_acquire)) {
+                ESP_LOGW(TAG,
+                         "set_servo_torque (reason=%s): publishing kUncertain; "
+                         "bus confirmation failed for yaw_failed=%d (r=%d) "
+                         "pitch_failed=%d (r=%d)",
+                         ReleaseReasonName(reason),
+                         result.yaw_ok ? 0 : 1, result.yaw_bus_return,
+                         result.pitch_ok ? 0 : 1, result.pitch_bus_return);
+            } else {
+                ESP_LOGW(TAG,
+                         "set_servo_torque (reason=%s): kUncertain publish "
+                         "skipped; torque_state_ advanced from %d to %d "
+                         "(likely MarkReleasing()); leaving concurrent state "
+                         "intact. bus_return yaw=%d pitch=%d",
+                         ReleaseReasonName(reason),
+                         static_cast<int>(pre_bus_state),
+                         static_cast<int>(expected),
+                         result.yaw_bus_return, result.pitch_bus_return);
+            }
         };
 
         if (!servo_ok_ || scs_bus_mutex_ == nullptr) {
@@ -3307,6 +3324,8 @@ private:
                     xSemaphoreGive(scs_bus_mutex_);
                     return result;
                 }
+                const TorqueState pre_bus_state =
+                    torque_state_.load(std::memory_order_acquire);
                 result.yaw_bus_return =
                     scs_bus_.EnableTorque(SERVO_YAW_ID, 1);
                 result.pitch_bus_return =
@@ -3318,7 +3337,7 @@ private:
                 if (result.pitch_ok) {
                     pitch_torque_enabled_ = true;
                 }
-                publish_after_bus_attempt();
+                publish_after_bus_attempt(pre_bus_state);
                 // Real bus write attempted; ok is governed by yaw_ok/pitch_ok.
                 log_result(ExitKind::kBusAction);
                 xSemaphoreGive(scs_bus_mutex_);
@@ -3408,6 +3427,8 @@ private:
                     return result;
                 }
             }
+            const TorqueState pre_bus_state =
+                torque_state_.load(std::memory_order_acquire);
             result.yaw_bus_return = scs_bus_.EnableTorque(
                 SERVO_YAW_ID, yaw_enabled ? 1 : 0);
             result.pitch_bus_return = scs_bus_.EnableTorque(
@@ -3419,7 +3440,7 @@ private:
             if (result.pitch_ok) {
                 pitch_torque_enabled_ = pitch_enabled;
             }
-            publish_after_bus_attempt();
+            publish_after_bus_attempt(pre_bus_state);
             // Real bus write attempted; ok is governed by yaw_ok/pitch_ok.
             log_result(ExitKind::kBusAction);
             xSemaphoreGive(scs_bus_mutex_);


### PR DESCRIPTION
# Closes #170

## Summary

SCS0009 EnableTorque ACK loss recovery. When `InternalSetServoTorque(false, false, ...)` is called and the OFF bus frame reaches the servo but the ACK / read-back is lost on the UART path, per-axis state previously stayed cached at `true`, causing `PublishTorqueState()` to publish `kEngaged` from stale values and stranding the device torque-off with firmware believing torque is engaged. Both `EnsureTorqueEngagedBeforeMove()` and the manual `set_servo_torque(true, true)` MCP handler then short-circuited on the cached `kEngaged` state, leaving PMIC OFF/ON as the only recovery path.

This PR introduces a new `kUncertain` torque state for the ACK loss case, with concurrent-publish guards and an auto-release retry exception so the #168 Phase 4 mitigation continues to function.

## Changes

1. **`8e4ffcd`** — Add `kUncertain` torque state. On bus failure in `InternalSetServoTorque(false, false)`, publish `kUncertain` via `compare_exchange_strong` against the pre-bus state, so subsequent re-engage attempts go through the actual `EnableTorque(ON)` path instead of short-circuiting.

2. **`f5c1a8b`** — Guard `kUncertain` publish against concurrent `MarkReleasing()`. The `compare_exchange_strong` only publishes `kUncertain` when the state has not advanced past `pre_bus_state` (e.g. to `kReleasing` by an `kAutoIdle` path), preventing the bus-error path from overwriting a valid in-flight transition.

3. **`19af847`** — Allow `MaybeAutoReleaseTorque()` retry from `kUncertain`. Codex review caught that the auto-release guard returned immediately for any state other than `kEngaged`, silently regressing #168 Phase 4 SCS0009 cumulative-WritePos mitigation when the `kAutoIdle` OFF bus frame failed to confirm. Now `kUncertain` is treated as engaged for auto-release purposes: lost-frame case retries via the existing `kReleasing` transition; delivered case short-circuits via `InternalSetServoTorque`'s idempotent path.

4. **`e92121a`** — CHANGELOG entry noting the `MaybeAutoReleaseTorque` retry behavior under `kUncertain`.

## Real-device verification

- ESP32 boot + mDNS + WS connect: confirmed via `get_status` returning `connected: true`, `tools_count: 30`.
- `set_servo_torque(false, false)` while idle returns `idempotent_short_circuit: true` with `yaw_bus_return = pitch_bus_return = -1`, confirming the #168 Phase 4 auto-release timer already fired and the idempotent short-circuit path is reached normally.
- The #170 fix core (= ACK loss → strand) is not directly verifiable on a healthy bus without forcing an ACK transmission failure (out of scope for routine testing). The `kUncertain` publish path is only reached on actual UART transmission failure; the codex review of the rebased + fix baseline returned 0 findings.

## Test plan

- [x] codex review on rebased baseline (2 rounds: initial finding + post-fix 0 findings)
- [x] Docker build PASS on rebased + fix baseline
- [x] ESP32 flash + boot + WS connect verify
- [x] `set_servo_torque` idempotent short-circuit path returns expected fields
- [x] Real-device motion regression: `move_head(yaw=20, pitch=44)` → physical motion observed, `get_head_angles` returned `{yaw: 19, pitch: 44}` (±1° servo position tolerance); reverse `move_head(yaw=0, pitch=44)` → physical return motion observed with stable hold at setpoint, `get_head_angles` returned `{yaw: 0, pitch: 44}`. Confirms #170 fix does not regress baseline motion path.
- [ ] (out of scope) forced ACK loss simulation — not routinely testable

## Refs

- Carved out from #168 Phase 4 adversarial review (PR #173, merged).
- Uses `idempotent_short_circuit` / `wait_exhausted` field split from #171 (PR #248, merged).
- Depends on #245 (PR #249, merged) mDNS browse reliability fix — verified on rebased baseline.
