### PR TITLE
fix(gateway): #177 ownership lock refuse-mode MVP (Windows-safe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,14 @@ documented-only.
 
 ### Gateway
 
+- Add ownership lock for concurrent gateway startup (refuse-mode MVP).
+  Second process refuses with deterministic stderr error and exit code 1
+  instead of silently breaking the first owner's WebSocket. Lock file:
+  `~/.stackchan-mcp/owner.lock`. Use `stackchan-mcp --check` to inspect
+  current owner. The previous configuration/port diagnostic remains
+  available as `stackchan-mcp --preflight`. Queue and preempt modes are
+  follow-ups. (#177)
+
 - Fixed: mDNS advertiser no longer interferes with the host OS Bonjour
   hostname. The SRV `server` field is now a fixed `stackchan-mcp.local.`
   instead of the system hostname, so the Python zeroconf library does

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -11,6 +11,7 @@ working.
 
 from __future__ import annotations
 
+import atexit
 import argparse
 import asyncio
 import errno
@@ -78,10 +79,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--check",
         action="store_true",
+        help="Print the current gateway ownership lock status and exit.",
+    )
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
         help=(
-            "Run a non-destructive preflight (configuration, port "
-            "availability, derived URLs) and exit. Exit 0 if ready to run, "
-            "non-zero if at least one blocking issue is found."
+            "Run a non-destructive configuration and port preflight, then "
+            "exit. Exit 0 if ready to run, non-zero if at least one "
+            "blocking issue is found."
         ),
     )
     parser.add_argument(
@@ -395,6 +401,25 @@ def _load_dotenv() -> None:
     load_dotenv()
 
 
+def _run_ownership_check() -> int:
+    """Print the current ownership lock status and exit cleanly."""
+    from .ownership import is_pid_alive, read_lock
+
+    info = read_lock()
+    if info is None:
+        print("no current owner")
+        print("ownership preflight: ready")
+        print("Result: ready. Exit 0.")
+    elif is_pid_alive(info["pid"]):
+        print(
+            f"owner_id={info['owner_id']} pid={info['pid']} "
+            f"start_ts={info['start_ts']} host={info['host']}"
+        )
+    else:
+        print(f"stale lock found: pid {info['pid']} not alive")
+    return 0
+
+
 # Default Homebrew prefixes that ship libopus.dylib on macOS. Apple
 # Silicon installs default to ``/opt/homebrew``; Intel Macs use
 # ``/usr/local``. Keeping both keeps the helper portable across
@@ -612,10 +637,11 @@ async def _run(*, advertise_mdns: bool = True) -> None:
 def main(argv: list[str] | None = None) -> None:
     """Console-script entry point.
 
-    Parses ``--help`` / ``--version`` / ``--check`` early (without
-    starting the server), then loads ``.env``, configures logging, and
-    starts the gateway. Side effects are intentionally scoped to this
-    function so that ``import stackchan_mcp`` stays clean.
+    Parses ``--help`` / ``--version`` / ``--check`` / ``--preflight`` early
+    (without starting the server), then loads ``.env``, configures logging,
+    claims gateway ownership, and starts the gateway. Side effects are
+    intentionally scoped to this function so that ``import stackchan_mcp``
+    stays clean.
     """
     parser = _build_arg_parser()
     # argparse exits with status 0 on --help / --version before reaching
@@ -623,6 +649,9 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     if args.check:
+        sys.exit(_run_ownership_check())
+
+    if args.preflight:
         # ``_run_preflight`` loads ``.env`` itself; do not double-load
         # via the path below.
         sys.exit(_run_preflight())
@@ -635,7 +664,34 @@ def main(argv: list[str] | None = None) -> None:
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
 
-    asyncio.run(_run(advertise_mdns=not args.no_mdns))
+    from .ownership import (
+        OwnershipError,
+        acquire_lock,
+        generate_owner_id,
+        release_lock,
+    )
+
+    owner_id = generate_owner_id()
+    try:
+        info = acquire_lock(owner_id)
+    except OwnershipError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        "stackchan-mcp: acquired ownership lock "
+        f"(owner_id={info['owner_id']}, pid={info['pid']})",
+        file=sys.stderr,
+    )
+    atexit.register(release_lock)
+
+    try:
+        try:
+            asyncio.run(_run(advertise_mdns=not args.no_mdns))
+        except KeyboardInterrupt:
+            pass
+    finally:
+        release_lock()
 
 
 if __name__ == "__main__":

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -38,8 +38,15 @@ def generate_owner_id() -> str:
 
 
 def is_pid_alive(pid: int) -> bool:
