### PR TITLE
feat(gateway): jsonl event log helper for stackchan-event notifications (#260 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ documented-only.
   `Server._handle_message`) so any incompatible future SDK shape fails
   fast with a clear error instead of silent breakage. (#260)
 
+- Added: JSONL event log helper that appends each validated
+  `stackchan-event` frame to `~/.claude/stackchan-events.jsonl`
+  (override via `STACKCHAN_EVENTS_PATH`) so MCP client hooks can pick
+  events up between the firmware reaction and the next conversational
+  turn. Entries older than 7 days are pruned exactly once on gateway
+  startup via an atomic rename. Persistence failures are logged and
+  swallowed; the MCP notification path remains the primary delivery
+  channel for capability-aware clients. (#260 follow-up)
+
 - Added: function-dark #178 Phase B chunk 1 command queue module with an
   environment-configurable bounded FIFO, correlation metadata for response
   routing, a single-flight dispatcher loop, and a standardized queue-full

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -644,6 +644,7 @@ async def _run(*, advertise_mdns: bool = True) -> None:
     """Start both the ESP32 WebSocket server and the stdio MCP server."""
     import signal
 
+    from .event_log import rotate_old_entries
     from .gateway import get_gateway
     from .stdio_server import run_stdio_server
 
@@ -658,6 +659,13 @@ async def _run(*, advertise_mdns: bool = True) -> None:
 
     if sys.platform != "win32":
         loop.add_signal_handler(signal.SIGTERM, _handle_sigterm)
+
+    # Prune stale stackchan-event log entries (older than the helper's
+    # retention window) exactly once per startup. Long-running gateways
+    # are not re-rotated mid-flight; downstream readers filter by
+    # ``ts_unix`` themselves. Failures inside ``rotate_old_entries`` are
+    # logged and swallowed, so a broken log file cannot block startup.
+    rotate_old_entries()
 
     await gateway.start(advertise_mdns=advertise_mdns)
     logger.info("Gateway started, waiting for ESP32 connections...")

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -772,6 +772,30 @@ class ESP32Manager:
             ts,
             session_id,
         )
+
+        # Persist the validated event to the JSONL log so downstream
+        # consumers (e.g. an MCP client UserPromptSubmit hook that
+        # injects events into the next agent turn) can pick it up
+        # between the firmware reaction and the next conversational
+        # turn. ``log_event`` swallows OS / permission errors
+        # internally; the broad except below is a second-tier guard so
+        # any unforeseen helper bug cannot break the MCP notification
+        # path that follows.
+        from .event_log import log_event
+
+        try:
+            log_event(
+                event_type=event_type,
+                subtype=subtype,
+                duration_ms=duration_ms,
+                ts=ts,
+                session_id=session_id,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.warning(
+                "stackchan-event log persistence raised unexpectedly: %s", exc
+            )
+
         from .stdio_server import notify_stackchan_event
 
         await notify_stackchan_event("stackchan/event", params)

--- a/gateway/stackchan_mcp/event_log.py
+++ b/gateway/stackchan_mcp/event_log.py
@@ -1,0 +1,176 @@
+"""Event log writer for firmware-originated stackchan events.
+
+The gateway appends each successfully-validated ``stackchan-event`` frame
+to a JSONL file (default ``~/.claude/stackchan-events.jsonl``) so that
+downstream consumers — most notably an MCP client hook that injects the
+event into the next agent turn as additional context — can read events
+between the firmware reaction and the next conversational turn. This is
+the gateway-side half of the "touch event reaches the LLM client" path;
+the MCP notification path itself remains unchanged and is the primary
+delivery channel for capability-aware clients.
+
+The log file path is overridable via ``STACKCHAN_EVENTS_PATH``. Entries
+whose ``ts_unix`` is older than ``RETENTION_DAYS`` are pruned exactly
+once on gateway startup via :func:`rotate_old_entries`. Long-running
+gateways are not re-rotated mid-flight; downstream readers are expected
+to filter by ``ts_unix`` themselves, and any disk-growth concern over
+multi-day uptimes is tracked as a separate follow-up.
+
+All persistence failures (``PermissionError``, ``OSError``, malformed
+lines, missing parent directory, etc.) are caught and logged at WARNING
+level. The MCP notification path must never be broken by event log
+persistence issues; callers should treat this helper as fire-and-forget.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LOG_PATH: Final[Path] = Path.home() / ".claude" / "stackchan-events.jsonl"
+PATH_ENV_VAR: Final[str] = "STACKCHAN_EVENTS_PATH"
+RETENTION_DAYS: Final[int] = 7
+_RETENTION_SECONDS: Final[int] = RETENTION_DAYS * 24 * 60 * 60
+
+
+def resolve_log_path() -> Path:
+    """Return the active event log path.
+
+    Honors the ``STACKCHAN_EVENTS_PATH`` environment variable when set
+    (``~`` is expanded), otherwise falls back to
+    ``~/.claude/stackchan-events.jsonl``.
+    """
+    override = os.environ.get(PATH_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_LOG_PATH
+
+
+def log_event(
+    event_type: str,
+    subtype: str,
+    duration_ms: int,
+    ts: int,
+    session_id: str,
+    *,
+    ts_unix: float | None = None,
+) -> None:
+    """Append a single stackchan event to the JSONL log.
+
+    Parameters
+    ----------
+    event_type, subtype, duration_ms, ts, session_id
+        Already-validated fields from the firmware-emitted
+        ``stackchan-event`` WebSocket frame. ``ts`` is firmware uptime
+        in milliseconds (monotonic); ``ts_unix`` is the wall-clock
+        moment the gateway recorded the event and is what hook
+        consumers should use for ``"how long ago"`` calculations.
+    ts_unix
+        Optional override for the wall-clock timestamp. Defaults to
+        ``time.time()`` at append time. Exposed for tests.
+
+    Errors are logged at WARNING and swallowed; the MCP notification
+    path continues regardless of disk outcome.
+    """
+    if ts_unix is None:
+        ts_unix = time.time()
+
+    path = resolve_log_path()
+    line = {
+        "event_type": event_type,
+        "subtype": subtype,
+        "duration_ms": duration_ms,
+        "ts": ts,
+        "ts_unix": ts_unix,
+        "session_id": session_id,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(line, ensure_ascii=False) + "\n")
+            f.flush()
+    except (OSError, PermissionError) as exc:
+        logger.warning(
+            "Failed to append stackchan-event log line to %s: %s",
+            path,
+            exc,
+        )
+
+
+def rotate_old_entries(*, now_unix: float | None = None) -> None:
+    """Prune log entries older than ``RETENTION_DAYS`` from the log file.
+
+    Intended to be called exactly once at gateway startup. Reads every
+    line, keeps the ones whose ``ts_unix`` is within the retention
+    window, and atomically replaces the original file via
+    ``os.replace`` on a same-directory temporary file. Malformed lines
+    and lines without a usable ``ts_unix`` are dropped.
+
+    A missing log file is a no-op. Any disk or permission error during
+    rotation is logged at WARNING and swallowed so a broken log file
+    cannot prevent the gateway from starting up.
+    """
+    path = resolve_log_path()
+    if not path.exists():
+        return
+    if now_unix is None:
+        now_unix = time.time()
+    cutoff = now_unix - _RETENTION_SECONDS
+
+    kept: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    obj = json.loads(stripped)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "Dropping malformed event log line during rotation: %s",
+                        stripped[:120],
+                    )
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                ts_unix = obj.get("ts_unix")
+                if isinstance(ts_unix, bool) or not isinstance(ts_unix, (int, float)):
+                    continue
+                if ts_unix >= cutoff:
+                    kept.append(stripped + "\n")
+    except (OSError, PermissionError) as exc:
+        logger.warning(
+            "Failed to read stackchan-event log %s for rotation: %s",
+            path,
+            exc,
+        )
+        return
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=str(path.parent),
+            prefix=path.name + ".",
+            suffix=".tmp",
+        ) as tmp:
+            tmp.writelines(kept)
+            tmp.flush()
+            tmp_path = Path(tmp.name)
+        os.replace(tmp_path, path)
+    except (OSError, PermissionError) as exc:
+        logger.warning(
+            "Failed to atomically rotate stackchan-event log %s: %s",
+            path,
+            exc,
+        )

--- a/gateway/tests/test_event_log.py
+++ b/gateway/tests/test_event_log.py
@@ -1,0 +1,343 @@
+"""Tests for ``stackchan_mcp.event_log`` JSONL writer + rotation helper."""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from stackchan_mcp import event_log
+from stackchan_mcp.event_log import (
+    DEFAULT_LOG_PATH,
+    PATH_ENV_VAR,
+    RETENTION_DAYS,
+    log_event,
+    resolve_log_path,
+    rotate_old_entries,
+)
+
+
+# --- resolve_log_path -------------------------------------------------------
+
+
+def test_resolve_log_path_returns_default_when_env_unset(monkeypatch):
+    monkeypatch.delenv(PATH_ENV_VAR, raising=False)
+    assert resolve_log_path() == DEFAULT_LOG_PATH
+
+
+def test_resolve_log_path_honors_env_override(monkeypatch, tmp_path):
+    override = tmp_path / "custom-events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(override))
+    assert resolve_log_path() == override
+
+
+def test_resolve_log_path_expands_tilde(monkeypatch):
+    monkeypatch.setenv(PATH_ENV_VAR, "~/custom/events.jsonl")
+    expected = Path.home() / "custom" / "events.jsonl"
+    assert resolve_log_path() == expected
+
+
+# --- log_event happy path ---------------------------------------------------
+
+
+def test_log_event_appends_line_to_jsonl(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    log_event(
+        event_type="touch",
+        subtype="tap",
+        duration_ms=350,
+        ts=123456,
+        session_id="session-1",
+        ts_unix=1717000000.5,
+    )
+
+    raw = path.read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+    entry = json.loads(raw.splitlines()[-1])
+    assert entry == {
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "ts": 123456,
+        "ts_unix": 1717000000.5,
+        "session_id": "session-1",
+    }
+
+
+def test_log_event_appends_multiple_lines_in_order(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    log_event("touch", "tap", 100, 1, "s", ts_unix=1.0)
+    log_event("touch", "stroke", 1200, 2, "s", ts_unix=2.0)
+    log_event("touch", "tap", 200, 3, "s", ts_unix=3.0)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert json.loads(lines[0])["ts_unix"] == 1.0
+    assert json.loads(lines[1])["subtype"] == "stroke"
+    assert json.loads(lines[2])["duration_ms"] == 200
+
+
+def test_log_event_creates_missing_parent_directory(monkeypatch, tmp_path):
+    path = tmp_path / "nested" / "deep" / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    log_event("touch", "tap", 100, 1, "s", ts_unix=1.0)
+
+    assert path.exists()
+    assert path.parent.exists()
+
+
+def test_log_event_defaults_ts_unix_to_now(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    fixed_now = 1717000100.25
+    monkeypatch.setattr(event_log.time, "time", lambda: fixed_now)
+
+    log_event("touch", "tap", 100, 1, "s")
+
+    entry = json.loads(path.read_text(encoding="utf-8").splitlines()[-1])
+    assert entry["ts_unix"] == fixed_now
+
+
+# --- log_event error swallowing --------------------------------------------
+
+
+def test_log_event_swallows_oserror_and_logs_warning(
+    monkeypatch, tmp_path, caplog
+):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated-disk-full")
+
+    monkeypatch.setattr(Path, "open", boom)
+
+    with caplog.at_level(logging.WARNING):
+        log_event("touch", "tap", 100, 1, "s", ts_unix=1.0)
+
+    assert "Failed to append stackchan-event log line" in caplog.text
+
+
+# --- rotate_old_entries ----------------------------------------------------
+
+
+def test_rotate_missing_file_is_noop(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    rotate_old_entries(now_unix=1000.0)
+
+    assert not path.exists()
+
+
+def test_rotate_keeps_recent_drops_stale(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    now = 1717000000.0
+    retention_secs = RETENTION_DAYS * 24 * 60 * 60
+    stale_ts = now - retention_secs - 10
+    fresh_ts = now - 60
+
+    path.write_text(
+        json.dumps(
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 100,
+                "ts": 1,
+                "ts_unix": stale_ts,
+                "session_id": "old",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "event_type": "touch",
+                "subtype": "stroke",
+                "duration_ms": 1200,
+                "ts": 2,
+                "ts_unix": fresh_ts,
+                "session_id": "new",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rotate_old_entries(now_unix=now)
+
+    surviving = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(surviving) == 1
+    assert surviving[0]["session_id"] == "new"
+
+
+def test_rotate_keeps_entries_exactly_at_cutoff(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    now = 1717000000.0
+    retention_secs = RETENTION_DAYS * 24 * 60 * 60
+    boundary_ts = now - retention_secs
+
+    path.write_text(
+        json.dumps(
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 100,
+                "ts": 1,
+                "ts_unix": boundary_ts,
+                "session_id": "boundary",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rotate_old_entries(now_unix=now)
+
+    surviving = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(surviving) == 1
+    assert surviving[0]["session_id"] == "boundary"
+
+
+def test_rotate_drops_malformed_lines(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    now = 1717000000.0
+    valid_recent = json.dumps(
+        {
+            "event_type": "touch",
+            "subtype": "tap",
+            "duration_ms": 100,
+            "ts": 1,
+            "ts_unix": now - 60,
+            "session_id": "ok",
+        }
+    )
+    path.write_text(
+        "not-json\n"
+        + valid_recent
+        + "\n"
+        + '{"ts_unix": "not-a-number"}\n'
+        + "{}\n"
+        + "[]\n"
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rotate_old_entries(now_unix=now)
+
+    surviving = [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert len(surviving) == 1
+    assert surviving[0]["session_id"] == "ok"
+
+
+def test_rotate_treats_bool_ts_unix_as_invalid(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    now = 1717000000.0
+    path.write_text(
+        json.dumps(
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 100,
+                "ts": 1,
+                "ts_unix": True,
+                "session_id": "bool",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 100,
+                "ts": 2,
+                "ts_unix": now - 60,
+                "session_id": "ok",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rotate_old_entries(now_unix=now)
+
+    surviving = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(surviving) == 1
+    assert surviving[0]["session_id"] == "ok"
+
+
+def test_rotate_replaces_via_os_replace_atomically(monkeypatch, tmp_path):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+
+    now = 1717000000.0
+    path.write_text(
+        json.dumps(
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 100,
+                "ts": 1,
+                "ts_unix": now - 60,
+                "session_id": "keep",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+    original_replace = os.replace
+
+    def tracking_replace(src, dst):
+        calls.append((str(src), str(dst)))
+        original_replace(src, dst)
+
+    monkeypatch.setattr(event_log.os, "replace", tracking_replace)
+
+    rotate_old_entries(now_unix=now)
+
+    assert len(calls) == 1
+    assert calls[0][1] == str(path)
+    surviving = path.read_text(encoding="utf-8").splitlines()
+    assert len(surviving) == 1
+
+
+def test_rotate_swallows_read_error_and_logs_warning(
+    monkeypatch, tmp_path, caplog
+):
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(path))
+    path.write_text("{}\n", encoding="utf-8")
+
+    def boom_open(*args, **kwargs):
+        raise OSError("read-permission-denied")
+
+    monkeypatch.setattr(Path, "open", boom_open)
+
+    with caplog.at_level(logging.WARNING):
+        rotate_old_entries(now_unix=1000.0)
+
+    assert "Failed to read stackchan-event log" in caplog.text


### PR DESCRIPTION
## Summary

Add a JSONL event log helper that persists every validated
`stackchan-event` frame to `~/.claude/stackchan-events.jsonl` (override
via `STACKCHAN_EVENTS_PATH`). The log gives MCP client hooks a stable
place to pick events up between the firmware reaction and the next
conversational turn — a complement to the in-band MCP notification path
that #262 (#260) already lands.

The MCP notification continues to be the primary delivery channel for
capability-aware clients. The JSONL log is a fire-and-forget
side-channel: persistence failures never break the notification path.

Refs #260.

## Changes

- New module `gateway/stackchan_mcp/event_log.py`:
  - `resolve_log_path()` resolves the active log path, honoring
    `STACKCHAN_EVENTS_PATH` with `~` expansion and falling back to
    `~/.claude/stackchan-events.jsonl`.
  - `log_event(event_type, subtype, duration_ms, ts, session_id, *, ts_unix=None)`
    appends a single JSON line with the validated event plus a
    wall-clock `ts_unix` (default `time.time()`). Errors are logged at
    WARNING and swallowed.
  - `rotate_old_entries(*, now_unix=None)` prunes lines whose `ts_unix`
    is older than 7 days, atomically replacing the file via a
    same-directory `tempfile.NamedTemporaryFile` + `os.replace`. A
    missing file is a no-op. Malformed lines and lines without a usable
    `ts_unix` are dropped. Disk / permission errors are swallowed so a
    broken log file cannot block startup.

- `gateway/stackchan_mcp/esp32_client.py`: `_emit_stackchan_event`
  calls `log_event` after the existing `logger.info` line and before
  the in-band `notify_stackchan_event` call. A second-tier `try/except`
  guard wraps the helper so any unforeseen persistence bug cannot break
  the MCP notification path that follows.

- `gateway/stackchan_mcp/cli.py`: `_run()` calls `rotate_old_entries()`
  once before `gateway.start()` so old entries are pruned at startup.
  Long-running gateways are not re-rotated mid-flight; downstream
  readers are expected to filter by `ts_unix` themselves.

- `CHANGELOG.md`: `[Unreleased]` Gateway entry added.

## File format

Each line in `~/.claude/stackchan-events.jsonl` is a single JSON object:

```json
{
  "event_type": "touch",
  "subtype": "tap",
  "duration_ms": 350,
  "ts": 123456,
  "ts_unix": 1717000000.5,
  "session_id": "session-1"
}
```

`ts` is the firmware-monotonic ESP32 boot uptime in milliseconds (from
the upstream `stackchan-event` frame), and `ts_unix` is the wall-clock
float epoch second the gateway recorded the event. Downstream hook
consumers should use `ts_unix` for any "how long ago" calculation.

## Validation

- `cd gateway && uv run pytest tests/test_event_log.py` — 15 / 15 pass
  (new module).
- `cd gateway && uv run pytest tests/test_stackchan_event.py` —
  15 / 15 pass (existing #260 path unaffected).
- `cd gateway && uv run pytest tests/` — 396 passed, 3 failed, 1
  skipped. The 3 failures are pre-existing in `test_cli.py` after the
  ownership lock diagnostics landed (#258); they are tracked as #261
  and are not introduced by this change.
- `cd gateway && uv run ruff check .` — passed.
- `git diff main..HEAD --check` — clean.
- Codex pre-PR review (standard): no findings on the diff.
- Real-device verification: pending the maintainer's flash + physical
  tap / stroke walk-through to confirm the JSONL file accumulates
  entries.

## Compatibility

- The in-band MCP notification path (#260) is unchanged.
- Capability-aware clients continue to receive `stackchan/event`
  notifications exactly as before.
- Pruning is opt-out by deleting the log file (rebuilt on next event)
  and the path is opt-redirected via `STACKCHAN_EVENTS_PATH`.
- No new dependencies; only the standard library is used in
  `event_log`.

## Refs

- Refs #260 (capability landed in #262).
