### PR TITLE
feat(gateway/firmware): #260 stackchan/event capability for touch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ documented-only.
 
 ### Gateway
 
+- Added: `stackchan/event` experimental MCP capability and server-initiated
+  notification bridge for firmware-originated touch events (`tap` /
+  `stroke`) forwarded from additive `stackchan-event` WebSocket frames.
+  Pinned the `mcp` runtime dependency to `>=1.27,<2.0` and added a
+  startup compatibility guard for the private SDK members the bridge
+  depends on (`Server._experimental_handlers` /
+  `Server._handle_message`) so any incompatible future SDK shape fails
+  fast with a clear error instead of silent breakage. (#260)
+
 - Added: function-dark #178 Phase B chunk 1 command queue module with an
   environment-configurable bounded FIFO, correlation metadata for response
   routing, a single-flight dispatcher loop, and a standardized queue-full
@@ -76,6 +85,11 @@ documented-only.
   compatibility but is no longer used by chunk 2+3 CLI cleanup paths.
 
 ### Firmware
+
+- Added: `Application::SendStackChanEvent(...)` and appended touch-event
+  emission after the existing Si12T tap / stroke local reaction flow so
+  connected gateways can receive additive `stackchan-event` WebSocket
+  frames. (#260)
 
 - Added `WriteHeadAngles(yaw, pitch, speed_dps)` overload for speed-based motion control on the user-driven `move_head` path. Existing duration-based overload preserved; boot-init path unchanged in this PR. Adds `MAX_SPEED_DPS=240` (SCS0009 datasheet ceiling) safety clamp and `MIN_SMOOTH_SPEED_DPS=72` documented smoothness floor (sub-floor speeds are permitted with an `ESP_LOGW` warning so the gateway `"low"` preset can deliver deliberately slow motion). (#129)
 

--- a/firmware/main/application.cc
+++ b/firmware/main/application.cc
@@ -1168,6 +1168,35 @@ void Application::SendMcpMessage(const std::string& payload) {
     });
 }
 
+void Application::SendStackChanEvent(
+    const char* event_type, const char* subtype, uint64_t duration_ms) {
+    std::string event_type_str = event_type ? event_type : "";
+    std::string subtype_str = subtype ? subtype : "";
+    Schedule([this, event_type_str, subtype_str, duration_ms]() {
+        if (!protocol_ || !protocol_->IsTransportConnected()) {
+            return;
+        }
+
+        cJSON* root = cJSON_CreateObject();
+        if (root == nullptr) {
+            return;
+        }
+        cJSON_AddStringToObject(root, "session_id", protocol_->session_id().c_str());
+        cJSON_AddStringToObject(root, "type", "stackchan-event");
+        cJSON_AddStringToObject(root, "event_type", event_type_str.c_str());
+        cJSON_AddStringToObject(root, "subtype", subtype_str.c_str());
+        cJSON_AddNumberToObject(root, "duration_ms", static_cast<double>(duration_ms));
+        cJSON_AddNumberToObject(root, "ts", static_cast<double>(esp_timer_get_time() / 1000ULL));
+
+        char* str = cJSON_PrintUnformatted(root);
+        if (str != nullptr) {
+            protocol_->SendText(std::string(str));
+            cJSON_free(str);
+        }
+        cJSON_Delete(root);
+    });
+}
+
 void Application::SendJsonString(const std::string& json_str) {
     // Thread-safe generic WS text frame send. Used by board-initiated
     // notifications such as avatar_set_loaded (Phase 4.5 avatar). Mirrors
@@ -1220,4 +1249,3 @@ void Application::ResetProtocol() {
         protocol_.reset();
     });
 }
-

--- a/firmware/main/application.h
+++ b/firmware/main/application.h
@@ -108,6 +108,7 @@ public:
     bool UpgradeFirmware(const std::string& url, const std::string& version = "");
     bool CanEnterSleepMode();
     void SendMcpMessage(const std::string& payload);
+    void SendStackChanEvent(const char* event_type, const char* subtype, uint64_t duration_ms);
 
     // Phase 4.5 avatar: thread-safe generic WS text frame send.
     // Wraps Protocol::SendText through the main-task Schedule for the

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -3868,6 +3868,7 @@ private:
         // not pop the avatar back over the WiFi config / settings screens.
         SetAvatarExpressionIfActive("surprised");
         ScheduleIdleRevert();