+    """Return whether pid is alive without disturbing the target process.
+
+    On Windows, os.kill(pid, 0) calls TerminateProcess(..., 0), which would
+    kill the target process; use a non-destructive Win32 API check instead.
+    """
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        return _is_pid_alive_windows(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -47,6 +54,41 @@ def is_pid_alive(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _is_pid_alive_windows(pid: int) -> bool:
+    import ctypes
+    import ctypes.wintypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [
+        ctypes.wintypes.DWORD,
+        ctypes.wintypes.BOOL,
+        ctypes.wintypes.DWORD,
+    ]
+    kernel32.OpenProcess.restype = ctypes.wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [
+        ctypes.wintypes.HANDLE,
+        ctypes.POINTER(ctypes.wintypes.DWORD),
+    ]
+    kernel32.GetExitCodeProcess.restype = ctypes.wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [ctypes.wintypes.HANDLE]
+    kernel32.CloseHandle.restype = ctypes.wintypes.BOOL
+
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return False
+
+    try:
+        exit_code = ctypes.wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def read_lock(path: Path = LOCK_PATH) -> LockInfo | None:

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -1,0 +1,133 @@
+"""Gateway ownership lock - refuse-mode MVP (#177 Phase A)."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypedDict
+
+LOCK_DIR = Path.home() / ".stackchan-mcp"
+LOCK_PATH = LOCK_DIR / "owner.lock"
+
+
+class LockInfo(TypedDict):
+    owner_id: str
+    pid: int
+    start_ts: str
+    host: str
+
+
+class OwnershipError(RuntimeError):
+    """Raised when ownership cannot be acquired."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def generate_owner_id() -> str:
+    env = os.environ.get("STACKCHAN_OWNER_ID")
+    if env:
+        return env
+    return f"stackchan-mcp-{uuid.uuid4().hex[:8]}"
+
+
+def is_pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def read_lock(path: Path = LOCK_PATH) -> LockInfo | None:
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    owner_id = raw.get("owner_id")
+    pid = raw.get("pid")
+    start_ts = raw.get("start_ts")
+    host = raw.get("host")
+    if (
+        not isinstance(owner_id, str)
+        or not isinstance(pid, int)
+        or not isinstance(start_ts, str)
+        or not isinstance(host, str)
+    ):
+        return None
+
+    return {
+        "owner_id": owner_id,
+        "pid": pid,
+        "start_ts": start_ts,
+        "host": host,
+    }
+
+
+def _write_lock_atomic(info: LockInfo, path: Path = LOCK_PATH) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    tmp.write_text(json.dumps(info, indent=2), encoding="utf-8")
+    try:
+        # Link the complete temp file into place only if no owner file exists.
+        # This keeps readers from seeing partial JSON and lets exactly one
+        # simultaneous startup win the initial claim.
+        os.link(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def acquire_lock(owner_id: str, path: Path = LOCK_PATH) -> LockInfo:
+    """Acquire the ownership lock. Raise OwnershipError on refuse."""
+    while True:
+        existing = read_lock(path)
+        if existing is not None:
+            if is_pid_alive(existing["pid"]):
+                raise OwnershipError(
+                    "stackchan-mcp: device already owned by "
+                    f"{existing['owner_id']} "
+                    f"(pid {existing['pid']}, since {existing['start_ts']})"
+                )
+            print(
+                f"stackchan-mcp: removed stale lock from dead pid {existing['pid']}",
+                file=sys.stderr,
+            )
+            path.unlink(missing_ok=True)
+        elif path.exists():
+            path.unlink()
+
+        info: LockInfo = {
+            "owner_id": owner_id,
+            "pid": os.getpid(),
+            "start_ts": _now_iso(),
+            "host": socket.gethostname(),
+        }
+        try:
+            _write_lock_atomic(info, path)
+        except FileExistsError:
+            continue
+        return info
+
+
+def release_lock(path: Path = LOCK_PATH) -> None:
+    """Remove the lock file. Idempotent."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass

--- a/gateway/tests/test_ownership.py
+++ b/gateway/tests/test_ownership.py
@@ -1,0 +1,92 @@
+"""Tests for #177 Phase A ownership lock."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from stackchan_mcp.ownership import (
+    OwnershipError,
+    acquire_lock,
+    generate_owner_id,
+    is_pid_alive,
+    read_lock,
+    release_lock,
+)
+
+
+@pytest.fixture
+def lock_path(tmp_path: Path) -> Path:
+    return tmp_path / "owner.lock"
+
+
+def test_acquire_when_no_lock_succeeds(lock_path: Path) -> None:
+    info = acquire_lock("test-owner-1", lock_path)
+    assert info["owner_id"] == "test-owner-1"
+    assert info["pid"] == os.getpid()
+    assert lock_path.exists()
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert data["owner_id"] == "test-owner-1"
+
+
+def test_acquire_when_live_lock_refuses(lock_path: Path) -> None:
+    acquire_lock("first-owner", lock_path)
+    with pytest.raises(OwnershipError, match="already owned by first-owner"):
+        acquire_lock("second-owner", lock_path)
+
+
+def test_acquire_when_stale_lock_overwrites(lock_path: Path) -> None:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "dead-owner",
+                "pid": 999999,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "nowhere",
+            }
+        ),
+        encoding="utf-8",
+    )
+    info = acquire_lock("new-owner", lock_path)
+    assert info["owner_id"] == "new-owner"
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert data["owner_id"] == "new-owner"
+
+
+def test_release_is_idempotent(lock_path: Path) -> None:
+    acquire_lock("owner", lock_path)
+    release_lock(lock_path)
+    assert not lock_path.exists()
+    release_lock(lock_path)
+
+
+def test_read_lock_returns_none_when_missing(lock_path: Path) -> None:
+    assert read_lock(lock_path) is None
+
+
+def test_is_pid_alive_for_self_returns_true() -> None:
+    assert is_pid_alive(os.getpid()) is True
+
+
+def test_is_pid_alive_for_dead_pid_returns_false() -> None:
+    assert is_pid_alive(999999) is False
+
+
+def test_generate_owner_id_uses_env_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STACKCHAN_OWNER_ID", "custom-id")
+    assert generate_owner_id() == "custom-id"
+
+
+def test_generate_owner_id_falls_back_to_uuid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("STACKCHAN_OWNER_ID", raising=False)
+    label = generate_owner_id()
+    assert label.startswith("stackchan-mcp-")
+    assert len(label) == len("stackchan-mcp-") + 8


