### PR TITLE
feat: #129 add speed preset API to move_head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ documented-only.
 
 ### Firmware
 
+- Added `WriteHeadAngles(yaw, pitch, speed_dps)` overload for speed-based motion control on the user-driven `move_head` path. Existing duration-based overload preserved; boot-init path unchanged in this PR. Adds `MIN_SMOOTH_SPEED_DPS=72` (on-device measured floor) and `MAX_SPEED_DPS=240` (SCS0009 datasheet ceiling) clamping constants. (#129)
+
 - Add `kUncertain` state to `TorqueState`: an `EnableTorque(OFF)` (or
   `ON`) attempt that loses its ACK no longer publishes `kEngaged` from
   cached state. Subsequent motion or manual `set_servo_torque(...)`
@@ -276,6 +278,8 @@ documented-only.
   current owner. The previous configuration/port diagnostic remains
   available as `stackchan-mcp --preflight`. Queue and preempt modes are
   follow-ups. (#177)
+
+- Added optional `speed` parameter to `move_head` MCP tool. Accepts `"low"` / `"mid"` / `"high"` presets or a raw degrees-per-second integer. Internal resolution forwards `speed_dps` to the firmware; omitting `speed` preserves prior behavior. (#129)
 
 - Fixed: mDNS advertiser no longer interferes with the host OS Bonjour
   hostname. The SRV `server` field is now a fixed `stackchan-mcp.local.`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ documented-only.
 
 ### Firmware
 
-- Added `WriteHeadAngles(yaw, pitch, speed_dps)` overload for speed-based motion control on the user-driven `move_head` path. Existing duration-based overload preserved; boot-init path unchanged in this PR. Adds `MIN_SMOOTH_SPEED_DPS=72` (on-device measured floor) and `MAX_SPEED_DPS=240` (SCS0009 datasheet ceiling) clamping constants. (#129)
+- Added `WriteHeadAngles(yaw, pitch, speed_dps)` overload for speed-based motion control on the user-driven `move_head` path. Existing duration-based overload preserved; boot-init path unchanged in this PR. Adds `MAX_SPEED_DPS=240` (SCS0009 datasheet ceiling) safety clamp and `MIN_SMOOTH_SPEED_DPS=72` documented smoothness floor (sub-floor speeds are permitted with an `ESP_LOGW` warning so the gateway `"low"` preset can deliver deliberately slow motion). (#129)
 
 - Add `kUncertain` state to `TorqueState`: an `EnableTorque(OFF)` (or
   `ON`) attempt that loses its ACK no longer publishes `kEngaged` from

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -796,9 +796,11 @@ private:
     static constexpr uint32_t MOTION_TICK_MS = 20;
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     // Speed-based motion API (Issue #129).
-    // MIN_SMOOTH_SPEED_DPS is the on-device measured smoothness floor.
-    // Below this, motion looks stepped on SCS0009 at MOTION_TICK_MS=20 ms
-    // (5 step/tick "transition out", measured 2026-05-15).
+    // MIN_SMOOTH_SPEED_DPS is the on-device measured smoothness floor
+    // (5 step/tick "transition out", measured 2026-05-15). Speeds below
+    // this look textured on SCS0009 at MOTION_TICK_MS=20 ms; the firmware
+    // permits sub-floor speeds (logged with ESP_LOGW) so callers like the
+    // gateway "low" preset (30 dps) can deliver deliberately slow motion.
     static constexpr int MIN_SMOOTH_SPEED_DPS = 72;
     // MAX_SPEED_DPS is the SCS0009 datasheet reliability test working speed
     // (60 deg / 0.25 s = 240 deg/s, validated for >50k cycles at 1/2 rated load).
@@ -3667,9 +3669,13 @@ private:
         if (safe_speed <= 0) {
             safe_speed = DEFAULT_SPEED_DPS;
         } else if (safe_speed < MIN_SMOOTH_SPEED_DPS) {
-            ESP_LOGW(TAG, "WriteHeadAngles: speed_dps=%d below MIN_SMOOTH_SPEED_DPS=%d, clamping",
+            // Below the on-device measured smoothness floor -- motion will look
+            // textured on SCS0009 at MOTION_TICK_MS=20 ms. This is intentionally
+            // permitted (the gateway "low" preset is 30 dps, deliberately below
+            // the floor for slow, expressive motion per Issue #129 design).
+            // Log once so callers can see they are below the smooth zone.
+            ESP_LOGW(TAG, "WriteHeadAngles: speed_dps=%d below MIN_SMOOTH_SPEED_DPS=%d (textured motion is expected)",
                      speed_dps, MIN_SMOOTH_SPEED_DPS);
-            safe_speed = MIN_SMOOTH_SPEED_DPS;
         } else if (safe_speed > MAX_SPEED_DPS) {
             ESP_LOGW(TAG, "WriteHeadAngles: speed_dps=%d above MAX_SPEED_DPS=%d, clamping",
                      speed_dps, MAX_SPEED_DPS);

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -795,6 +795,17 @@ private:
 #endif
     static constexpr uint32_t MOTION_TICK_MS = 20;
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
+    // Speed-based motion API (Issue #129).
+    // MIN_SMOOTH_SPEED_DPS is the on-device measured smoothness floor.
+    // Below this, motion looks stepped on SCS0009 at MOTION_TICK_MS=20 ms
+    // (5 step/tick "transition out", measured 2026-05-15).
+    static constexpr int MIN_SMOOTH_SPEED_DPS = 72;
+    // MAX_SPEED_DPS is the SCS0009 datasheet reliability test working speed
+    // (60 deg / 0.25 s = 240 deg/s, validated for >50k cycles at 1/2 rated load).
+    static constexpr int MAX_SPEED_DPS = 240;
+    // DEFAULT_SPEED_DPS is used when the caller passes speed_dps <= 0.
+    // Matches the gateway "mid" preset.
+    static constexpr int DEFAULT_SPEED_DPS = 120;
     static constexpr uint32_t MOTION_PER_WRITE_TIME_MS = 30;
     static constexpr uint32_t MOTION_POLL_INTERVAL_MS = 50;
     static constexpr uint32_t AUTO_TORQUE_RELEASE_MIN_MS = 500;
@@ -3647,6 +3658,33 @@ private:
         xSemaphoreGive(motion_mutex_);
     }
 
+    void WriteHeadAngles(int yaw_deg, int pitch_deg, int speed_dps) {
+        if (!servo_ok_ || motion_driver_ == nullptr) {
+            ESP_LOGW(TAG, "WriteHeadAngles(speed_dps) skipped: servo not initialized");
+            return;
+        }
+        int safe_speed = speed_dps;
+        if (safe_speed <= 0) {
+            safe_speed = DEFAULT_SPEED_DPS;
+        } else if (safe_speed < MIN_SMOOTH_SPEED_DPS) {
+            ESP_LOGW(TAG, "WriteHeadAngles: speed_dps=%d below MIN_SMOOTH_SPEED_DPS=%d, clamping",
+                     speed_dps, MIN_SMOOTH_SPEED_DPS);
+            safe_speed = MIN_SMOOTH_SPEED_DPS;
+        } else if (safe_speed > MAX_SPEED_DPS) {
+            ESP_LOGW(TAG, "WriteHeadAngles: speed_dps=%d above MAX_SPEED_DPS=%d, clamping",
+                     speed_dps, MAX_SPEED_DPS);
+            safe_speed = MAX_SPEED_DPS;
+        }
+
+        int yaw_delta = std::abs(yaw_deg - static_cast<int>(motion_driver_->GetYawDeg()));
+        int pitch_delta = std::abs(pitch_deg - static_cast<int>(motion_driver_->GetPitchDeg()));
+        int max_delta = std::max(yaw_delta, pitch_delta);
+        uint32_t duration_ms = std::max<uint32_t>(
+            MOTION_TICK_MS,
+            static_cast<uint32_t>(max_delta) * 1000U / static_cast<uint32_t>(safe_speed));
+        WriteHeadAngles(yaw_deg, pitch_deg, duration_ms);
+    }
+
     // Servo wobble: yaw -A -> +A -> -A -> 0. Each step is dispatched only
     // after the active MotionDriver reports idle, so the delegated path never
     // overwrites an in-flight SCS0009 internal motion.
@@ -4974,7 +5012,7 @@ private:
         // spot) above, plus Issue #80 / #98.
         mcp_server.AddTool(
             "self.robot.set_head_angles",
-            "Set the head angles of the robot. yaw: horizontal (-90 to 90). pitch: vertical. M5Stack-recommended operating range is 5 to 85 degrees per https://docs.m5stack.com/en/StackChan (\"Motion Angle Notice\"). The firmware also accepts values up to 88 degrees (the hard clamp guards against the audible sub-stall observed at pitch=89 on real hardware), but values outside 5-85 degrees are not officially endorsed and may stress the servo over time. Requests below 0 degrees or above 88 degrees are silently clamped with an ESP_LOGW. See README \"Hardware safety notes\".",
+            "Set the head angles of the robot. yaw: horizontal (-90 to 90). pitch: vertical. M5Stack-recommended operating range is 5 to 85 degrees per https://docs.m5stack.com/en/StackChan (\"Motion Angle Notice\"). The firmware also accepts values up to 88 degrees (the hard clamp guards against the audible sub-stall observed at pitch=89 on real hardware), but values outside 5-85 degrees are not officially endorsed and may stress the servo over time. Requests below 0 degrees or above 88 degrees are silently clamped with an ESP_LOGW. Optional speed_dps: angular speed in degrees per second. If omitted or zero, the existing duration-based default applies. See README \"Hardware safety notes\".",
             // Pitch schema range is intentionally permissive across the
             // entire `int` value range (std::numeric_limits<int>::min/max):
             // the authoritative Tier 1 enforcement lives in the handler
@@ -4993,10 +5031,14 @@ private:
             PropertyList({Property("yaw", kPropertyTypeInteger, 0, -90, 90),
                           Property("pitch", kPropertyTypeInteger, 0,
                                    std::numeric_limits<int>::min(),
+                                   std::numeric_limits<int>::max()),
+                          Property("speed_dps", kPropertyTypeInteger, 0,
+                                   std::numeric_limits<int>::min(),
                                    std::numeric_limits<int>::max())}),
             [this](const PropertyList& properties) -> ReturnValue {
                 int yaw = properties["yaw"].value<int>();
                 int pitch = properties["pitch"].value<int>();
+                int speed_dps = properties["speed_dps"].value<int>();
                 // Issue #80 / #98: two-tier pitch guard.
                 //
                 // Tier 1 (hard clamp): silently clamp to [SAFE_PITCH_MIN,
@@ -5025,7 +5067,11 @@ private:
                 }
                 int yaw_pos = YawDegToPos(yaw);
                 int pitch_pos = PitchDegToPos(pitch);
-                WriteHeadAngles(yaw, pitch);
+                if (speed_dps > 0) {
+                    WriteHeadAngles(yaw, pitch, speed_dps);
+                } else {
+                    WriteHeadAngles(yaw, pitch);
+                }
                 bool yaw_motion_started = false;
                 bool pitch_motion_started = false;
                 if (servo_ok_) {

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -20,6 +20,41 @@ from .tts import synthesize_and_send
 
 logger = logging.getLogger(__name__)
 
+PRESET_DPS = {
+    "low": 30,
+    "mid": 120,
+    "high": 240,
+}
+SPEED_DPS_MAX = 10000
+SPEED_DESCRIPTION = """speed (optional): How fast to move the head.
+  - "low"  — slow, deliberate, ~30°/s. Good for curious tilts or gentle look-toward.
+  - "mid"  — default natural turn, ~120°/s. Use for conversational eye contact.
+  - "high" — quick reaction, ~240°/s. Use for surprise / double-take.
+  - Or a raw degrees-per-second integer if you need a specific value."""
+
+
+def _resolve_speed_dps(speed: Any) -> int | None:
+    """Return an int speed_dps to forward, or None to omit the field."""
+    if speed is None:
+        return None
+    if isinstance(speed, bool):
+        raise TypeError("speed must be a preset string or an integer, not bool")
+    if isinstance(speed, str):
+        if speed not in PRESET_DPS:
+            raise ValueError(
+                f"speed preset must be one of {list(PRESET_DPS)}, got {speed!r}"
+            )
+        return PRESET_DPS[speed]
+    if isinstance(speed, int):
+        if speed < 1:
+            raise ValueError(f"speed integer must be >= 1, got {speed}")
+        if speed > SPEED_DPS_MAX:
+            raise ValueError(f"speed integer must be <= {SPEED_DPS_MAX}, got {speed}")
+        return speed
+    raise TypeError(
+        f"speed must be 'low' / 'mid' / 'high' / int / None, got {type(speed).__name__}"
+    )
+
 
 def create_server() -> Server:
     """Create and configure the MCP server with tool handlers."""
@@ -131,6 +166,17 @@ def create_server() -> Server:
                             ),
                             "minimum": 5,
                             "maximum": 85,
+                        },
+                        "speed": {
+                            "oneOf": [
+                                {"enum": ["low", "mid", "high"]},
+                                {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": SPEED_DPS_MAX,
+                                },
+                            ],
+                            "description": SPEED_DESCRIPTION,
                         },
                     },
                     "required": ["yaw", "pitch"],
@@ -894,6 +940,18 @@ def create_server() -> Server:
                         ),
                     )
                 ]
+            try:
+                speed_dps = _resolve_speed_dps(arguments.get("speed"))
+            except (TypeError, ValueError) as exc:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"error": str(exc)}),
+                    )
+                ]
+            arguments = {"yaw": yaw_val, "pitch": pitch_val}
+            if speed_dps is not None:
+                arguments["speed_dps"] = speed_dps
 
         # Map MCP client tool names to ESP32 MCP tool names (self.* prefix)
         tool_map: dict[str, tuple[str, dict[str, Any]]] = {

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from mcp.types import CallToolRequest, ListToolsRequest
 
-from stackchan_mcp.stdio_server import create_server
+from stackchan_mcp.stdio_server import SPEED_DESCRIPTION, create_server, _resolve_speed_dps
 from stackchan_mcp.tts import get_registry
 
 
@@ -410,6 +410,38 @@ async def test_list_tools_move_head_declares_recommended_pitch_range():
     # reading it can pick the right alternative for permissive use cases.
     assert "set_head_angles" in tool.description
 
+    speed_schema = tool.inputSchema["properties"]["speed"]
+    assert speed_schema["oneOf"] == [
+        {"enum": ["low", "mid", "high"]},
+        {"type": "integer", "minimum": 1, "maximum": 10000},
+    ]
+    assert speed_schema["description"] == SPEED_DESCRIPTION
+
+
+@pytest.mark.parametrize(
+    ("speed", "expected_dps"),
+    [
+        ("low", 30),
+        ("mid", 120),
+        ("high", 240),
+        (None, None),
+        (200, 200),
+        (1, 1),
+        (10000, 10000),
+    ],
+)
+def test_resolve_speed_dps_valid(speed, expected_dps):
+    assert _resolve_speed_dps(speed) == expected_dps
+
+
+@pytest.mark.parametrize(
+    "bad_speed",
+    ["fast", "slow", "", 0, -1, 10001, True, False, 1.5, [120], {}],
+)
+def test_resolve_speed_dps_invalid(bad_speed):
+    with pytest.raises((ValueError, TypeError)):
+        _resolve_speed_dps(bad_speed)
+
 
 def _make_fake_gateway(monkeypatch):
     """Helper: wire a FakeESP32/FakeGateway into the stdio_server module.
@@ -444,10 +476,16 @@ def _make_fake_gateway(monkeypatch):
     return calls
 
 
-def _move_head_request(yaw, pitch):
+_MISSING = object()
+
+
+def _move_head_request(yaw, pitch, speed=_MISSING):
+    arguments = {"yaw": yaw, "pitch": pitch}
+    if speed is not _MISSING:
+        arguments["speed"] = speed
     return CallToolRequest(
         method="tools/call",
-        params={"name": "move_head", "arguments": {"yaw": yaw, "pitch": pitch}},
+        params={"name": "move_head", "arguments": arguments},
     )
 
 
@@ -538,6 +576,42 @@ async def test_move_head_accepts_pitch_inside_recommended(monkeypatch, pitch):
     name, arguments = calls[0]
     assert name == "self.robot.set_head_angles"
     assert arguments == {"yaw": 0, "pitch": pitch}
+
+    payload = json.loads(result.root.content[0].text)
+    assert "error" not in payload
+
+
+@pytest.mark.asyncio
+async def test_move_head_speed_mid_forwards_speed_dps(monkeypatch):
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=10, pitch=45, speed="mid")
+    )
+
+    assert len(calls) == 1
+    name, arguments = calls[0]
+    assert name == "self.robot.set_head_angles"
+    assert arguments == {"yaw": 10, "pitch": 45, "speed_dps": 120}
+
+    payload = json.loads(result.root.content[0].text)
+    assert "error" not in payload
+
+
+@pytest.mark.asyncio
+async def test_move_head_without_speed_omits_speed_dps(monkeypatch):
+    calls = _make_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _move_head_request(yaw=10, pitch=45)
+    )
+
+    assert len(calls) == 1
+    name, arguments = calls[0]
+    assert name == "self.robot.set_head_angles"
+    assert arguments == {"yaw": 10, "pitch": 45}
 
     payload = json.loads(result.root.content[0].text)
     assert "error" not in payload


### PR DESCRIPTION
## Summary

Add an LLM-friendly speed control to the user-driven `move_head` MCP tool, spanning both gateway (Python MCP) and firmware (C++ ESP32) layers. Boot-init motion path is intentionally left untouched in this PR.

## What this PR delivers

- **Gateway**: `move_head` MCP tool gains an optional `speed` parameter accepting `"low"` / `"mid"` / `"high"` presets or a raw degrees-per-second integer. Tool description is LLM-facing with explicit use-case guidance (curious tilts, conversational turns, surprise reactions).
- **Firmware**: new `WriteHeadAngles(yaw, pitch, speed_dps)` overload interpolates motion at the caller-specified angular velocity. The existing `WriteHeadAngles(yaw, pitch, duration_ms = MOTION_DEFAULT_DURATION_MS)` overload is preserved unchanged; all existing call sites keep identical behavior.
- **Firmware**: extends `self.robot.set_head_angles` MCP tool to accept and forward optional `speed_dps`; omitting it preserves the pre-#129 duration-based default path bit-for-bit.
- **Firmware constants**:
  - `MAX_SPEED_DPS = 240` — SCS0009 datasheet reliability test working speed; out-of-range high values are clamped with a one-shot `ESP_LOGW`.
  - `MIN_SMOOTH_SPEED_DPS = 72` — on-device measured smoothness floor (5 step/tick "transition out", measured 2026-05-15). Below this, motion looks textured on SCS0009 at `MOTION_TICK_MS=20 ms`. Sub-floor speeds are **permitted with a one-shot `ESP_LOGW`** so the gateway `"low"` preset (30 dps) can deliver deliberately slow, expressive motion as documented in the design.
- **Gateway tests**: parametrized unit tests for the preset → dps resolver covering valid presets, `None`, raw integers, and invalid string / out-of-range / wrong-type rejection. Two end-to-end tests assert `speed="mid"` forwards `speed_dps=120` and that omitting `speed` preserves pre-#129 dispatch.
- **CHANGELOG**: `[Unreleased]` entries under `### Gateway` and `### Firmware`.

## Preset to dps mapping

| Preset | speed_dps | Intent |
|---|---|---|
| `"low"` | 30 | Slow, deliberate motion (curious tilts, gentle look-toward). Slightly textured on SCS0009 hardware until software easing lands (follow-up). |
| `"mid"` (default) | 120 | Natural conversational turn / eye contact. Reliably smooth. |
| `"high"` | 240 | Quick reaction / surprise / double-take. At SCS0009 datasheet reliability ceiling. |
| raw int | 1..10000 (gateway) | Escape hatch for fine-tuning. Firmware warns on sub-floor and clamps above `MAX_SPEED_DPS`. |

Numbers are starting candidates per Issue #129's final design comment and may be fine-tuned on-device after merge.

## Backward compatibility

- Existing `move_head(yaw, pitch)` calls (without `speed`) continue to dispatch with no `speed_dps` field, so the firmware takes its existing duration-based default path. Pre-#129 behavior is bit-for-bit preserved on the absence path.
- Existing `WriteHeadAngles(yaw, pitch, duration_ms)` firmware overload is untouched; the new overload is additive.

## Out of scope (follow-ups)

- **Boot-init motion path** (`BOOT_INIT_MOVE_MS=3000` budget floor + Phase-2 no-op cover semantics around `stackchan.cc:2900-2950`) is intentionally not modified. Refactoring boot-init to share the new speed API requires its own review of the budget-floor semantics and is a follow-up PR.
- **Software easing primitive** (`quadraticEaseInOut`-style interpolation inside the tick loop) is a follow-up PR. Until easing lands, the `"low"` preset (30°/s) will look slightly textured on SCS0009 hardware — accepted trade-off per Issue #129's design.
- **Raw-int `speed_dps` stall-floor guard** (#252): the raw-integer escape hatch on `move_head(speed=N)` has no lower-bound guard against the sub-step stall zone (`speed_dps ≤ 14`); preset paths (`"low"` = 30 dps and above) are safe. Tracked as priority/low for after on-device observation.
- Named motion templates (#89 / #90), FeetechScs `WritePos(time, speed)` propagation (gated on #79 MIT driver migration), `SyncWritePos` (gated on #79), and `MOTION_TICK_MS` adjustment are out of scope.

## Test plan

- [x] Gateway unit tests pass: `cd gateway && uv run pytest tests/test_stdio_server.py` — 53 passed (incl. new preset resolver tests and `speed="mid"` / `speed` omitted dispatch tests).
- [x] Gateway lint passes: `uv run ruff check .` — passed.
- [x] Docker firmware build passes (ESP-IDF v5.5.2): `xiaozhi.bin` 0x3691b0 bytes (13% partition free), `merged-binary.bin` 9.5 MB. `sdkconfig_append` confirms `CONFIG_FORCE_DEFAULT_WEBSOCKET_URL=n`, no personal token leak.
- [x] License boundary: GPL-3.0 SCS files in `firmware/main/boards/stackchan/` are untouched.
- [x] Boot-init path (`stackchan.cc:2900-2950` + `BOOT_INIT_*` constants) untouched.
- [x] Codex standard review (round 2 after low-preset clamp fix): no blocking findings.
- [ ] On-device verification of `"low"` / `"mid"` / `"high"` perceived speeds for fine-tuning the starting candidates (maintainer, post-merge).

## Refs

Closes #129

Carve-out follow-ups:
- #252 (raw-int stall-floor guard, priority/low)