+        Application::GetInstance().SendStackChanEvent("touch", "tap", duration_ms);
     }
 
     void HandleStroke(uint64_t duration_ms) {
@@ -3877,6 +3878,7 @@ private:
         SetAvatarExpressionIfActive("embarrassed");
         StartServoWobble();
         ScheduleIdleRevert();
+        Application::GetInstance().SendStackChanEvent("touch", "stroke", duration_ms);
     }
 
     // 200 ms periodic poll. Reads the sensor, applies a 2-sample debounce on

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -33,7 +33,16 @@ dependencies = [
     "websockets>=12",
     "pydantic>=2",
     "python-dotenv",
-    "mcp>=1.0",
+    # The stdio server captures the active ServerSession via a subclassed
+    # Server.run() loop because the public MCP SDK does not yet expose a
+    # stable hook for server-side notifications. That subclass relies on
+    # `Server._experimental_handlers` and `Server._handle_message`, which
+    # are private members. We pin to the verified 1.x line and gate access
+    # behind a startup compatibility guard (see stdio_server.py) so a
+    # future SDK release cannot silently break the gateway via PyPI
+    # auto-resolution. Bump the upper bound after verifying the next
+    # major line.
+    "mcp>=1.27,<2.0",
     "aiohttp>=3",
     "zeroconf>=0.149",
 ]

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -601,6 +601,9 @@ class ESP32Manager:
                     # the SAIVerse repository).
                     connection.handle_avatar_set_loaded(data)
 
+                elif msg_type == "stackchan-event":
+                    await self._emit_stackchan_event(data)
+
                 elif msg_type == "listen":
                     # Device-driven listening start/stop notification
                     # (wake word, button press, LCD touch — anything
@@ -722,6 +725,56 @@ class ESP32Manager:
             )
         else:
             logger.error("ESP32 MCP initialization failed")
+
+    async def _emit_stackchan_event(self, payload: dict[str, Any]) -> None:
+        """Forward a firmware-originated stackchan event to the MCP client."""
+        event_type = payload.get("event_type")
+        subtype = payload.get("subtype")
+        duration_ms = payload.get("duration_ms")
+        ts = payload.get("ts")
+        session_id = payload.get("session_id")
+
+        if event_type != "touch":
+            logger.warning("Malformed stackchan-event frame: event_type=%r", event_type)
+            return
+        if subtype not in {"tap", "stroke"}:
+            logger.warning("Malformed stackchan-event frame: subtype=%r", subtype)
+            return
+        if (
+            isinstance(duration_ms, bool)
+            or not isinstance(duration_ms, int)
+            or duration_ms < 0
+        ):
+            logger.warning(
+                "Malformed stackchan-event frame: duration_ms=%r",
+                duration_ms,
+            )
+            return
+        if isinstance(ts, bool) or not isinstance(ts, int) or ts < 0:
+            logger.warning("Malformed stackchan-event frame: ts=%r", ts)
+            return
+        if not isinstance(session_id, str) or not session_id:
+            logger.warning("Malformed stackchan-event frame: session_id=%r", session_id)
+            return
+
+        params = {
+            "event_type": event_type,
+            "subtype": subtype,
+            "duration_ms": duration_ms,
+            "ts": ts,
+            "session_id": session_id,
+        }
+        logger.info(
+            "stackchan-event: %s/%s duration=%sms ts=%s session=%s",
+            event_type,
+            subtype,
+            duration_ms,
+            ts,
+            session_id,
+        )
+        from .stdio_server import notify_stackchan_event
+
+        await notify_stackchan_event("stackchan/event", params)
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any]

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -6,19 +6,36 @@ Each tool call is relayed to the connected ESP32 device.
 
 from __future__ import annotations
 
+from contextlib import AsyncExitStack
+import inspect
 import json
 import logging
-from typing import Any
+from typing import Any, Literal, cast
 
-from mcp.server import Server
+import anyio
+from mcp.server import InitializationOptions, NotificationOptions, Server
+from mcp.server.session import ServerSession
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import Notification, TextContent, Tool
 
+from . import __version__
 from .gateway import get_gateway
 from .stt import listen_and_transcribe
 from .tts import synthesize_and_send
 
 logger = logging.getLogger(__name__)