### PR DESCRIPTION
## Summary

Adds gateway-side ownership coordination per #177, **refuse mode MVP only**. When a second `stackchan-mcp` gateway process tries to start on the same host while another instance is already running, it now fails with a deterministic stderr error and exit code 1 instead of silently breaking the first owner's ESP32 WebSocket.

This is the tactical fix for the multi-MCP-client port 8765 contention failure mode documented in #177 / #178. The structural successor is #178 (HTTP transport + single shared daemon), which has #169 as a hard prerequisite and a larger scope.

## What this changes

### New: `gateway/stackchan_mcp/ownership.py` (+133)

File-based lock at `~/.stackchan-mcp/owner.lock` (single-host coordination). Functions:

- `generate_owner_id()` — honors `STACKCHAN_OWNER_ID` env var, otherwise emits `stackchan-mcp-<uuid8>`
- `read_lock(path)` — returns `LockInfo | None`, tolerant of missing / corrupt files
- `acquire_lock(owner_id, path)` — race-free atomic claim via `os.link()`; raises `OwnershipError` if the existing owner's PID is alive; reaps stale locks from dead PIDs
- `is_pid_alive(pid)` — POSIX `kill(pid, 0)` probe
- `release_lock(path)` — idempotent removal

The lock contents (`owner_id`, `pid`, `start_ts` UTC ISO8601, `host`) are written via `_write_lock_atomic` — a `.tmp` file plus `os.link()` into final position — so concurrent startups see either no file or a fully written one, and exactly one wins the initial claim.

### Updated: `gateway/stackchan_mcp/cli.py` (+72/-8)

- `main()` now claims the ownership lock before `asyncio.run(_run())`. On `OwnershipError`, prints the error to stderr and exits 1. `atexit.register(release_lock)` ensures the lock is removed on graceful shutdown.
- `--check` is **repurposed** to report the current ownership lock status (`owner_id`, `pid`, `start_ts`, `host`) and exit. See "Breaking change" below.
- The previous configuration / port diagnostic that lived under `--check` is preserved verbatim under the new `--preflight` flag (no semantic change to the diagnostic itself).

### Updated: `gateway/stackchan_mcp/ownership.py` — Windows-safe `is_pid_alive` (+42)

Added a `sys.platform == "win32"` branch in `is_pid_alive(pid)` because Python's `os.kill(pid, 0)` on Windows is implemented as `TerminateProcess(handle, 0)`, which would kill the target process rather than probing its liveness. The POSIX path (`os.kill(pid, 0)` + `ProcessLookupError` / `PermissionError` handling) is unchanged. The Windows branch uses a lazily-imported `ctypes` helper that calls `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess`, closes the handle in a `try`/`finally`, and returns True only when the exit code equals `STILL_ACTIVE` (259). Matches the existing platform-branch convention in `cli.py` (SIGTERM handler) and `__init__.py` (opus.dll bundling).

### New tests: `gateway/tests/test_ownership.py` (+92)

8 unit tests covering:

