### PR TITLE
feat(gateway): #178 Phase B chunk 2+3 — ownership lock diagnostics + daemon CLI serve subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ documented-only.
   routing, a single-flight dispatcher loop, and a standardized queue-full
   error payload helper.
 
+- Added: #178 Phase B chunk 2 ownership lock diagnostics metadata
+  (`mode`, `http_endpoint`, `started_by`) while preserving #177-format
+  stdio lock files and existing-format `--check` output.
+
+- Added: #178 Phase B chunk 3 `stackchan-mcp serve` CLI with permanent
+  `--transport stdio` compatibility and a Streamable HTTP daemon
+  placeholder that releases ownership before the chunk 4 wiring lands.
+
 ### Firmware
 
 - Added `WriteHeadAngles(yaw, pitch, speed_dps)` overload for speed-based motion control on the user-driven `move_head` path. Existing duration-based overload preserved; boot-init path unchanged in this PR. Adds `MAX_SPEED_DPS=240` (SCS0009 datasheet ceiling) safety clamp and `MIN_SMOOTH_SPEED_DPS=72` documented smoothness floor (sub-floor speeds are permitted with an `ESP_LOGW` warning so the gateway `"low"` preset can deliver deliberately slow motion). (#129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ documented-only.
   `--transport stdio` compatibility and a Streamable HTTP daemon
   placeholder that releases ownership before the chunk 4 wiring lands.
 
+- Fixed: #178 Phase B chunk 2+3 streamable-http serve placeholder now
+  releases the ownership lock under every failure path between lock claim
+  and the `NotImplementedError` chunk 4 boundary; `acquire_lock` now
+  rejects `http_endpoint` and `started_by` metadata when `mode="stdio"` so
+  daemon-mode diagnostics cannot silently leak into `#177`-baseline stdio
+  lock files via public API misuse.
+
 ### Firmware
 
 - Added `WriteHeadAngles(yaw, pitch, speed_dps)` overload for speed-based motion control on the user-driven `move_head` path. Existing duration-based overload preserved; boot-init path unchanged in this PR. Adds `MAX_SPEED_DPS=240` (SCS0009 datasheet ceiling) safety clamp and `MIN_SMOOTH_SPEED_DPS=72` documented smoothness floor (sub-floor speeds are permitted with an `ESP_LOGW` warning so the gateway `"low"` preset can deliver deliberately slow motion). (#129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,17 @@ documented-only.
   value or a non-string `http_endpoint`) as missing fields rather than as
   a full read failure, so the four required `#177` base fields remain
   authoritative for the claim/refuse decision and `acquire_lock` cannot
-  silently unlink a live owner's lock under schema drift.
+  silently unlink a live owner's lock under schema drift. The shared
+  ownership-cleanup path is now owner-scoped via a new
+  `release_lock_if_owner(info)` helper that only unlinks the lock file
+  when `owner_id`, `pid`, and `start_ts` still match the caller's
+  claimed `LockInfo`. Both the `atexit.register` callback inside
+  `_acquire_startup_lock` and the explicit `finally` cleanup in the
+  stdio gateway and streamable-http placeholder now use this
+  owner-aware release, so a stale exit-callback from a previously-
+  released first process cannot unlink a successor process's live
+  lock. The legacy `release_lock()` primitive is kept for backward
+  compatibility but is no longer used by chunk 2+3 CLI cleanup paths.
 
 ### Firmware
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,12 @@ documented-only.
   gateway path and the streamable-http placeholder. `acquire_lock` itself
   also now rejects `http_endpoint` and `started_by` metadata when
   `mode="stdio"` so daemon-mode diagnostics cannot silently leak into
-  `#177`-baseline stdio lock files via public API misuse.
+  `#177`-baseline stdio lock files via public API misuse. `read_lock` now
+  treats invalid or unknown optional metadata (for example a future-mode
+  value or a non-string `http_endpoint`) as missing fields rather than as
+  a full read failure, so the four required `#177` base fields remain
+  authoritative for the claim/refuse decision and `acquire_lock` cannot
+  silently unlink a live owner's lock under schema drift.
 
 ### Firmware
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,20 @@ documented-only.
   `--transport stdio` compatibility and a Streamable HTTP daemon
   placeholder that releases ownership before the chunk 4 wiring lands.
 
-- Fixed: #178 Phase B chunk 2+3 streamable-http serve placeholder now
-  releases the ownership lock under every failure path between lock claim
-  and the `NotImplementedError` chunk 4 boundary; `acquire_lock` now
-  rejects `http_endpoint` and `started_by` metadata when `mode="stdio"` so
-  daemon-mode diagnostics cannot silently leak into `#177`-baseline stdio
-  lock files via public API misuse.
+- Fixed: #178 Phase B chunk 2+3 ownership lock cleanup safety. The
+  streamable-http `serve` placeholder now guards its `finally` cleanup with
+  an `acquired` flag so an `OwnershipError` raised by an existing owner is
+  not followed by an erroneous `release_lock()` that would unlink the
+  existing owner's lock file. The shared `_acquire_startup_lock` helper
+  now wraps the post-claim ack-print plus `atexit.register` step in a
+  `try/except BaseException` that releases the just-claimed lock and
+  re-raises, so a stderr-write failure (or any other intermediate failure
+  between `acquire_lock` returning and the caller's own `try/finally`)
+  cannot strand a live-pid lock — this safety now covers both the stdio
+  gateway path and the streamable-http placeholder. `acquire_lock` itself
+  also now rejects `http_endpoint` and `started_by` metadata when
+  `mode="stdio"` so daemon-mode diagnostics cannot silently leak into
+  `#177`-baseline stdio lock files via public API misuse.
 
 ### Firmware
 

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -711,12 +711,17 @@ def _acquire_startup_lock(
         print(str(exc), file=sys.stderr)
         sys.exit(1)
 
-    print(
-        "stackchan-mcp: acquired ownership lock "
-        f"(owner_id={info['owner_id']}, pid={info['pid']})",
-        file=sys.stderr,
-    )
-    atexit.register(release_lock)
+    try:
+        print(
+            "stackchan-mcp: acquired ownership lock "
+            f"(owner_id={info['owner_id']}, pid={info['pid']})",
+            file=sys.stderr,
+        )
+        atexit.register(release_lock)
+    except BaseException:
+        release_lock()
+        raise
+
     return info
 
 
@@ -757,15 +762,18 @@ def _run_streamable_http_placeholder() -> None:
 
     _configure_gateway_startup()
     host, port = _resolve_mcp_http_endpoint()
+    acquired = False
     try:
         _acquire_startup_lock(
             mode=_STREAMABLE_HTTP_TRANSPORT,
             http_endpoint=f"{host}:{port}",
             started_by="cli-serve",
         )
+        acquired = True
         raise NotImplementedError("Streamable HTTP daemon lands in #178 chunk 4")
     finally:
-        release_lock()
+        if acquired:
+            release_lock()
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -22,9 +22,13 @@ import shutil
 import socket
 import subprocess
 import sys
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from . import __version__
+
+if TYPE_CHECKING:
+    from .ownership import LockInfo, LockMode
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +61,18 @@ Environment variables:
                            (default 8765).
   CAPTURE_PORT             Port for the HTTP capture server
                            (default 8766).
+  MCP_HTTP_HOST            Bind address for the Streamable HTTP MCP server
+                           (default 127.0.0.1).
+  MCP_HTTP_PORT            Port for the Streamable HTTP MCP server
+                           (default 8767).
 
 See gateway/README.md and the top-level README.md for full setup,
 including pairing the ESP32 firmware and configuring the WiFi gateway URL.
 """
+
+_STDIO_TRANSPORT = "stdio"
+_STREAMABLE_HTTP_TRANSPORT = "streamable-http"
+_TRANSPORT_CHOICES = (_STDIO_TRANSPORT, _STREAMABLE_HTTP_TRANSPORT)
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -92,6 +104,25 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--no-mdns",
+        action="store_true",
+        help="Disable mDNS/DNS-SD advertisement for the WebSocket endpoint.",
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="{serve}")
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Start the StackChan gateway.",
+        description="Start the StackChan gateway using the selected transport.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    serve_parser.add_argument(
+        "--transport",
+        choices=_TRANSPORT_CHOICES,
+        default=_STDIO_TRANSPORT,
+        help="Gateway transport to serve (default: stdio).",
+    )
+    serve_parser.add_argument(
+        "--no-mdns",
+        dest="serve_no_mdns",
         action="store_true",
         help="Disable mDNS/DNS-SD advertisement for the WebSocket endpoint.",
     )
@@ -411,10 +442,16 @@ def _run_ownership_check() -> int:
         print("ownership preflight: ready")
         print("Result: ready. Exit 0.")
     elif is_pid_alive(info["pid"]):
-        print(
-            f"owner_id={info['owner_id']} pid={info['pid']} "
-            f"start_ts={info['start_ts']} host={info['host']}"
-        )
+        fields = [
+            f"owner_id={info['owner_id']}",
+            f"pid={info['pid']}",
+            f"start_ts={info['start_ts']}",
+            f"host={info['host']}",
+        ]
+        for key in ("mode", "http_endpoint", "started_by"):
+            if key in info:
+                fields.append(f"{key}={info[key]}")
+        print(" ".join(fields))
     else:
         print(f"stale lock found: pid {info['pid']} not alive")
     return 0
@@ -634,14 +671,111 @@ async def _run(*, advertise_mdns: bool = True) -> None:
         await gateway.stop()
 
 
+def _configure_gateway_startup() -> None:
+    """Load runtime configuration and logging for gateway startup paths."""
+    _load_dotenv()
+    _ensure_libopus_findable()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def _acquire_startup_lock(
+    *,
+    mode: "LockMode" = _STDIO_TRANSPORT,
+    http_endpoint: str | None = None,
+    started_by: str | None = None,
+) -> "LockInfo":
+    """Claim the gateway ownership lock and register normal cleanup."""
+    from .ownership import (
+        OwnershipError,
+        acquire_lock,
+        generate_owner_id,
+        release_lock,
+    )
+
+    owner_id = generate_owner_id()
+    try:
+        if mode == _STDIO_TRANSPORT and http_endpoint is None and started_by is None:
+            info = acquire_lock(owner_id)
+        else:
+            info = acquire_lock(
+                owner_id,
+                mode=mode,
+                http_endpoint=http_endpoint,
+                started_by=started_by,
+            )
+    except OwnershipError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        "stackchan-mcp: acquired ownership lock "
+        f"(owner_id={info['owner_id']}, pid={info['pid']})",
+        file=sys.stderr,
+    )
+    atexit.register(release_lock)
+    return info
+
+
+def _prepare_stdio_startup() -> "LockInfo":
+    """Prepare the existing stdio gateway flow without changing its lock shape."""
+    _configure_gateway_startup()
+    return _acquire_startup_lock()
+
+
+def _run_stdio_gateway(*, advertise_mdns: bool = True) -> None:
+    """Run the existing stdio MCP gateway flow."""
+    from .ownership import release_lock
+
+    _prepare_stdio_startup()
+    try:
+        try:
+            asyncio.run(_run(advertise_mdns=advertise_mdns))
+        except KeyboardInterrupt:
+            pass
+    finally:
+        release_lock()
+
+
+def _resolve_mcp_http_endpoint() -> tuple[str, int]:
+    """Resolve the Streamable HTTP daemon endpoint from environment."""
+    host = os.getenv("MCP_HTTP_HOST", "127.0.0.1")
+    raw_port = os.getenv("MCP_HTTP_PORT", "8767")
+    port, source = _validate_port_value(raw_port, "MCP_HTTP_PORT")
+    if port is None:
+        print(f"stackchan-mcp: invalid MCP_HTTP_PORT: {source}", file=sys.stderr)
+        sys.exit(1)
+    return host, port
+
+
+def _run_streamable_http_placeholder() -> None:
+    """Claim daemon ownership, then stop at the chunk 4 HTTP wiring boundary."""
+    from .ownership import release_lock
+
+    _configure_gateway_startup()
+    host, port = _resolve_mcp_http_endpoint()
+    _acquire_startup_lock(
+        mode=_STREAMABLE_HTTP_TRANSPORT,
+        http_endpoint=f"{host}:{port}",
+        started_by="cli-serve",
+    )
+    try:
+        raise NotImplementedError("Streamable HTTP daemon lands in #178 chunk 4")
+    finally:
+        release_lock()
+
+
 def main(argv: list[str] | None = None) -> None:
     """Console-script entry point.
 
     Parses ``--help`` / ``--version`` / ``--check`` / ``--preflight`` early
-    (without starting the server), then loads ``.env``, configures logging,
-    claims gateway ownership, and starts the gateway. Side effects are
-    intentionally scoped to this function so that ``import stackchan_mcp``
-    stays clean.
+    (without starting the server), then dispatches either the legacy
+    zero-subcommand stdio flow or the ``serve`` subcommand. Side effects
+    are intentionally scoped below argument parsing so that
+    ``import stackchan_mcp`` stays clean.
     """
     parser = _build_arg_parser()
     # argparse exits with status 0 on --help / --version before reaching
@@ -656,42 +790,19 @@ def main(argv: list[str] | None = None) -> None:
         # via the path below.
         sys.exit(_run_preflight())
 
-    _load_dotenv()
-    _ensure_libopus_findable()
+    if args.command is None:
+        _run_stdio_gateway(advertise_mdns=not args.no_mdns)
+        return
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    )
-
-    from .ownership import (
-        OwnershipError,
-        acquire_lock,
-        generate_owner_id,
-        release_lock,
-    )
-
-    owner_id = generate_owner_id()
-    try:
-        info = acquire_lock(owner_id)
-    except OwnershipError as exc:
-        print(str(exc), file=sys.stderr)
-        sys.exit(1)
-
-    print(
-        "stackchan-mcp: acquired ownership lock "
-        f"(owner_id={info['owner_id']}, pid={info['pid']})",
-        file=sys.stderr,
-    )
-    atexit.register(release_lock)
-
-    try:
-        try:
-            asyncio.run(_run(advertise_mdns=not args.no_mdns))
-        except KeyboardInterrupt:
-            pass
-    finally:
-        release_lock()
+    if args.command == "serve":
+        if args.transport == _STDIO_TRANSPORT:
+            advertise_mdns = not (
+                args.no_mdns or getattr(args, "serve_no_mdns", False)
+            )
+            _run_stdio_gateway(advertise_mdns=advertise_mdns)
+            return
+        _run_streamable_http_placeholder()
+        return
 
 
 if __name__ == "__main__":

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -693,7 +693,7 @@ def _acquire_startup_lock(
         OwnershipError,
         acquire_lock,
         generate_owner_id,
-        release_lock,
+        release_lock_if_owner,
     )
 
     owner_id = generate_owner_id()
@@ -717,9 +717,9 @@ def _acquire_startup_lock(
             f"(owner_id={info['owner_id']}, pid={info['pid']})",
             file=sys.stderr,
         )
-        atexit.register(release_lock)
+        atexit.register(release_lock_if_owner, info)
     except BaseException:
-        release_lock()
+        release_lock_if_owner(info)
         raise
 
     return info
@@ -733,16 +733,16 @@ def _prepare_stdio_startup() -> "LockInfo":
 
 def _run_stdio_gateway(*, advertise_mdns: bool = True) -> None:
     """Run the existing stdio MCP gateway flow."""
-    from .ownership import release_lock
+    from .ownership import release_lock_if_owner
 
-    _prepare_stdio_startup()
+    info = _prepare_stdio_startup()
     try:
         try:
             asyncio.run(_run(advertise_mdns=advertise_mdns))
         except KeyboardInterrupt:
             pass
     finally:
-        release_lock()
+        release_lock_if_owner(info)
 
 
 def _resolve_mcp_http_endpoint() -> tuple[str, int]:
@@ -758,22 +758,21 @@ def _resolve_mcp_http_endpoint() -> tuple[str, int]:
 
 def _run_streamable_http_placeholder() -> None:
     """Claim daemon ownership, then stop at the chunk 4 HTTP wiring boundary."""
-    from .ownership import release_lock
+    from .ownership import release_lock_if_owner
 
     _configure_gateway_startup()
     host, port = _resolve_mcp_http_endpoint()
-    acquired = False
+    info: LockInfo | None = None
     try:
-        _acquire_startup_lock(
+        info = _acquire_startup_lock(
             mode=_STREAMABLE_HTTP_TRANSPORT,
             http_endpoint=f"{host}:{port}",
             started_by="cli-serve",
         )
-        acquired = True
         raise NotImplementedError("Streamable HTTP daemon lands in #178 chunk 4")
     finally:
-        if acquired:
-            release_lock()
+        if info is not None:
+            release_lock_if_owner(info)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -757,12 +757,12 @@ def _run_streamable_http_placeholder() -> None:
 
     _configure_gateway_startup()
     host, port = _resolve_mcp_http_endpoint()
-    _acquire_startup_lock(
-        mode=_STREAMABLE_HTTP_TRANSPORT,
-        http_endpoint=f"{host}:{port}",
-        started_by="cli-serve",
-    )
     try:
+        _acquire_startup_lock(
+            mode=_STREAMABLE_HTTP_TRANSPORT,
+            http_endpoint=f"{host}:{port}",
+            started_by="cli-serve",
+        )
         raise NotImplementedError("Streamable HTTP daemon lands in #178 chunk 4")
     finally:
         release_lock()

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -9,17 +9,26 @@ import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 LOCK_DIR = Path.home() / ".stackchan-mcp"
 LOCK_PATH = LOCK_DIR / "owner.lock"
 
 
-class LockInfo(TypedDict):
+LockMode = Literal["stdio", "streamable-http"]
+
+
+class _BaseLockInfo(TypedDict):
     owner_id: str
     pid: int
     start_ts: str
     host: str
+
+
+class LockInfo(_BaseLockInfo, total=False):
+    mode: LockMode
+    http_endpoint: str | None
+    started_by: str | None
 
 
 class OwnershipError(RuntimeError):
@@ -114,12 +123,32 @@ def read_lock(path: Path = LOCK_PATH) -> LockInfo | None:
     ):
         return None
 
-    return {
+    info: LockInfo = {
         "owner_id": owner_id,
         "pid": pid,
         "start_ts": start_ts,
         "host": host,
     }
+
+    if "mode" in raw:
+        mode = raw["mode"]
+        if mode not in ("stdio", "streamable-http"):
+            return None
+        info["mode"] = mode
+
+    if "http_endpoint" in raw:
+        http_endpoint = raw["http_endpoint"]
+        if http_endpoint is not None and not isinstance(http_endpoint, str):
+            return None
+        info["http_endpoint"] = http_endpoint
+
+    if "started_by" in raw:
+        started_by = raw["started_by"]
+        if started_by is not None and not isinstance(started_by, str):
+            return None
+        info["started_by"] = started_by
+
+    return info
 
 
 def _write_lock_atomic(info: LockInfo, path: Path = LOCK_PATH) -> None:
@@ -135,8 +164,24 @@ def _write_lock_atomic(info: LockInfo, path: Path = LOCK_PATH) -> None:
         tmp.unlink(missing_ok=True)
 
 
-def acquire_lock(owner_id: str, path: Path = LOCK_PATH) -> LockInfo:
-    """Acquire the ownership lock. Raise OwnershipError on refuse."""
+def acquire_lock(
+    owner_id: str,
+    path: Path = LOCK_PATH,
+    *,
+    mode: LockMode = "stdio",
+    http_endpoint: str | None = None,
+    started_by: str | None = None,
+) -> LockInfo:
+    """Acquire the ownership lock. Raise OwnershipError on refuse.
+
+    The default stdio-mode call writes the original #177 lock shape so
+    older lock readers and ``stackchan-mcp --check`` output remain
+    compatible. Daemon transports can attach optional metadata for
+    diagnostics without changing the atomic hardlink claim.
+    """
+    if mode not in ("stdio", "streamable-http"):
+        raise ValueError(f"unsupported lock mode: {mode!r}")
+
     while True:
         existing = read_lock(path)
         if existing is not None:
@@ -160,6 +205,13 @@ def acquire_lock(owner_id: str, path: Path = LOCK_PATH) -> LockInfo:
             "start_ts": _now_iso(),
             "host": socket.gethostname(),
         }
+        if mode != "stdio":
+            info["mode"] = mode
+        if http_endpoint is not None:
+            info["http_endpoint"] = http_endpoint
+        if started_by is not None:
+            info["started_by"] = started_by
+
         try:
             _write_lock_atomic(info, path)
         except FileExistsError:

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -181,6 +181,11 @@ def acquire_lock(
     """
     if mode not in ("stdio", "streamable-http"):
         raise ValueError(f"unsupported lock mode: {mode!r}")
+    if mode == "stdio" and (http_endpoint is not None or started_by is not None):
+        raise ValueError(
+            "stdio-mode ownership locks must not carry http_endpoint or "
+            "started_by; these fields are reserved for non-stdio transports"
+        )
 
     while True:
         existing = read_lock(path)

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -229,8 +229,42 @@ def acquire_lock(
 
 
 def release_lock(path: Path = LOCK_PATH) -> None:
-    """Remove the lock file. Idempotent."""
+    """Remove the lock file. Idempotent.
+
+    This is the legacy, owner-unaware release primitive kept for backward
+    compatibility. New callers should prefer :func:`release_lock_if_owner`
+    so that a stale cleanup callback cannot unlink a successor process's
+    live lock.
+    """
     try:
         path.unlink()
     except FileNotFoundError:
         pass
+
+
+def release_lock_if_owner(info: LockInfo, path: Path = LOCK_PATH) -> bool:
+    """Remove the lock file only if it still belongs to ``info``.
+
+    Returns ``True`` if the lock was removed, ``False`` if the on-disk
+    lock has a different ``owner_id`` / ``pid`` / ``start_ts`` or no
+    longer exists. This is the owner-scoped counterpart to
+    :func:`release_lock` and is intended for cleanup paths (``finally``
+    blocks, ``atexit.register``) where the caller may have lost ownership
+    between claim and cleanup — for example after the gateway exited and
+    a second process acquired the lock before the first process's
+    interpreter exit callbacks ran.
+    """
+    existing = read_lock(path)
+    if existing is None:
+        return False
+    if (
+        existing.get("owner_id") != info.get("owner_id")
+        or existing.get("pid") != info.get("pid")
+        or existing.get("start_ts") != info.get("start_ts")
+    ):
+        return False
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -130,23 +130,27 @@ def read_lock(path: Path = LOCK_PATH) -> LockInfo | None:
         "host": host,
     }
 
-    if "mode" in raw:
-        mode = raw["mode"]
-        if mode not in ("stdio", "streamable-http"):
-            return None
+    # Optional metadata: silently ignore unknown or malformed values so a
+    # schema-drift writer (for example a future-mode lock file or a
+    # partially compatible external writer) cannot cause read_lock to
+    # return None and trick acquire_lock into unlinking a live owner's
+    # lock file. The four required #177 base fields above are
+    # authoritative for the claim/refuse decision; validating optional
+    # metadata is a separate diagnostic concern.
+
+    mode = raw.get("mode")
+    if mode in ("stdio", "streamable-http"):
         info["mode"] = mode
 
     if "http_endpoint" in raw:
         http_endpoint = raw["http_endpoint"]
-        if http_endpoint is not None and not isinstance(http_endpoint, str):
-            return None
-        info["http_endpoint"] = http_endpoint
+        if http_endpoint is None or isinstance(http_endpoint, str):
+            info["http_endpoint"] = http_endpoint
 
     if "started_by" in raw:
         started_by = raw["started_by"]
-        if started_by is not None and not isinstance(started_by, str):
-            return None
-        info["started_by"] = started_by
+        if started_by is None or isinstance(started_by, str):
+            info["started_by"] = started_by
 
     return info
 


### PR DESCRIPTION
## Summary

Adds ownership lock diagnostics metadata and a `serve` CLI subcommand for
Issue #178 Phase B. These are the second and third chunks of the four-chunk
landing of the daemon + Streamable HTTP MCP architecture chosen in the
Phase A spike (`docs/178-http-transport-spike.md`).

This PR restructures CLI entry while preserving zero-subcommand stdio
behaviour bit-identical to current `main`. The HTTP server itself does not
land here; `serve --transport streamable-http` raises `NotImplementedError`
after releasing the ownership lock, leaving the chunk 4 wiring as the next
step.

## What's in this PR

- `gateway/stackchan_mcp/ownership.py` (+62): new optional `mode`,
  `http_endpoint`, `started_by` fields on `LockInfo` via TypedDict
  `_BaseLockInfo` + `total=False` extension. `acquire_lock` gains keyword-
  only `mode` / `http_endpoint` / `started_by` parameters. `read_lock`
  accepts both `#177`-format and new-format lock files with defensive
  validation.
- `gateway/stackchan_mcp/cli.py` (+167 / -33): argparse `subparsers` with a
  new `serve` subcommand and `--transport {stdio,streamable-http}` flag.
  Zero-subcommand `stackchan-mcp` invocation is preserved bit-identical.
  Shared startup helpers split across `_configure_gateway_startup`,
  `_acquire_startup_lock`, `_prepare_stdio_startup`, `_run_stdio_gateway`,
  and `_run_streamable_http_placeholder`. Type-only imports from
  `.ownership` are guarded by `TYPE_CHECKING` to avoid circular imports.
- `CHANGELOG.md` (+8): two `[Unreleased]` Gateway bullets for chunks 2 and 3.

## Design contract

### Chunk 2 — ownership lock diagnostics

- New optional fields on `LockInfo`: `mode`, `http_endpoint`, `started_by`.
- `acquire_lock(owner_id)` with no kwargs writes a lock file byte-identical
  to the `#177` baseline (stdio default omits the new fields).
- `read_lock` accepts both `#177`-format and new-format lock files.
- `_write_lock_atomic` semantics (the `os.link` hardlink claim) are
  unchanged.

### Chunk 3 — daemon CLI serve subcommand

- argparse subparsers introduce a `serve` subcommand.
- Zero-subcommand `stackchan-mcp` is bit-identical to current `main`.
- `serve --transport stdio` is functionally identical to the zero-subcommand
  path; both share `_run_stdio_gateway`.
- `serve --transport streamable-http`:
  1. Loads `MCP_HTTP_HOST` (default `127.0.0.1`) and `MCP_HTTP_PORT`
     (default `8767`); invalid `MCP_HTTP_PORT` exits via the existing
     `_validate_port_value` error path.
  2. Acquires the ownership lock with `mode="streamable-http"`,
     `http_endpoint=f"{host}:{port}"`, `started_by="cli-serve"`.
  3. Raises `NotImplementedError("Streamable HTTP daemon lands in #178
     chunk 4")` inside a `try/finally` that always calls `release_lock()`,
     so no orphan lock is stranded.
- `--check`, `--preflight`, `--version`, and the top-level `--no-mdns`
  remain at the zero-subcommand level. `serve` accepts its own `--no-mdns`
  for parity.

## Back-compat verification

- `#177`-format lock files (4 base fields only) parse cleanly via the
  updated `read_lock`.
- Plain `stackchan-mcp` (no subcommand) startup output is byte-identical to
  the path on current `main` — same `.env` load, same logging config, same
  ownership ack message format.
- `stackchan-mcp --check` output is byte-identical for old-format locks;
  only locks carrying the new fields print the additional `key=value`
  trailers.
- No imports from `mcp`, `starlette`, `uvicorn`, `httpx`, or any HTTP/MCP
  SDK in this chunk pair — pure CLI + lock module restructure.

## References

- Issue #178 (this PR is chunk 2+3 of 4).
- Phase A transport spike: `docs/178-http-transport-spike.md`.
- Chunk 1 (command queue module) merged via #257: commit `79ae07f`.

## Roadmap

- chunks 2+3 (this PR): ownership lock diagnostics + daemon CLI serve
  subcommand placeholder.
- chunk 4: HTTP MCP server + queue dispatcher + ESP32 dispatch wiring.
- chunk 5: pytest suite + docs (daemon setup, stdio migration).
- Real-device verification gate is handled outside this chunk sequence.