+
+STACKCHAN_EVENT_METHOD = "stackchan/event"
+STACKCHAN_EVENT_INSTRUCTIONS = (
+    "Stack-chan physical events arrive as server-initiated "
+    "notifications with method='stackchan/event'. Params include "
+    "event_type ('touch'), subtype ('tap' or 'stroke'), "
+    "duration_ms, ts, session_id. When such a notification "
+    "arrives, react naturally using existing tools "
+    "(set_avatar, say, set_mouth, set_leds, move_head). There is "
+    "no dedicated reply tool — the existing tool palette is the "
+    "reaction surface."
+)
 
 PRESET_DPS = {
     "low": 30,
@@ -31,6 +48,172 @@ SPEED_DESCRIPTION = """speed (optional): How fast to move the head.
   - "mid"  — default natural turn, ~120°/s. Use for conversational eye contact.
   - "high" — quick reaction, ~240°/s. Use for surprise / double-take.
   - Or a raw degrees-per-second integer if you need a specific value."""
+
+_active_session: Any | None = None
+
+
+class StackChanEventNotification(
+    Notification[dict[str, Any], Literal["stackchan/event"]]
+):
+    method: Literal["stackchan/event"] = "stackchan/event"
+    params: dict[str, Any]
+
+
+class StackChanServer(Server):
+    async def run(
+        self,
+        read_stream: Any,
+        write_stream: Any,
+        initialization_options: InitializationOptions,
+        raise_exceptions: bool = False,
+        stateless: bool = False,
+    ) -> None:
+        global _active_session
+        try:
+            async with AsyncExitStack() as stack:
+                lifespan_context = await stack.enter_async_context(self.lifespan(self))
+                session = await stack.enter_async_context(
+                    ServerSession(
+                        read_stream,
+                        write_stream,
+                        initialization_options,
+                        stateless=stateless,
+                    )
+                )
+                _active_session = session
+
+                task_support = (
+                    self._experimental_handlers.task_support
+                    if self._experimental_handlers
+                    else None
+                )
+                if task_support is not None:
+                    task_support.configure_session(session)
+                    await stack.enter_async_context(task_support.run())
+
+                async with anyio.create_task_group() as tg:
+                    try:
+                        async for message in session.incoming_messages:
+                            logger.debug("Received message: %s", message)
+                            tg.start_soon(
+                                self._handle_message,
+                                message,
+                                session,
+                                lifespan_context,
+                                raise_exceptions,
+                            )
+                    finally:
+                        tg.cancel_scope.cancel()
+        finally:
+            _active_session = None
+
+    async def _handle_message(
+        self,
+        message: Any,
+        session: Any,
+        lifespan_context: Any,
+        raise_exceptions: bool = False,
+    ) -> None:
+        global _active_session
+        _active_session = session
+        await super()._handle_message(
+            message,
+            session,
+            lifespan_context,
+            raise_exceptions,
+        )
+
+
+async def notify_stackchan_event(method: str, params: dict[str, Any]) -> None:
+    """Forward a stackchan event to the connected MCP client."""
+    if method != STACKCHAN_EVENT_METHOD:
+        logger.warning("Unsupported stackchan event notification method: %s", method)
+        return
+
+    session = _active_session
+    if session is None:
+        logger.warning("Cannot emit stackchan/event notification: no active MCP session")
+        return
+
+    notification = StackChanEventNotification(params=params)
+    try:
+        await session.send_notification(cast(Any, notification))
+    except Exception as exc:  # pragma: no cover - depends on client transport failure
+        logger.warning("Failed to emit stackchan/event notification: %s", exc)
+
+
+def _create_initialization_options(server: Server) -> InitializationOptions:
+    return InitializationOptions(
+        server_name="stackchan-mcp",
+        server_version=__version__,
+        capabilities=server.get_capabilities(
+            notification_options=NotificationOptions(),
+            experimental_capabilities={STACKCHAN_EVENT_METHOD: {}},
+        ),
+        instructions=STACKCHAN_EVENT_INSTRUCTIONS,
+    )
+
+
+def _verify_mcp_sdk_compatibility() -> None:
+    """Fail fast if the installed MCP SDK no longer exposes the private
+    attributes that ``StackChanServer`` depends on.
+
+    ``StackChanServer`` mirrors a slimmed-down copy of ``Server.run()`` so it
+    can capture the active ``ServerSession`` for server-initiated
+    ``stackchan/event`` notifications. The public MCP SDK currently does not
+    offer a stable hook for this, so the subclass touches
+    ``Server._experimental_handlers`` and ``Server._handle_message`` directly.
+
+    These private members are pinned by the ``mcp>=1.27,<2.0`` range declared
+    in ``pyproject.toml``. This guard adds an extra safety net so the gateway
+    fails with a clear ``RuntimeError`` at startup rather than silently
+    dropping notifications or crashing mid-message if a future installation
+    somehow resolves a wholly incompatible SDK shape.
+    """
+
+    probe = Server("compat-check")
+
+    if not hasattr(probe, "_experimental_handlers"):
+        raise RuntimeError(
+            "stackchan-mcp gateway requires `mcp.server.Server._experimental_handlers` "
+            "to exist on instances. The installed MCP SDK appears to have removed or "
+            "renamed this attribute; pin `mcp` to a verified 1.x release."
+        )
+
+    handle = getattr(probe, "_handle_message", None)
+    if not callable(handle) or not inspect.iscoroutinefunction(handle):
+        raise RuntimeError(
+            "stackchan-mcp gateway requires `mcp.server.Server._handle_message` to be "
+            "an async callable. The installed MCP SDK does not expose it in the "
+            "expected shape; pin `mcp` to a verified 1.x release."
+        )
+
+    try:
+        sig = inspect.signature(handle)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "stackchan-mcp gateway could not introspect "
+            "`mcp.server.Server._handle_message` signature on the installed MCP SDK; "
+            "pin `mcp` to a verified 1.x release."
+        ) from exc
+
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+    ]
+    if len(positional) < 4:
+        raise RuntimeError(
+            "stackchan-mcp gateway requires `mcp.server.Server._handle_message` to "
+            "accept at least 4 positional arguments "
+            "(message, session, lifespan_context, raise_exceptions); the installed "
+            f"MCP SDK exposes {sig}. Pin `mcp` to a verified 1.x release."
+        )
 
 
 def _resolve_speed_dps(speed: Any) -> int | None:
@@ -58,7 +241,8 @@ def _resolve_speed_dps(speed: Any) -> int | None:
 
 def create_server() -> Server:
     """Create and configure the MCP server with tool handlers."""
-    server = Server("stackchan-mcp")
+    _verify_mcp_sdk_compatibility()
+    server = StackChanServer("stackchan-mcp")
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
@@ -1104,4 +1288,4 @@ async def run_stdio_server() -> None:
     server = create_server()
     async with stdio_server() as (read_stream, write_stream):
         logger.info("stdio MCP server starting")
-        await server.run(read_stream, write_stream, server.create_initialization_options())
+        await server.run(read_stream, write_stream, _create_initialization_options(server))

--- a/gateway/tests/test_stackchan_event.py
+++ b/gateway/tests/test_stackchan_event.py
@@ -1,0 +1,223 @@
+"""Tests for stackchan/event server notifications."""
+
+import json
+import logging
+
+import pytest
+
+from stackchan_mcp.esp32_client import ESP32Manager
+import stackchan_mcp.stdio_server as stdio_server
+from stackchan_mcp.stdio_server import (
+    STACKCHAN_EVENT_INSTRUCTIONS,
+    STACKCHAN_EVENT_METHOD,
+    _create_initialization_options,
+    create_server,
+    notify_stackchan_event,
+)
+
+
+@pytest.mark.asyncio
+async def test_stackchan_event_frame_dispatches_to_notify_bridge(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_notify(method, params):
+        calls.append((method, params))
+
+    monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
+    manager = ESP32Manager()
+
+    await manager._handler(
+        _FakeWebSocket(
+            [
+                json.dumps(
+                    {
+                        "session_id": "session-1",
+                        "type": "stackchan-event",
+                        "event_type": "touch",
+                        "subtype": "tap",
+                        "duration_ms": 350,
+                        "ts": 123456,
+                    }
+                )
+            ]
+        )
+    )
+
+    assert calls == [
+        (
+            STACKCHAN_EVENT_METHOD,
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 350,
+                "ts": 123456,
+                "session_id": "session-1",
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "warning"),
+    [
+        ({"event_type": "motion"}, "event_type='motion'"),
+        ({"subtype": "press"}, "subtype='press'"),
+        ({"duration_ms": "350"}, "duration_ms='350'"),
+        ({"duration_ms": True}, "duration_ms=True"),
+        ({"duration_ms": -1}, "duration_ms=-1"),
+        ({"ts": "123456"}, "ts='123456'"),
+        ({"ts": True}, "ts=True"),
+        ({"ts": -1}, "ts=-1"),
+        ({"session_id": ""}, "session_id=''"),
+        ({"session_id": None}, "session_id=None"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stackchan_event_malformed_frame_warns_without_notify(
+    monkeypatch,
+    caplog,
+    overrides,
+    warning,
+):
+    calls = []
+
+    async def fake_notify(method, params):
+        calls.append((method, params))
+
+    monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
+    manager = ESP32Manager()
+    payload = {
+        "session_id": "session-1",
+        "type": "stackchan-event",
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "ts": 123456,
+    }
+    payload.update(overrides)
+
+    with caplog.at_level(logging.WARNING):
+        await manager._emit_stackchan_event(payload)
+
+    assert calls == []
+    assert f"Malformed stackchan-event frame: {warning}" in caplog.text
+
+
+def test_stackchan_event_capability_and_instructions_are_declared():
+    server = create_server()
+    options = _create_initialization_options(server)
+
+    assert options.capabilities.experimental == {STACKCHAN_EVENT_METHOD: {}}
+    assert options.instructions == STACKCHAN_EVENT_INSTRUCTIONS
+
+
+@pytest.mark.asyncio
+async def test_server_run_captures_active_session_before_first_message(monkeypatch):
+    observed = []
+
+    class FakeIncomingMessages:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            observed.append(stdio_server._active_session)
+            raise StopAsyncIteration
+
+    class FakeServerSession:
+        def __init__(self, *args, **kwargs):
+            self.incoming_messages = FakeIncomingMessages()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(stdio_server, "ServerSession", FakeServerSession)
+    server = create_server()
+
+    await server.run(None, None, _create_initialization_options(server))
+
+    assert len(observed) == 1
+    assert isinstance(observed[0], FakeServerSession)
+    assert stdio_server._active_session is None
+
+
+@pytest.mark.asyncio
+async def test_notify_stackchan_event_uses_active_session(monkeypatch):
+    session = _FakeSession()
+    monkeypatch.setattr(stdio_server, "_active_session", session)
+
+    params = {
+        "event_type": "touch",
+        "subtype": "stroke",
+        "duration_ms": 900,
+        "ts": 222,
+        "session_id": "session-1",
+    }
+    await notify_stackchan_event(STACKCHAN_EVENT_METHOD, params)
+
+    assert session.notifications == [
+        {
+            "method": STACKCHAN_EVENT_METHOD,
+            "params": params,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notify_stackchan_event_without_active_session_logs_and_returns(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(stdio_server, "_active_session", None)
+
+    with caplog.at_level(logging.WARNING):
+        await notify_stackchan_event(
+            STACKCHAN_EVENT_METHOD,
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 350,
+                "ts": 123,
+                "session_id": "session-1",
+            },
+        )
+
+    assert "no active MCP session" in caplog.text
+
+
+class _FakeWebSocket:
+    request = None
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent = []
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def close(self):
+        return None
+
+
+class _FakeSession:
+    def __init__(self):
+        self.notifications = []
+
+    async def send_notification(self, notification):
+        self.notifications.append(
+            notification.model_dump(
+                by_alias=True,
+                mode="json",
+                exclude_none=True,
+            )
+        )

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2062,7 +2062,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3" },
     { name = "faster-whisper", marker = "extra == 'stt-faster-whisper'", specifier = ">=1.0" },
     { name = "httpx", marker = "extra == 'tts'", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.27,<2.0" },
     { name = "openai", marker = "extra == 'stt-openai'", specifier = ">=1.0" },
     { name = "opuslib", marker = "extra == 'stt'", specifier = ">=3" },
     { name = "opuslib", marker = "extra == 'tts'", specifier = ">=3" },


### PR DESCRIPTION
## Summary

Add the `stackchan/event` experimental MCP capability so that
firmware-originated physical events (initially: head-touch `tap` / `stroke`
detected via Si12T) propagate to connected MCP clients as server-initiated
notifications. The LLM client can then react conversationally using existing
tools (`set_avatar`, `say`, `set_mouth`, `set_leds`, `move_head`) without
introducing a new reply tool.

Closes #260.

## Changes

### Layer 1 — firmware (`stackchan.cc` + `application.cc` / `.h`)

- Appended a single emit call to `HandleTap()` and `HandleStroke()` in
  `boards/stackchan/stackchan.cc` after the existing local reaction flow
  (avatar pop, wobble, idle revert) so the event also propagates to the
  gateway.
- Added `Application::SendStackChanEvent(event_type, subtype, duration_ms)`
  which emits an additive `stackchan-event` WebSocket text frame:

  ```json
  {
    "session_id": "<protocol session id>",
    "type": "stackchan-event",
    "event_type": "touch",
    "subtype": "tap",
    "duration_ms": 350,
    "ts": 1717398430123
  }
  ```

- `ts` is a monotonic ESP32 boot uptime in milliseconds
  (`esp_timer_get_time() / 1000`), not a Unix epoch timestamp. The intent is
  event ordering for the LLM client, not wall-clock correlation.
- The helper is a no-op when the WebSocket transport is not connected, so it
  does not interfere with offline operation.
- Lambda capture in `Application::Schedule()` copies the `const char*`
  arguments into `std::string` before capture-by-value to avoid pointer
  dangling.

### Layer 2 — gateway (`esp32_client.py`)

- Added a `"stackchan-event"` branch to the existing `_handler` dispatch so
  the new frame type does not disrupt the prior message types (`hello`,
  `mcp`, `tts`, `listen`, `opus` binary, `avatar_set_loaded`).
- Added `_emit_stackchan_event(payload)` with strict per-field validation
  (`event_type`, `subtype`, `duration_ms`, `ts`, `session_id`). Malformed
  frames are logged at WARNING level and dropped without forwarding.
  `isinstance(value, bool)` is checked before `isinstance(value, int)` to
  avoid the Python `bool` ⊂ `int` pitfall.
- The validated event is forwarded via `notify_stackchan_event` to the stdio
  MCP server bridge.

### Layer 3 — MCP server (`stdio_server.py`)

- Declared `stackchan/event` in `experimental_capabilities` so
  capability-aware clients can opt in.
- Added matching `instructions` text guiding clients to react via existing
  tools without expecting a dedicated reply tool.
- Introduced `StackChanServer(Server)` which captures the active
  `ServerSession` in a module-level reference so server-initiated
  notifications can reach the connected client. The public MCP SDK does not
  currently expose a stable hook for server-side notifications, so the
  subclass touches `Server._experimental_handlers` and
  `Server._handle_message`.

### Layer 4 — supply-chain safety for the private SDK touch

- Pinned `mcp` runtime dependency from `>=1.0` to `>=1.27,<2.0` so PyPI
  installations no longer auto-resolve an unverified future SDK version that
  could rename or change the private members the bridge depends on.
- Added a startup compatibility guard (`_verify_mcp_sdk_compatibility`)
  which fails fast with a clear `RuntimeError` if a future SDK release no
  longer exposes `_experimental_handlers` or `_handle_message` in the
  expected shape (callable async + at least 4 positional parameters). This
  prevents silent stop / mid-message crash on incompatible installs.
- Long-term direction: migrate to a public MCP SDK hook for server-initiated
  notifications once one becomes available, then drop the private API touch.

## Validation

- `cd gateway && uv run pytest tests/test_stackchan_event.py` — 15 / 15 pass
  (new module)
- `cd gateway && uv run pytest tests/` — 381 passed, 3 failed, 1 skipped
  - The 3 failures are pre-existing in `test_cli.py` after the ownership
    lock diagnostics landed (#258) and are not introduced by this PR.
    Confirmed by stashing the diff and rerunning the same tests against
    `main` (`02191e3`): identical 381 / 3 / 1 result. Tracked separately as
    #261.
- `cd gateway && uv run ruff check .` — passed
- `git diff main..HEAD --check` — clean (no whitespace issues)
- Codex pre-PR review:
  - Adversarial round 1: one `high` finding on unbounded MCP dependency
    combined with private API touch. Addressed by pinning the runtime
    dependency and adding the startup compatibility guard.
  - Standard round (post-fix): 0 findings on the same diff.
- Real-device verification: pending the maintainer's flash and physical tap
  / stroke walk-through to confirm the notification reaches the connected
  MCP client.

## Compatibility

- All existing WebSocket frame types continue to work; `stackchan-event` is
  additive.
- The `stackchan/event` capability is opt-in; non-aware clients ignore the
  notification, preserving full backward compatibility.
- Gateway: minor version bump candidate (no breaking change).
- Firmware: OTA-compatible, no protocol version bump required.

## Out of scope (= future follow-ups)

- Motion events (shake / pickup via IMU): can be added later as
  `event_type="motion"` on the same `stackchan/event` channel.
- Camera streaming: tracked separately.
- Reply correlation IDs (request / response binding): not needed for
  fire-and-forget notifications.

## Refs

- Closes #260
- Carve-out for pre-existing test regression: #261