- `acquire_lock` succeeds on a clean slate
- `acquire_lock` refuses with `OwnershipError` when a live owner exists (message includes the prior `owner_id`)
- `acquire_lock` reaps a stale lock pointing at a dead PID and claims successfully
- `release_lock` is idempotent
- `read_lock` returns `None` for a missing file
- `is_pid_alive` returns `True` for `os.getpid()`, `False` for an unallocated high PID
- `generate_owner_id` uses `STACKCHAN_OWNER_ID` env var when set
- `generate_owner_id` falls back to the `stackchan-mcp-<uuid8>` UUID form

### CHANGELOG

One entry under `[Unreleased]` Gateway.

## Breaking change: `--check` semantics

Previously `stackchan-mcp --check` printed the configuration / port preflight (env var presence, port-bind probe, lsof port-holder lookup, redacted URL summary) and exited 0/1. After this PR:

- `stackchan-mcp --check` prints ownership lock status only.
- The previous configuration / port preflight remains available as `stackchan-mcp --preflight` (same output, same exit semantics).

Operators relying on `--check` in install verification scripts should rename the invocation to `--preflight`. The new `--check` is intentionally lightweight (single JSON file read, no network / port probes) so it is safe to call from cron / status dashboards while a gateway is running.

## Acceptance criteria from #177

- [x] Concurrent gateway startup on the same host produces a deterministic outcome (refuse) — no silent device loss.
- [x] `stackchan-mcp --check` reports the current owner if one exists.
- [x] No regression for single-client usage — the existing zero-config path acquires and releases the lock transparently.
- [x] Stale lock recovery: a crashed previous owner does not permanently block the next startup (next acquire reaps stale PIDs).
- [N/A this PR] Take-over within a defined time bound (< 3 s) — applies to queue / preempt modes, not refuse mode. See "Out of scope" below.

## Test plan

- `cd gateway && uv run pytest tests/test_ownership.py -v` — 8/8 PASS expected
- `cd gateway && uv run pytest` — full suite green
- `cd gateway && uv run ruff check .` — clean
- Manual: start one gateway, run `stackchan-mcp --check` from another shell → prints owner info; start a second gateway → exits 1 with the expected stderr line.
- Manual: kill -9 a running gateway (leaves a stale lock), start a fresh gateway → reaps the stale lock and acquires successfully, logs `removed stale lock from dead pid <N>`.

Real-device verification (ESP32 WebSocket round-trip) is not required for this PR: the change is purely gateway-side process coordination and does not touch the ESP32 wire format or firmware.

## Out of scope / Follow-ups

- **Mode B (queue)** and **Mode C (preempt)** from #177's proposed direction — to be added as separate enhancements once the refuse-mode MVP has shipped and operational signal is gathered. The current single-file-lock data model leaves room for these (the take-over protocol can be layered on top via a `release_requested` field).
- **`STACKCHAN_OWNERSHIP_MODE` env var** — implied selector for the future modes; not introduced in this PR to keep the env surface minimal until B/C land.
- **PID-reuse hardening via process start-time / boot-id verification** — tracked as #253. The current dead-PID detection satisfies #177's "Stale lock recovery" acceptance criterion in normal use; the PID-reuse corner case (PID wraparound + crashed gateway + recycled PID assigned to an unrelated long-lived process) is a separately-scoped hardening opportunity with cross-platform identity-retrieval implications (Linux `/proc/<pid>/stat`, macOS `proc_pidinfo`, Windows `GetProcessTimes`) better addressed in its own PR.
- **`--preflight` does not probe ownership lock status** — by design. The two diagnostics are kept on separate flags because `--preflight` is a side-effect-free config / port readiness check (safe to call regardless of lock state), while `--check` reports the current lock owner. Operators interleaving multi-instance startup are expected to consult both; the surface unification can be reconsidered when queue / preempt modes (Mode B / C) introduce richer status semantics. The mismatch between a `Result: ready` preflight and a subsequent `acquire_lock` refusal is observable (the gateway exits with a clear stderr message rather than silently misbehaving) and only triggers in multi-instance troubleshooting, not in the single-client zero-config path.
- **Concurrent-acquire process-level regression test** — covered logically by `os.link()` atomicity (POSIX-guaranteed); a process-level race test would be flaky and adds little value beyond the existing single-process tests.
- **Mock-based Windows-path tests for `is_pid_alive`** — Mock tests for native Win32 APIs give weak signal for correctness; real coverage requires a Windows CI runner, which is a separate enhancement tracked outside this PR.
- **Cross-host coordination** — explicitly out of scope per #177 (single-host file lock by design).

## Refs

- Closes #177
- Related: #178 (structural successor — HTTP transport + command queue, hard prerequisite #169)
- Follow-up: #253 (PID-reuse hardening via process start-time / boot-id verification)
