### PR TITLE
feat(gateway): #178 Phase B stage 3 — Streamable HTTP daemon + queue dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ documented-only.
   `--transport stdio` compatibility and a Streamable HTTP daemon
   placeholder that releases ownership before the chunk 4 wiring lands.
 
+- feat(gateway): Streamable HTTP daemon transport with bounded command
+  queue and saturation backpressure. (#178)
+
+- docs(gateway): daemon setup and Phase B migration notes. (#178)
+
 - Fixed: #178 Phase B chunk 2+3 ownership lock cleanup safety. The
   streamable-http `serve` placeholder now guards its `finally` cleanup with
   an `acquired` flag so an `OwnershipError` raised by an existing owner is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ documented-only.
 
 - docs(gateway): daemon setup and Phase B migration notes. (#178)
 
+- Fixed: #178 Phase B stage 3 HTTP daemon — cancel-safe queue dispatch
+  drops items for cancelled HTTP requests before ESP32 dispatch and
+  drains pending items on lifespan shutdown with a JSON-RPC
+  server-shutdown error. Narrowed unauthenticated `/healthz` to a
+  liveness-only payload and moved device, queue, and owner detail to
+  the authenticated `/status` endpoint (now includes `owner_id`).
+  (#178)
+
 - Fixed: #178 Phase B chunk 2+3 ownership lock cleanup safety. The
   streamable-http `serve` placeholder now guards its `finally` cleanup with
   an `acquired` flag so an `OwnershipError` raised by an existing owner is

--- a/docs/178-daemon-setup.md
+++ b/docs/178-daemon-setup.md
@@ -1,0 +1,151 @@
+# Issue #178 Daemon Setup
+
+The gateway now has two supported MCP server modes:
+
+- **stdio mode**: `stackchan-mcp` with no subcommand. This is the original
+  single-client mode used by existing MCP client configs.
+- **daemon mode**: `stackchan-mcp serve --transport streamable-http`. This
+  starts one long-lived gateway process, keeps one ESP32 WebSocket connection,
+  and accepts multiple MCP clients over Streamable HTTP.
+
+Use daemon mode when more than one MCP client or automation needs to share the
+same StackChan device. Keep stdio mode for simple local setups, compatibility
+testing, and existing clients that do not yet support Streamable HTTP.
+
+## Start the daemon
+
+```bash
+cd gateway
+uv run stackchan-mcp serve --transport streamable-http
+```
+
+The daemon starts the same ESP32 WebSocket listener and capture server as stdio
+mode, then exposes the MCP endpoint at:
+
+```text
+http://127.0.0.1:8767/mcp
+```
+
+The zero-subcommand stdio entry point remains supported and unchanged:
+
+```bash
+stackchan-mcp
+```
+
+`stackchan-mcp serve --transport stdio` is equivalent to the zero-subcommand
+stdio path.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `STACKCHAN_TOKEN` | unset | Bearer token shared with the ESP32 firmware and, when set, required by HTTP MCP clients. |
+| `BEARER_TOKEN` | unset | Legacy alias used only when `STACKCHAN_TOKEN` is unset. |
+| `MCP_HTTP_HOST` | `127.0.0.1` | Bind host for the Streamable HTTP MCP endpoint. |
+| `MCP_HTTP_PORT` | `8767` | Bind port for the Streamable HTTP MCP endpoint. |
+| `MCP_HTTP_ALLOWED_HOSTS` | unset | Comma-separated Host / Origin allowlist for non-loopback clients, for example `192.168.1.10,stackchan.local:8767`. |
+| `STACKCHAN_COMMAND_QUEUE_SIZE` | `32` | Maximum queued ESP32-bound tool calls before the daemon returns backpressure. |
+
+The existing gateway variables (`HOST`, `WS_PORT`, `CAPTURE_PORT`,
+`VISION_HOST`, `VISION_URL`, `VISION_TOKEN`, and audio hook settings) keep the
+same meaning in daemon mode.
+
+## Bind safety
+
+Loopback binds (`127.0.0.1`, `::1`, or `localhost`) may run without an HTTP
+bearer token for local development.
+
+Non-loopback binds, such as `0.0.0.0` or a LAN IP address, require
+`STACKCHAN_TOKEN` or `BEARER_TOKEN`. Startup is refused otherwise:
+
+```text
+stackchan-mcp: refusing non-loopback MCP_HTTP_HOST without STACKCHAN_TOKEN or BEARER_TOKEN
+```
+
+When a token is configured, every request to `/mcp` and `/status` must include:
+
+```text
+Authorization: Bearer <token>
+```
+
+`/healthz` is intentionally unauthenticated so local process monitors can check
+whether the daemon is alive. Host and Origin headers are still validated on all
+daemon endpoints.
+
+For wildcard binds such as `MCP_HTTP_HOST=0.0.0.0`, loopback Host values
+(`127.0.0.1`, `localhost`, `::1`) are accepted by default. LAN clients usually
+send the machine's LAN IP or DNS name in the `Host` header, so add those values
+to `MCP_HTTP_ALLOWED_HOSTS`:
+
+```bash
+STACKCHAN_TOKEN=your-secret-token-here \
+MCP_HTTP_HOST=0.0.0.0 \
+MCP_HTTP_ALLOWED_HOSTS=192.168.1.10,stackchan.local:8767 \
+stackchan-mcp serve --transport streamable-http
+```
+
+## MCP client configuration
+
+Use a Streamable HTTP MCP client pointed at `/mcp`. Example
+`mcp.config.json`:
+
+```json
+{
+  "mcpServers": {
+    "stackchan-mcp": {
+      "type": "streamable-http",
+      "url": "http://127.0.0.1:8767/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret-token-here"
+      }
+    }
+  }
+}
+```
+
+If no `STACKCHAN_TOKEN` or `BEARER_TOKEN` is configured and the daemon is bound
+to loopback, omit the `headers` block.
+
+## Operational endpoints
+
+`GET /healthz` returns daemon-local health:
+
+```json
+{
+  "ok": true,
+  "esp32_connected": true,
+  "queue_depth": 0,
+  "queue_capacity": 32,
+  "owner_id": "stackchan-mcp-1234abcd"
+}
+```
+
+`GET /status` returns the same gateway status as the `get_status` MCP tool,
+plus `queue_depth`, `queue_capacity`, and `connected_clients`.
+
+## Migration notes
+
+Existing stdio configs do not need to change. The following remains valid:
+
+```json
+{
+  "mcpServers": {
+    "stackchan-mcp": {
+      "type": "stdio",
+      "command": "stackchan-mcp"
+    }
+  }
+}
+```
+
+To migrate, start the daemon as an independent process first, then point each
+Streamable HTTP-capable MCP client at `http://127.0.0.1:8767/mcp`. Once a
+client uses the daemon, it should not also spawn `stackchan-mcp` in stdio mode
+for the same device, because the daemon is the process that owns the ESP32
+WebSocket.
+
+The daemon keeps a single bounded FIFO command queue for ESP32-bound tool
+calls. `get_status` bypasses the queue because it reads gateway-local state.
+When the queue is full, the daemon returns a JSON-RPC error with code `-32000`
+and message `stackchan command queue is full`; it does not buffer commands
+without a limit.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -75,6 +75,25 @@ Default ports:
 - WebSocket (ESP32 -> gateway): `0.0.0.0:8765`
 - HTTP capture (ESP32 -> gateway): `0.0.0.0:8766`
 
+## Daemon mode (Phase B)
+
+For multi-client setups, run one shared Streamable HTTP daemon instead of
+letting each MCP client spawn its own stdio gateway:
+
+```bash
+uv run stackchan-mcp serve --transport streamable-http
+```
+
+The daemon exposes MCP at `http://127.0.0.1:8767/mcp` by default, keeps the
+existing ESP32 WebSocket and capture listeners, and serializes ESP32-bound
+tool calls through a bounded command queue. See
+[`../docs/178-daemon-setup.md`](../docs/178-daemon-setup.md) for environment
+variables, bearer-token rules, `MCP_HTTP_ALLOWED_HOSTS`, bind safety, and
+migration notes.
+
+The zero-subcommand stdio mode remains supported and unchanged for existing
+client configs.
+
 By default, the gateway advertises the WebSocket endpoint as
 `_stackchan-mcp._tcp.local.` via mDNS/DNS-SD so fresh firmware can discover it
 on the local LAN. Run `stackchan-mcp --no-mdns` to disable this advertisement.
@@ -90,10 +109,10 @@ again, check `get_status` from the stdio MCP side to confirm the device is back.
 ## Configuration changes
 
 The gateway reads `.env` once at process start. Because the gateway runs as a
-**stdio MCP server** (it has no standalone CLI mode beyond `--help` /
-`--version` / `--check`), editing `.env` while it is connected to an MCP
-client does not take effect on the running process — and killing the gateway
-process directly will not auto-restart it; the MCP client owns the lifecycle.
+**stdio MCP server** by default, editing `.env` while it is connected to an MCP
+client does not take effect on the running process — and killing that stdio
+gateway process directly will not auto-restart it; the MCP client owns the
+lifecycle. In daemon mode, restart the daemon process after changing `.env`.
 
 After editing `.env` (for example to update `STACKCHAN_TOKEN`, `VISION_URL`,
 or `VISION_TOKEN`):

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -65,6 +65,8 @@ Environment variables:
                            (default 127.0.0.1).
   MCP_HTTP_PORT            Port for the Streamable HTTP MCP server
                            (default 8767).
+  MCP_HTTP_ALLOWED_HOSTS   Comma-separated Host / Origin allowlist entries
+                           for non-loopback Streamable HTTP clients.
 
 See gateway/README.md and the top-level README.md for full setup,
 including pairing the ESP32 firmware and configuring the WiFi gateway URL.
@@ -531,6 +533,12 @@ def _run_preflight() -> int:
     else:
         print("  STACKCHAN_TOKEN     not set (gateway will accept any client)")
 
+    mcp_http_allowed_hosts = os.getenv("MCP_HTTP_ALLOWED_HOSTS", "")
+    if mcp_http_allowed_hosts:
+        print(f"  MCP_HTTP_ALLOWED_HOSTS {mcp_http_allowed_hosts}")
+    else:
+        print("  MCP_HTTP_ALLOWED_HOSTS not set")
+
     vision_host = os.getenv("VISION_HOST", "")
     capture_port_raw = os.getenv("CAPTURE_PORT", "8766")
     if vision_host:
@@ -580,14 +588,26 @@ def _run_preflight() -> int:
     print()
     print("Ports:")
     host = os.getenv("HOST", "0.0.0.0")
+    mcp_http_host = os.getenv("MCP_HTTP_HOST", "127.0.0.1")
     ws_port, ws_source = _resolve_ws_port()
     cap_port, cap_source = _resolve_capture_port()
+    raw_mcp_http_port = os.getenv("MCP_HTTP_PORT")
+    if raw_mcp_http_port is None:
+        mcp_http_port, mcp_http_source = (8767, "default")
+    else:
+        mcp_http_port, mcp_http_source = _validate_port_value(
+            raw_mcp_http_port,
+            "MCP_HTTP_PORT",
+        )
 
     if ws_port is None:
         print(f"  ws://{host}:???     INVALID ({ws_source})")
         issues += 1
     if cap_port is None:
         print(f"  http://{host}:???   INVALID ({cap_source})")
+        issues += 1
+    if mcp_http_port is None:
+        print(f"  http://{mcp_http_host}:???/mcp INVALID ({mcp_http_source})")
         issues += 1
 
     if (
@@ -612,6 +632,21 @@ def _run_preflight() -> int:
         )
         issues += 1
 
+    if mcp_http_port is not None:
+        for label, other_port, other_source in (
+            ("WS_PORT", ws_port, ws_source),
+            ("CAPTURE_PORT", cap_port, cap_source),
+        ):
+            if other_port is None or mcp_http_port == 0 or other_port == 0:
+                continue
+            if mcp_http_port == other_port:
+                print(
+                    f"  MCP_HTTP_PORT ({mcp_http_source}) and {label} "
+                    f"({other_source}) both resolve to {mcp_http_port}; "
+                    "the daemon needs distinct listener ports."
+                )
+                issues += 1
+
     if ws_port is not None:
         ws_available, ws_holder = _check_port(host, ws_port)
         print(
@@ -628,6 +663,22 @@ def _run_preflight() -> int:
             f"{_format_port_status(cap_available, cap_holder)}"
         )
         if not cap_available:
+            issues += 1
+
+    if mcp_http_port is not None:
+        from .http_server import validate_bind_safety
+
+        mcp_available, mcp_holder = _check_port(mcp_http_host, mcp_http_port)
+        print(
+            f"  http://{mcp_http_host}:{mcp_http_port}/mcp "
+            f"{_format_port_status(mcp_available, mcp_holder)}"
+        )
+        if not mcp_available:
+            issues += 1
+        try:
+            validate_bind_safety(mcp_http_host, token)
+        except ValueError as exc:
+            print(f"  MCP HTTP bind safety: BLOCKED ({exc})")
             issues += 1
 
     # --- Result -------------------------------------------------------------
@@ -764,12 +815,73 @@ def _resolve_mcp_http_endpoint() -> tuple[str, int]:
     return host, port
 
 
-def _run_streamable_http_placeholder() -> None:
-    """Claim daemon ownership, then stop at the chunk 4 HTTP wiring boundary."""
+async def _run_streamable_http_daemon(
+    *,
+    host: str,
+    port: int,
+    owner_id: str,
+    token: str | None,
+    advertise_mdns: bool,
+) -> None:
+    """Run the Streamable HTTP MCP daemon until the ASGI server exits."""
+    import uvicorn
+
+    from .event_log import rotate_old_entries
+    from .gateway import get_gateway
+    from .http_server import build_app, make_dispatch_fn
+    from .queue import CommandQueue
+
+    rotate_old_entries()
+
+    gateway = get_gateway()
+    queue = CommandQueue()
+    app = build_app(
+        queue,
+        gateway=gateway,
+        owner_id=owner_id,
+        host=host,
+        port=port,
+        token=token,
+        dispatch_fn=make_dispatch_fn(gateway),
+    )
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level="info",
+        lifespan="on",
+    )
+    server = uvicorn.Server(config)
+
+    await gateway.start(advertise_mdns=advertise_mdns)
+    logger.info(
+        "Streamable HTTP MCP daemon starting on http://%s:%d/mcp",
+        host,
+        port,
+    )
+    try:
+        await server.serve()
+    finally:
+        await gateway.stop()
+
+
+def _run_streamable_http_placeholder(*, advertise_mdns: bool = True) -> None:
+    """Run the Streamable HTTP MCP daemon."""
     from .ownership import release_lock_if_owner
+    from .http_server import (
+        get_configured_token,
+        validate_bind_safety,
+    )
 
     _configure_gateway_startup()
     host, port = _resolve_mcp_http_endpoint()
+    token = get_configured_token()
+    try:
+        validate_bind_safety(host, token)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
     info: LockInfo | None = None
     try:
         info = _acquire_startup_lock(
@@ -777,7 +889,18 @@ def _run_streamable_http_placeholder() -> None:
             http_endpoint=f"{host}:{port}",
             started_by="cli-serve",
         )
-        raise NotImplementedError("Streamable HTTP daemon lands in #178 chunk 4")
+        try:
+            asyncio.run(
+                _run_streamable_http_daemon(
+                    host=host,
+                    port=port,
+                    owner_id=info["owner_id"],
+                    token=token,
+                    advertise_mdns=advertise_mdns,
+                )
+            )
+        except KeyboardInterrupt:
+            pass
     finally:
         if info is not None:
             release_lock_if_owner(info)
@@ -810,13 +933,11 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if args.command == "serve":
+        advertise_mdns = not (args.no_mdns or getattr(args, "serve_no_mdns", False))
         if args.transport == _STDIO_TRANSPORT:
-            advertise_mdns = not (
-                args.no_mdns or getattr(args, "serve_no_mdns", False)
-            )
             _run_stdio_gateway(advertise_mdns=advertise_mdns)
             return
-        _run_streamable_http_placeholder()
+        _run_streamable_http_placeholder(advertise_mdns=advertise_mdns)
         return
 
 

--- a/gateway/stackchan_mcp/http_server.py
+++ b/gateway/stackchan_mcp/http_server.py
@@ -1,0 +1,337 @@
+"""Streamable HTTP MCP daemon wiring for the StackChan gateway."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ipaddress
+import json
+import os
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import urlparse
+
+import jsonschema
+from mcp.server.streamable_http import MCP_SESSION_ID_HEADER
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.types import CallToolRequest, CallToolResult, ErrorData, ServerResult, TextContent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.routing import Route
+from starlette.types import Receive, Scope, Send
+
+from .queue import CommandQueue, QueueFull, QueueItem, build_queue_full_error
+from .stdio_server import _dispatch_mcp_tool, create_server
+
+BYPASS_TOOLS = frozenset({"get_status"})
+MCP_HTTP_ALLOWED_HOSTS_ENV = "MCP_HTTP_ALLOWED_HOSTS"
+AUTH_FAILURE_MESSAGE = "Unauthorized: missing or invalid bearer token"
+HOST_FAILURE_MESSAGE = "Forbidden: invalid Host header"
+ORIGIN_FAILURE_MESSAGE = "Forbidden: invalid Origin header"
+NON_LOOPBACK_TOKEN_REQUIRED_MESSAGE = (
+    "stackchan-mcp: refusing non-loopback MCP_HTTP_HOST without "
+    "STACKCHAN_TOKEN or BEARER_TOKEN"
+)
+DISCONNECTED_DEVICE_PAYLOAD = {
+    "error": "No ESP32 device connected. Please check the device."
+}
+
+DispatchFn = Callable[[QueueItem], Awaitable[list[TextContent]]]
+
+
+def get_configured_token() -> str | None:
+    """Return the configured HTTP bearer token, if any."""
+    return os.getenv("STACKCHAN_TOKEN") or os.getenv("BEARER_TOKEN") or None
+
+
+def is_wildcard_bind_host(host: str) -> bool:
+    """Return whether ``host`` binds all local interfaces."""
+    normalized = host.strip().lower()
+    return normalized in {"", "0.0.0.0", "::"}
+
+
+def is_loopback_bind_host(host: str) -> bool:
+    """Return whether ``host`` is a loopback-only bind target."""
+    normalized = host.strip().lower()
+    if normalized in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_bind_safety(host: str, token: str | None) -> None:
+    """Reject non-loopback daemon binds when no HTTP bearer token is set."""
+    if not token and not is_loopback_bind_host(host):
+        raise ValueError(NON_LOOPBACK_TOKEN_REQUIRED_MESSAGE)
+
+
+def make_dispatch_fn(gateway: Any) -> DispatchFn:
+    """Build the single-flight ESP32 dispatcher used by the command queue."""
+
+    async def dispatch(item: QueueItem) -> list[TextContent]:
+        if not gateway.esp32.device_connected:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(DISCONNECTED_DEVICE_PAYLOAD),
+                )
+            ]
+        return await _dispatch_mcp_tool(item.tool_name, item.arguments, gateway)
+
+    return dispatch
+
+
+def build_app(
+    queue: CommandQueue,
+    *,
+    gateway: Any,
+    owner_id: str,
+    host: str,
+    port: int,
+    token: str | None = None,
+    dispatch_fn: DispatchFn | None = None,
+) -> _GuardedASGIApp:
+    """Build the ASGI app for Streamable HTTP MCP plus health endpoints."""
+    server = create_server()
+    session_manager = StreamableHTTPSessionManager(
+        app=server,
+        json_response=True,
+        stateless=False,
+    )
+    _install_queue_tool_handler(server, queue=queue, gateway=gateway)
+
+    async def healthz(_request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "ok": True,
+                "esp32_connected": bool(gateway.esp32.device_connected),
+                "queue_depth": queue.depth,
+                "queue_capacity": queue.capacity,
+                "owner_id": owner_id,
+            }
+        )
+
+    async def status(_request: Request) -> JSONResponse:
+        raw_status = gateway.esp32.get_status()
+        status_payload = dict(raw_status) if isinstance(raw_status, dict) else {}
+        if not isinstance(raw_status, dict):
+            status_payload["status"] = raw_status
+        status_payload.update(
+            {
+                "queue_depth": queue.depth,
+                "queue_capacity": queue.capacity,
+                "connected_clients": _connected_client_count(session_manager),
+            }
+        )
+        return JSONResponse(status_payload)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_app: Starlette):
+        dispatcher_task: asyncio.Task[None] | None = None
+        async with session_manager.run():
+            if dispatch_fn is not None:
+                dispatcher_task = asyncio.create_task(queue.run_dispatcher(dispatch_fn))
+            try:
+                yield
+            finally:
+                if dispatcher_task is not None:
+                    dispatcher_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await dispatcher_task
+
+    routes = [
+        Route(
+            "/mcp",
+            endpoint=_StreamableHTTPASGIApp(session_manager),
+            methods=["GET", "POST", "DELETE"],
+        ),
+        Route("/healthz", endpoint=healthz, methods=["GET"]),
+        Route("/status", endpoint=status, methods=["GET"]),
+    ]
+    app = Starlette(routes=routes, lifespan=lifespan)
+    app.state.command_queue = queue
+    app.state.session_manager = session_manager
+    app.state.gateway = gateway
+    return _GuardedASGIApp(
+        app,
+        token=token,
+        allowed_hosts=_allowed_host_values(host, port),
+    )
+
+
+def _install_queue_tool_handler(
+    server: Any,
+    *,
+    queue: CommandQueue,
+    gateway: Any,
+) -> None:
+    async def handler(req: CallToolRequest) -> ServerResult | ErrorData:
+        tool_name = req.params.name
+        arguments = req.params.arguments or {}
+        tool = await server._get_cached_tool_definition(tool_name)
+        if tool is not None:
+            try:
+                jsonschema.validate(instance=arguments, schema=tool.inputSchema)
+            except jsonschema.ValidationError as exc:
+                return server._make_error_result(
+                    f"Input validation error: {exc.message}"
+                )
+
+        if tool_name in BYPASS_TOOLS:
+            content = await _dispatch_mcp_tool(tool_name, arguments, gateway)
+            return _tool_result(content)
+
+        context = server.request_context
+        request = context.request
+        client_session_id = None
+        if isinstance(request, Request):
+            client_session_id = request.headers.get(MCP_SESSION_ID_HEADER)
+
+        response_future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        item = QueueItem(
+            correlation_id=str(uuid.uuid4()),
+            client_session_id=client_session_id,
+            client_request_id=context.request_id,
+            tool_name=tool_name,
+            arguments=arguments,
+            response_future=response_future,
+            enqueued_at=time.monotonic(),
+        )
+        try:
+            queue.enqueue(item)
+        except QueueFull as exc:
+            return ErrorData(**build_queue_full_error(exc.queue_depth))
+
+        content = await response_future
+        return _tool_result(content)
+
+    server.request_handlers[CallToolRequest] = handler
+
+
+def _tool_result(content: list[TextContent]) -> ServerResult:
+    return ServerResult(
+        CallToolResult(
+            content=content,
+            isError=False,
+        )
+    )
+
+
+def _connected_client_count(session_manager: StreamableHTTPSessionManager) -> int:
+    return len(getattr(session_manager, "_server_instances", {}))
+
+
+def _allowed_host_values(host: str, port: int) -> set[str]:
+    hosts = {host.strip().lower()}
+    if is_loopback_bind_host(host) or is_wildcard_bind_host(host):
+        hosts.update({"127.0.0.1", "localhost", "::1"})
+
+    values: set[str] = set()
+    for item in hosts:
+        values.add(item)
+        values.add(_host_with_port(item, port))
+    values.update(_allowed_hosts_from_env(port))
+    return values
+
+
+def _allowed_hosts_from_env(port: int) -> set[str]:
+    raw_hosts = os.getenv(MCP_HTTP_ALLOWED_HOSTS_ENV, "")
+    values: set[str] = set()
+    for raw_item in raw_hosts.split(","):
+        item = raw_item.strip().lower()
+        if not item:
+            continue
+        parsed = urlparse(item)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            item = parsed.netloc.lower()
+        values.add(item)
+        if ":" not in item or (item.startswith("[") and "]:" not in item):
+            values.add(_host_with_port(item, port))
+    return values
+
+
+def _host_with_port(host: str, port: int) -> str:
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"
+
+
+def _is_allowed_host_header(value: str | None, allowed_hosts: set[str]) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in allowed_hosts
+
+
+def _is_allowed_origin(value: str | None, allowed_hosts: set[str]) -> bool:
+    if not value:
+        return True
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    return _is_allowed_host_header(parsed.netloc, allowed_hosts)
+
+
+class _GuardedASGIApp:
+    def __init__(
+        self,
+        app: Starlette,
+        *,
+        token: str | None,
+        allowed_hosts: set[str],
+    ) -> None:
+        self._app = app
+        self._token = token
+        self._allowed_hosts = allowed_hosts
+        self.state = app.state
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
+        if not _is_allowed_host_header(request.headers.get("host"), self._allowed_hosts):
+            await PlainTextResponse(HOST_FAILURE_MESSAGE, status_code=403)(
+                scope,
+                receive,
+                send,
+            )
+            return
+        if not _is_allowed_origin(request.headers.get("origin"), self._allowed_hosts):
+            await PlainTextResponse(ORIGIN_FAILURE_MESSAGE, status_code=403)(
+                scope,
+                receive,
+                send,
+            )
+            return
+        if self._token and scope.get("path") in {"/mcp", "/status"}:
+            expected = f"Bearer {self._token}"
+            if request.headers.get("authorization") != expected:
+                await PlainTextResponse(
+                    AUTH_FAILURE_MESSAGE,
+                    status_code=401,
+                    headers={"WWW-Authenticate": "Bearer"},
+                )(scope, receive, send)
+                return
+
+        await self._app(scope, receive, send)
+
+    async def router_startup(self) -> None:
+        await self._app.router.startup()
+
+    @property
+    def router(self) -> Any:
+        return self._app.router
+
+
+class _StreamableHTTPASGIApp:
+    def __init__(self, session_manager: StreamableHTTPSessionManager) -> None:
+        self._session_manager = session_manager
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self._session_manager.handle_request(scope, receive, send)

--- a/gateway/stackchan_mcp/http_server.py
+++ b/gateway/stackchan_mcp/http_server.py
@@ -38,6 +38,8 @@ NON_LOOPBACK_TOKEN_REQUIRED_MESSAGE = (
 DISCONNECTED_DEVICE_PAYLOAD = {
     "error": "No ESP32 device connected. Please check the device."
 }
+SERVER_SHUTDOWN_ERROR_CODE = -32000
+SERVER_SHUTDOWN_ERROR_MESSAGE = "stackchan MCP HTTP server is shutting down"
 
 DispatchFn = Callable[[QueueItem], Awaitable[list[TextContent]]]
 
@@ -103,18 +105,16 @@ def build_app(
         json_response=True,
         stateless=False,
     )
-    _install_queue_tool_handler(server, queue=queue, gateway=gateway)
+    pending_items: dict[str, QueueItem] = {}
+    _install_queue_tool_handler(
+        server,
+        queue=queue,
+        gateway=gateway,
+        pending_items=pending_items,
+    )
 
     async def healthz(_request: Request) -> JSONResponse:
-        return JSONResponse(
-            {
-                "ok": True,
-                "esp32_connected": bool(gateway.esp32.device_connected),
-                "queue_depth": queue.depth,
-                "queue_capacity": queue.capacity,
-                "owner_id": owner_id,
-            }
-        )
+        return JSONResponse({"ok": True})
 
     async def status(_request: Request) -> JSONResponse:
         raw_status = gateway.esp32.get_status()
@@ -123,8 +123,10 @@ def build_app(
             status_payload["status"] = raw_status
         status_payload.update(
             {
+                "esp32_connected": bool(gateway.esp32.device_connected),
                 "queue_depth": queue.depth,
                 "queue_capacity": queue.capacity,
+                "owner_id": owner_id,
                 "connected_clients": _connected_client_count(session_manager),
             }
         )
@@ -135,7 +137,9 @@ def build_app(
         dispatcher_task: asyncio.Task[None] | None = None
         async with session_manager.run():
             if dispatch_fn is not None:
-                dispatcher_task = asyncio.create_task(queue.run_dispatcher(dispatch_fn))
+                dispatcher_task = asyncio.create_task(
+                    queue.run_dispatcher(_skip_done_dispatch(dispatch_fn))
+                )
             try:
                 yield
             finally:
@@ -143,6 +147,8 @@ def build_app(
                     dispatcher_task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await dispatcher_task
+                _complete_pending_items_for_shutdown(pending_items)
+                _drain_queued_items_for_shutdown(queue)
 
     routes = [
         Route(
@@ -169,6 +175,7 @@ def _install_queue_tool_handler(
     *,
     queue: CommandQueue,
     gateway: Any,
+    pending_items: dict[str, QueueItem],
 ) -> None:
     async def handler(req: CallToolRequest) -> ServerResult | ErrorData:
         tool_name = req.params.name
@@ -207,10 +214,62 @@ def _install_queue_tool_handler(
         except QueueFull as exc:
             return ErrorData(**build_queue_full_error(exc.queue_depth))
 
-        content = await response_future
-        return _tool_result(content)
+        pending_items[item.correlation_id] = item
+        try:
+            content_or_error = await response_future
+        except asyncio.CancelledError:
+            response_future.cancel()
+            raise
+        finally:
+            if response_future.done():
+                pending_items.pop(item.correlation_id, None)
+
+        if isinstance(content_or_error, ErrorData):
+            return content_or_error
+        return _tool_result(content_or_error)
 
     server.request_handlers[CallToolRequest] = handler
+
+
+def _skip_done_dispatch(dispatch_fn: DispatchFn) -> DispatchFn:
+    async def dispatch(item: QueueItem) -> list[TextContent]:
+        if item.response_future.done():
+            return []
+        return await dispatch_fn(item)
+
+    return dispatch
+
+
+def _complete_pending_items_for_shutdown(
+    pending_items: dict[str, QueueItem],
+) -> None:
+    for item in list(pending_items.values()):
+        _complete_item_with_shutdown_error(item)
+    pending_items.clear()
+
+
+def _drain_queued_items_for_shutdown(queue: CommandQueue) -> None:
+    raw_queue = getattr(queue, "_queue")
+    while True:
+        try:
+            item = raw_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return
+        _complete_item_with_shutdown_error(item)
+        raw_queue.task_done()
+
+
+def _complete_item_with_shutdown_error(item: QueueItem) -> None:
+    if not item.response_future.done():
+        item.response_future.set_result(_server_shutdown_error())
+
+
+def _server_shutdown_error() -> ErrorData:
+    return ErrorData(
+        code=SERVER_SHUTDOWN_ERROR_CODE,
+        message=SERVER_SHUTDOWN_ERROR_MESSAGE,
+        data={"reason": "server_shutdown"},
+    )
 
 
 def _tool_result(content: list[TextContent]) -> ServerResult:

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -50,6 +50,7 @@ SPEED_DESCRIPTION = """speed (optional): How fast to move the head.
   - Or a raw degrees-per-second integer if you need a specific value."""
 
 _active_session: Any | None = None
+_active_sessions: dict[int, Any] = {}
 
 
 class StackChanEventNotification(
@@ -60,6 +61,18 @@ class StackChanEventNotification(
 
 
 class StackChanServer(Server):
+    def create_initialization_options(
+        self,
+        notification_options: NotificationOptions | None = None,
+        experimental_capabilities: dict[str, dict[str, Any]] | None = None,
+    ) -> InitializationOptions:
+        if notification_options is None and experimental_capabilities is None:
+            return _create_initialization_options(self)
+        return super().create_initialization_options(
+            notification_options=notification_options,
+            experimental_capabilities=experimental_capabilities,
+        )
+
     async def run(
         self,
         read_stream: Any,
@@ -69,6 +82,7 @@ class StackChanServer(Server):
         stateless: bool = False,
     ) -> None:
         global _active_session
+        session: Any | None = None
         try:
             async with AsyncExitStack() as stack:
                 lifespan_context = await stack.enter_async_context(self.lifespan(self))
@@ -81,6 +95,7 @@ class StackChanServer(Server):
                     )
                 )
                 _active_session = session
+                _active_sessions[id(session)] = session
 
                 task_support = (
                     self._experimental_handlers.task_support
@@ -105,7 +120,9 @@ class StackChanServer(Server):
                     finally:
                         tg.cancel_scope.cancel()
         finally:
-            _active_session = None
+            if session is not None:
+                _active_sessions.pop(id(session), None)
+            _active_session = _latest_active_session()
 
     async def _handle_message(
         self,
@@ -116,12 +133,19 @@ class StackChanServer(Server):
     ) -> None:
         global _active_session
         _active_session = session
+        _active_sessions[id(session)] = session
         await super()._handle_message(
             message,
             session,
             lifespan_context,
             raise_exceptions,
-        )
+    )
+
+
+def _latest_active_session() -> Any | None:
+    if not _active_sessions:
+        return None
+    return next(reversed(_active_sessions.values()))
 
 
 async def notify_stackchan_event(method: str, params: dict[str, Any]) -> None:
@@ -130,16 +154,19 @@ async def notify_stackchan_event(method: str, params: dict[str, Any]) -> None:
         logger.warning("Unsupported stackchan event notification method: %s", method)
         return
 
-    session = _active_session
-    if session is None:
+    sessions = list(_active_sessions.values())
+    if not sessions and _active_session is not None:
+        sessions = [_active_session]
+    if not sessions:
         logger.warning("Cannot emit stackchan/event notification: no active MCP session")
         return
 
     notification = StackChanEventNotification(params=params)
-    try:
-        await session.send_notification(cast(Any, notification))
-    except Exception as exc:  # pragma: no cover - depends on client transport failure
-        logger.warning("Failed to emit stackchan/event notification: %s", exc)
+    for session in sessions:
+        try:
+            await session.send_notification(cast(Any, notification))
+        except Exception as exc:  # pragma: no cover - depends on client transport failure
+            logger.warning("Failed to emit stackchan/event notification: %s", exc)
 
 
 def _create_initialization_options(server: Server) -> InitializationOptions:
@@ -237,6 +264,264 @@ def _resolve_speed_dps(speed: Any) -> int | None:
     raise TypeError(
         f"speed must be 'low' / 'mid' / 'high' / int / None, got {type(speed).__name__}"
     )
+
+
+async def _dispatch_mcp_tool(
+    name: str,
+    arguments: dict[str, Any],
+    gateway: Any,
+) -> list[TextContent]:
+    """Run one StackChan MCP tool against the provided gateway instance."""
+    if name == "get_status":
+        status = gateway.esp32.get_status()
+        return [TextContent(type="text", text=json.dumps(status, indent=2))]
+
+    if name == "say":
+        try:
+            result = await synthesize_and_send(arguments, gateway=gateway)
+        except (ValueError, NotImplementedError, RuntimeError) as exc:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps({"error": str(exc)}),
+                )
+            ]
+        return [TextContent(type="text", text=json.dumps(result))]
+
+    if name == "listen":
+        try:
+            result = await listen_and_transcribe(arguments, gateway=gateway)
+        except (ValueError, NotImplementedError, RuntimeError) as exc:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps({"error": str(exc)}),
+                )
+            ]
+        return [TextContent(type="text", text=json.dumps(result))]
+
+    if name == "load_avatar_set":
+        archive_path = arguments.get("archive_path", "")
+        mode = arguments.get("mode", "")
+        try:
+            timeout = float(arguments.get("timeout", 60.0))
+        except (TypeError, ValueError):
+            timeout = 60.0
+        if not archive_path or not isinstance(archive_path, str):
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {"ok": False, "error": "archive_path is required"}
+                    ),
+                )
+            ]
+        if mode not in ("layered", "matrix"):
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps({"ok": False, "error": f"unknown mode: {mode}"}),
+                )
+            ]
+        result = await gateway.load_avatar_set(archive_path, mode, timeout)
+        return [TextContent(type="text", text=json.dumps(result))]
+
+    if not gateway.esp32.device_connected:
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {"error": "No ESP32 device connected. Please check the device."}
+                ),
+            )
+        ]
+
+    if name == "move_head":
+        yaw_val = arguments.get("yaw")
+        pitch_val = arguments.get("pitch")
+        if (
+            not isinstance(yaw_val, int)
+            or isinstance(yaw_val, bool)
+            or not (-90 <= yaw_val <= 90)
+        ):
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "error": (
+                                "yaw must be an integer in -90..90 "
+                                f"(got {yaw_val!r})"
+                            )
+                        }
+                    ),
+                )
+            ]
+        if (
+            not isinstance(pitch_val, int)
+            or isinstance(pitch_val, bool)
+            or not (5 <= pitch_val <= 85)
+        ):
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "error": (
+                                "pitch must be an integer in 5..85 "
+                                "(M5Stack-recommended operating range; "
+                                "for the wider firmware hard clamp "
+                                "0..88 use `set_head_angles`). got "
+                                f"{pitch_val!r}"
+                            )
+                        }
+                    ),
+                )
+            ]
+        try:
+            speed_dps = _resolve_speed_dps(arguments.get("speed"))
+        except (TypeError, ValueError) as exc:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps({"error": str(exc)}),
+                )
+            ]
+        arguments = {"yaw": yaw_val, "pitch": pitch_val}
+        if speed_dps is not None:
+            arguments["speed_dps"] = speed_dps
+
+    tool_map: dict[str, tuple[str, dict[str, Any]]] = {
+        "get_device_info": (
+            "self.get_device_status",
+            {},
+        ),
+        "take_photo": (
+            "self.camera.take_photo",
+            arguments,
+        ),
+        "set_volume": (
+            "self.audio_speaker.set_volume",
+            arguments,
+        ),
+        "set_brightness": (
+            "self.screen.set_brightness",
+            arguments,
+        ),
+        "move_head": (
+            "self.robot.set_head_angles",
+            arguments,
+        ),
+        "get_head_angles": (
+            "self.robot.get_head_angles",
+            {},
+        ),
+        "gpio_test": (
+            "self.robot.gpio_test",
+            {},
+        ),
+        "uart_diag": (
+            "self.robot.uart_diag",
+            {},
+        ),
+        "check_vm_en": (
+            "self.robot.check_vm_en",
+            {},
+        ),
+        "set_avatar": (
+            "self.display.set_avatar",
+            arguments,
+        ),
+        "set_mouth": (
+            "self.display.set_mouth",
+            arguments,
+        ),
+        "set_mouth_sequence": (
+            "self.display.set_mouth_sequence",
+            {"steps_json": json.dumps(arguments.get("steps", []))},
+        ),
+        "set_blink": (
+            "self.display.set_blink",
+            arguments,
+        ),
+        "set_servo_torque": (
+            "self.robot.set_servo_torque",
+            arguments,
+        ),
+        "set_auto_torque_release": (
+            "self.robot.set_auto_torque_release",
+            arguments,
+        ),
+        "get_touch_state": (
+            "self.touch.get_touch_state",
+            {},
+        ),
+        "set_led": (
+            "self.led.set_color",
+            arguments,
+        ),
+        "set_all_leds": (
+            "self.led.set_all",
+            arguments,
+        ),
+        "set_leds": (
+            "self.led.set_many",
+            {"colors": json.dumps(arguments.get("colors", []))},
+        ),
+        "clear_leds": (
+            "self.led.clear",
+            {},
+        ),
+        "i2c_scan": (
+            "self.i2c.scan",
+            {},
+        ),
+        "i2c_read": (
+            "self.i2c.read",
+            arguments,
+        ),
+        "i2c_write": (
+            "self.i2c.write",
+            arguments,
+        ),
+        "i2c_write_read": (
+            "self.i2c.write_read",
+            arguments,
+        ),
+    }
+
+    if name not in tool_map:
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps({"error": f"Unknown tool: {name}"}),
+            )
+        ]
+
+    esp32_name, esp32_args = tool_map[name]
+    result, error = await gateway.esp32.call_tool(esp32_name, esp32_args)
+
+    if error:
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps({"error": error.get("message", str(error))}),
+            )
+        ]
+
+    if isinstance(result, dict):
+        content = result.get("content", [])
+        if content and isinstance(content, list):
+            texts = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    texts.append(item.get("text", ""))
+            if texts:
+                return [TextContent(type="text", text="\n".join(texts))]
+
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    return [TextContent(type="text", text=str(result))]
 
 
 def create_server() -> Server:
@@ -994,291 +1279,7 @@ def create_server() -> Server:
     async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextContent]:
         """Handle a tool call by relaying to ESP32."""
         arguments = arguments or {}
-        gw = get_gateway()
-
-        if name == "get_status":
-            # get_status is handled locally — no ESP32 needed
-            status = gw.esp32.get_status()
-            return [TextContent(type="text", text=json.dumps(status, indent=2))]
-
-        if name == "say":
-            # TTS runs on the gateway side. The orchestrator validates
-            # arguments, looks up an engine, synthesises PCM, encodes
-            # Opus, and pushes frames through the WebSocket binary
-            # channel that the device's audio decoder consumes. Errors
-            # are surfaced as clean MCP error JSON rather than letting
-            # tracebacks leak into the agent's transcript.
-            try:
-                result = await synthesize_and_send(arguments, gateway=gw)
-            except (ValueError, NotImplementedError, RuntimeError) as exc:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": str(exc)}),
-                    )
-                ]
-            return [TextContent(type="text", text=json.dumps(result))]
-
-        if name == "listen":
-            # STT runs on the gateway side. The orchestrator drives the
-            # device's listening state via ``listen.start``/``stop``
-            # notifications, buffers the inbound Opus frames, decodes
-            # them, and hands the PCM blob to the registered engine.
-            # Same error-class discipline as say(): ValueError /
-            # NotImplementedError / RuntimeError all turn into clean
-            # MCP error JSON.
-            try:
-                result = await listen_and_transcribe(arguments, gateway=gw)
-            except (ValueError, NotImplementedError, RuntimeError) as exc:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": str(exc)}),
-                    )
-                ]
-            return [TextContent(type="text", text=json.dumps(result))]
-
-        if name == "load_avatar_set":
-            # Phase 4.5 avatar: stage the raw RGB565 payload and notify
-            # the device via WS avatar_set_fetch; the device performs the
-            # HTTP fetch + SHA256 verify + AvatarSet::Load and replies
-            # with avatar_set_loaded. All orchestration lives in
-            # Gateway.load_avatar_set; this branch is a thin wrapper that
-            # parses arguments and returns the dict-result as MCP JSON.
-            archive_path = arguments.get("archive_path", "")
-            mode = arguments.get("mode", "")
-            try:
-                timeout = float(arguments.get("timeout", 60.0))
-            except (TypeError, ValueError):
-                timeout = 60.0
-            if not archive_path or not isinstance(archive_path, str):
-                return [TextContent(
-                    type="text",
-                    text=json.dumps({"ok": False, "error": "archive_path is required"}),
-                )]
-            if mode not in ("layered", "matrix"):
-                return [TextContent(
-                    type="text",
-                    text=json.dumps({"ok": False, "error": f"unknown mode: {mode}"}),
-                )]
-            result = await gw.load_avatar_set(archive_path, mode, timeout)
-            return [TextContent(type="text", text=json.dumps(result))]
-
-        if not gw.esp32.device_connected:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({"error": "No ESP32 device connected. Please check the device."}),
-                )
-            ]
-
-        if name == "move_head":
-            # Belt-and-suspenders validation for the recommended pitch range.
-            # The Tool inputSchema already declares minimum/maximum for both
-            # yaw and pitch, but mcp Python SDK server-side enforcement of
-            # JSON Schema bounds is not guaranteed across versions and
-            # clients. Reject out-of-recommended values here as a clean
-            # MCP error JSON before any motion command reaches the device.
-            # Callers that genuinely need the firmware hard clamp 0..88
-            # should use the firmware-side `set_head_angles` device tool,
-            # which exposes the authoritative two-tier guard described in
-            # the README "Y-axis (pitch) safe range" section.
-            yaw_val = arguments.get("yaw")
-            pitch_val = arguments.get("pitch")
-            if (
-                not isinstance(yaw_val, int)
-                or isinstance(yaw_val, bool)
-                or not (-90 <= yaw_val <= 90)
-            ):
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "error": (
-                                    "yaw must be an integer in -90..90 "
-                                    f"(got {yaw_val!r})"
-                                )
-                            }
-                        ),
-                    )
-                ]
-            if (
-                not isinstance(pitch_val, int)
-                or isinstance(pitch_val, bool)
-                or not (5 <= pitch_val <= 85)
-            ):
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "error": (
-                                    "pitch must be an integer in 5..85 "
-                                    "(M5Stack-recommended operating range; "
-                                    "for the wider firmware hard clamp "
-                                    "0..88 use `set_head_angles`). got "
-                                    f"{pitch_val!r}"
-                                )
-                            }
-                        ),
-                    )
-                ]
-            try:
-                speed_dps = _resolve_speed_dps(arguments.get("speed"))
-            except (TypeError, ValueError) as exc:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": str(exc)}),
-                    )
-                ]
-            arguments = {"yaw": yaw_val, "pitch": pitch_val}
-            if speed_dps is not None:
-                arguments["speed_dps"] = speed_dps
-
-        # Map MCP client tool names to ESP32 MCP tool names (self.* prefix)
-        tool_map: dict[str, tuple[str, dict[str, Any]]] = {
-            "get_device_info": (
-                "self.get_device_status",
-                {},
-            ),
-            "take_photo": (
-                "self.camera.take_photo",
-                arguments,
-            ),
-            "set_volume": (
-                "self.audio_speaker.set_volume",
-                arguments,
-            ),
-            "set_brightness": (
-                "self.screen.set_brightness",
-                arguments,
-            ),
-            "move_head": (
-                "self.robot.set_head_angles",
-                arguments,
-            ),
-            "get_head_angles": (
-                "self.robot.get_head_angles",
-                {},
-            ),
-            "gpio_test": (
-                "self.robot.gpio_test",
-                {},
-            ),
-            "uart_diag": (
-                "self.robot.uart_diag",
-                {},
-            ),
-            "check_vm_en": (
-                "self.robot.check_vm_en",
-                {},
-            ),
-            "set_avatar": (
-                "self.display.set_avatar",
-                arguments,
-            ),
-            "set_mouth": (
-                "self.display.set_mouth",
-                arguments,
-            ),
-            # The MCP Property type system on ESP32 only supports
-            # string/integer/boolean, so we serialise the steps array to
-            # a JSON string here. The firmware decodes it via cJSON.
-            "set_mouth_sequence": (
-                "self.display.set_mouth_sequence",
-                {"steps_json": json.dumps(arguments.get("steps", []))},
-            ),
-            "set_blink": (
-                "self.display.set_blink",
-                arguments,
-            ),
-            "set_servo_torque": (
-                "self.robot.set_servo_torque",
-                arguments,
-            ),
-            "set_auto_torque_release": (
-                "self.robot.set_auto_torque_release",
-                arguments,
-            ),
-            "get_touch_state": (
-                "self.touch.get_touch_state",
-                {},
-            ),
-            "set_led": (
-                "self.led.set_color",
-                arguments,
-            ),
-            "set_all_leds": (
-                "self.led.set_all",
-                arguments,
-            ),
-            # Firmware accepts colors as a JSON-encoded string (the on-device
-            # MCP layer has no array property type), so re-pack the Python
-            # list here. The schema we exposed above still lets the LLM
-            # think in real arrays.
-            "set_leds": (
-                "self.led.set_many",
-                {"colors": json.dumps(arguments.get("colors", []))},
-            ),
-            "clear_leds": (
-                "self.led.clear",
-                {},
-            ),
-            "i2c_scan": (
-                "self.i2c.scan",
-                {},
-            ),
-            "i2c_read": (
-                "self.i2c.read",
-                arguments,
-            ),
-            "i2c_write": (
-                "self.i2c.write",
-                arguments,
-            ),
-            "i2c_write_read": (
-                "self.i2c.write_read",
-                arguments,
-            ),
-        }
-
-        if name not in tool_map:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({"error": f"Unknown tool: {name}"}),
-                )
-            ]
-
-        esp32_name, esp32_args = tool_map[name]
-        result, error = await gw.esp32.call_tool(esp32_name, esp32_args)
-
-        if error:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({"error": error.get("message", str(error))}),
-                )
-            ]
-
-        # result from ESP32 is MCP format: {"content": [...], "isError": bool}
-        if isinstance(result, dict):
-            content = result.get("content", [])
-            if content and isinstance(content, list):
-                # Pass through content items as text
-                texts = []
-                for item in content:
-                    if isinstance(item, dict) and item.get("type") == "text":
-                        texts.append(item.get("text", ""))
-                if texts:
-                    return [TextContent(type="text", text="\n".join(texts))]
-
-            # Fallback: dump entire result
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        return [TextContent(type="text", text=str(result))]
+        return await _dispatch_mcp_tool(name, arguments, get_gateway())
 
     return server
 

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -40,6 +40,9 @@ _PREFLIGHT_ENV_VARS = (
     # already export ``PORT``.
     "PORT",
     "CAPTURE_PORT",
+    "MCP_HTTP_HOST",
+    "MCP_HTTP_PORT",
+    "MCP_HTTP_ALLOWED_HOSTS",
 )
 
 
@@ -59,6 +62,15 @@ def _isolate_preflight_env(
     monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
     for var in _PREFLIGHT_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
+
+
+def _fake_lock_info() -> dict[str, object]:
+    return {
+        "owner_id": "test-owner",
+        "pid": 123,
+        "start_ts": "2026-06-05T00:00:00Z",
+        "host": "test-host",
+    }
 
 
 def test_arg_parser_help_long_flag(capsys: pytest.CaptureFixture[str]) -> None:
@@ -166,14 +178,18 @@ def test_arg_parser_no_mdns_defaults_to_false() -> None:
 
 
 def test_main_default_advertises_mdns(monkeypatch: pytest.MonkeyPatch) -> None:
+    from stackchan_mcp import ownership
+
     called: dict[str, bool] = {}
 
     async def fake_run(*, advertise_mdns: bool = True) -> None:
         called["advertise_mdns"] = advertise_mdns
 
+    monkeypatch.setattr(cli, "_prepare_stdio_startup", _fake_lock_info)
     monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
     monkeypatch.setattr(cli, "_ensure_libopus_findable", lambda: None)
     monkeypatch.setattr(cli, "_run", fake_run)
+    monkeypatch.setattr(ownership, "release_lock_if_owner", lambda info: True)
 
     main([])
 
@@ -183,14 +199,18 @@ def test_main_default_advertises_mdns(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_main_no_mdns_disables_advertisement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from stackchan_mcp import ownership
+
     called: dict[str, bool] = {}
 
     async def fake_run(*, advertise_mdns: bool = True) -> None:
         called["advertise_mdns"] = advertise_mdns
 
+    monkeypatch.setattr(cli, "_prepare_stdio_startup", _fake_lock_info)
     monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
     monkeypatch.setattr(cli, "_ensure_libopus_findable", lambda: None)
     monkeypatch.setattr(cli, "_run", fake_run)
+    monkeypatch.setattr(ownership, "release_lock_if_owner", lambda info: True)
 
     main(["--no-mdns"])
 
@@ -251,6 +271,84 @@ def test_main_check_flag_remains_side_effect_free_with_no_mdns(
         main(["--check", "--no-mdns"])
 
     assert exc.value.code == 0
+
+
+def test_streamable_http_refuses_non_loopback_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("MCP_HTTP_HOST", "0.0.0.0")
+
+    def fail_acquire(**kwargs: object) -> object:
+        raise AssertionError("bind safety must run before ownership lock")
+
+    monkeypatch.setattr(cli, "_acquire_startup_lock", fail_acquire)
+
+    with pytest.raises(SystemExit) as exc:
+        main(["serve", "--transport", "streamable-http"])
+
+    assert exc.value.code == 1
+    assert (
+        "stackchan-mcp: refusing non-loopback MCP_HTTP_HOST without "
+        "STACKCHAN_TOKEN or BEARER_TOKEN"
+    ) in capsys.readouterr().err
+
+
+def test_streamable_http_releases_lock_after_daemon_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from stackchan_mcp import ownership
+
+    info = {
+        "owner_id": "owner-test",
+        "pid": 123,
+        "start_ts": "2026-06-05T00:00:00Z",
+        "host": "test-host",
+        "mode": "streamable-http",
+        "http_endpoint": "127.0.0.1:8767",
+        "started_by": "cli-serve",
+    }
+    acquired: list[dict[str, object]] = []
+    released: list[object] = []
+    daemon_kwargs: list[dict[str, object]] = []
+
+    def fake_acquire(**kwargs: object) -> dict[str, object]:
+        acquired.append(kwargs)
+        return info
+
+    async def fake_daemon(**kwargs: object) -> None:
+        daemon_kwargs.append(kwargs)
+
+    monkeypatch.setattr(cli, "_configure_gateway_startup", lambda: None)
+    monkeypatch.setattr(cli, "_acquire_startup_lock", fake_acquire)
+    monkeypatch.setattr(cli, "_run_streamable_http_daemon", fake_daemon)
+    monkeypatch.setattr(ownership, "release_lock_if_owner", released.append)
+    monkeypatch.delenv("MCP_HTTP_HOST", raising=False)
+    monkeypatch.delenv("MCP_HTTP_PORT", raising=False)
+    monkeypatch.delenv("STACKCHAN_TOKEN", raising=False)
+    monkeypatch.delenv("BEARER_TOKEN", raising=False)
+
+    cli._run_streamable_http_placeholder(advertise_mdns=False)
+
+    assert acquired == [
+        {
+            "mode": "streamable-http",
+            "http_endpoint": "127.0.0.1:8767",
+            "started_by": "cli-serve",
+        }
+    ]
+    assert daemon_kwargs == [
+        {
+            "host": "127.0.0.1",
+            "port": 8767,
+            "owner_id": "owner-test",
+            "token": None,
+            "advertise_mdns": False,
+        }
+    ]
+    assert released == [info]
 
 
 def test_format_port_status_available() -> None:
@@ -396,11 +494,13 @@ def test_run_preflight_with_no_config_reports_defaults_and_exits_zero(
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "STACKCHAN_TOKEN     not set" in out
+    assert "MCP_HTTP_ALLOWED_HOSTS not set" in out
     assert "VISION_HOST         not set" in out
     assert "VISION_URL          not set" in out
     assert "VISION_TOKEN        not set" in out
     assert "ws://0.0.0.0:8765" in out
     assert "http://0.0.0.0:8766" in out
+    assert "http://127.0.0.1:8767/mcp" in out
     assert "AVAILABLE" in out
     assert "Result: ready. Exit 0." in out
 
@@ -552,7 +652,8 @@ def test_run_preflight_in_use_ports_return_nonzero(
     out = capsys.readouterr().out
     assert "IN USE (pid 12345, mock-8765)" in out
     assert "IN USE (pid 12345, mock-8766)" in out
-    assert "Result: 2 issues. Exit 1." in out
+    assert "IN USE (pid 12345, mock-8767)" in out
+    assert "Result: 3 issues. Exit 1." in out
 
 
 def test_run_preflight_one_in_use_port_singular_phrasing(
@@ -576,26 +677,39 @@ def test_run_preflight_one_in_use_port_singular_phrasing(
     assert "Result: 1 issue. Exit 1." in out
 
 
-def test_main_check_flag_runs_preflight_and_exits(
+def test_main_check_flag_runs_ownership_check_and_exits(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    """``main(['--check'])`` exits with the preflight return code.
+    """``main(['--check'])`` exits after the ownership check.
 
-    Guards the contract that ``--check`` never reaches the asyncio
-    gateway start-up below the early exit, by relying on ``main`` to
-    propagate ``_run_preflight``'s return as ``SystemExit``.
+    Guards the contract that ``--check`` never reaches gateway startup
+    or the port/config preflight path below the early exit.
     """
+    from stackchan_mcp import ownership
+
     _isolate_preflight_env(monkeypatch, tmp_path)
-    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+    monkeypatch.setattr(cli, "_run_preflight", lambda: 99)
+    monkeypatch.setattr(ownership, "read_lock", lambda: None)
 
     with pytest.raises(SystemExit) as exc:
         main(["--check"])
     assert exc.value.code == 0
     out = capsys.readouterr().out
-    assert "preflight" in out
+    assert "ownership preflight" in out
     assert "Result: ready" in out
+
+
+def test_main_preflight_flag_runs_preflight_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "_run_preflight", lambda: 7)
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--preflight"])
+
+    assert exc.value.code == 7
 
 
 # --- Port resolution tests (must mirror gateway.py) -------------------------
@@ -765,6 +879,56 @@ def test_run_preflight_invalid_capture_port_is_blocking(
     assert "CAPTURE_PORT" in out
 
 
+def test_run_preflight_invalid_mcp_http_port_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("MCP_HTTP_PORT", "not-a-number")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "INVALID" in out
+    assert "MCP_HTTP_PORT" in out
+
+
+def test_run_preflight_non_loopback_mcp_http_without_token_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("MCP_HTTP_HOST", "0.0.0.0")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "MCP HTTP bind safety: BLOCKED" in out
+    assert "Result: 1 issue. Exit 1." in out
+
+
+def test_run_preflight_non_loopback_mcp_http_with_token_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("MCP_HTTP_HOST", "0.0.0.0")
+    monkeypatch.setenv("STACKCHAN_TOKEN", "secret")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "MCP HTTP bind safety: BLOCKED" not in out
+    assert "http://0.0.0.0:8767/mcp" in out
+    assert "Result: ready. Exit 0." in out
+
+
 def test_run_preflight_uses_PORT_fallback_for_ws_port(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -810,6 +974,24 @@ def test_run_preflight_ws_and_capture_same_port_is_conflict(
     out = capsys.readouterr().out
     assert "8765" in out
     assert "distinct ports" in out
+
+
+def test_run_preflight_mcp_http_port_conflict_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("CAPTURE_PORT", "8767")
+    monkeypatch.setenv("MCP_HTTP_PORT", "8767")
+    monkeypatch.setattr(cli, "_check_port", lambda host, port: (True, None))
+
+    exit_code = _run_preflight()
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "MCP_HTTP_PORT" in out
+    assert "CAPTURE_PORT" in out
+    assert "distinct listener ports" in out
 
 
 def test_run_preflight_both_ports_zero_is_not_a_conflict(

--- a/gateway/tests/test_http_server.py
+++ b/gateway/tests/test_http_server.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+from mcp.server.streamable_http import MCP_SESSION_ID_HEADER
+from mcp.types import TextContent
+
+from stackchan_mcp.http_server import (
+    AUTH_FAILURE_MESSAGE,
+    BYPASS_TOOLS,
+    DISCONNECTED_DEVICE_PAYLOAD,
+    HOST_FAILURE_MESSAGE,
+    ORIGIN_FAILURE_MESSAGE,
+    MCP_HTTP_ALLOWED_HOSTS_ENV,
+    build_app,
+    make_dispatch_fn,
+)
+from stackchan_mcp.queue import CommandQueue, QueueFull, QueueItem, build_queue_full_error
+
+
+class FakeESP32:
+    def __init__(self, *, connected: bool = True) -> None:
+        self.device_connected = connected
+        self.calls: list[tuple[str, dict]] = []
+
+    def get_status(self) -> dict:
+        return {
+            "connected": self.device_connected,
+            "device": "fake-stackchan",
+        }
+
+    async def call_tool(self, name: str, arguments: dict) -> tuple[dict, None]:
+        self.calls.append((name, arguments))
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps({"name": name, "arguments": arguments}),
+                }
+            ],
+        }, None
+
+
+class FakeGateway:
+    def __init__(self, *, connected: bool = True) -> None:
+        self.esp32 = FakeESP32(connected=connected)
+
+
+@contextlib.asynccontextmanager
+async def _client(app, *, base_url: str = "http://127.0.0.1:8767") -> AsyncIterator[httpx.AsyncClient]:
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url=base_url) as client:
+            yield client
+
+
+def _headers(session_id: str | None = None, token: str | None = None) -> dict[str, str]:
+    headers = {"accept": "application/json"}
+    if session_id is not None:
+        headers[MCP_SESSION_ID_HEADER] = session_id
+    if token is not None:
+        headers["authorization"] = f"Bearer {token}"
+    return headers
+
+
+async def _initialize(client: httpx.AsyncClient, *, token: str | None = None, request_id: int = 1) -> str:
+    response = await client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        },
+        headers=_headers(token=token),
+    )
+    assert response.status_code == 200
+    session_id = response.headers[MCP_SESSION_ID_HEADER]
+    initialized = await client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers=_headers(session_id, token),
+    )
+    assert initialized.status_code == 202
+    return session_id
+
+
+async def _call_tool(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    name: str,
+    arguments: dict | None = None,
+    request_id: int | str = 2,
+    token: str | None = None,
+) -> httpx.Response:
+    return await client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        },
+        headers=_headers(session_id, token),
+    )
+
+
+async def _wait_for_queue_depth(queue: CommandQueue, depth: int) -> None:
+    for _ in range(50):
+        if queue.depth == depth:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"queue depth did not reach {depth}")
+
+
+@pytest.mark.asyncio
+async def test_queue_ordering_fifo_completion() -> None:
+    queue = CommandQueue(capacity=3)
+    observed: list[str] = []
+    loop = asyncio.get_running_loop()
+    futures = [loop.create_future() for _ in range(3)]
+
+    for index, future in enumerate(futures):
+        queue.enqueue(
+            QueueItem(
+                correlation_id=f"item-{index}",
+                client_session_id=None,
+                client_request_id=index,
+                tool_name=f"tool-{index}",
+                arguments={},
+                response_future=future,
+                enqueued_at=0.0,
+            )
+        )
+
+    async def dispatch(item: QueueItem) -> str:
+        observed.append(item.tool_name)
+        return item.tool_name
+
+    dispatcher = asyncio.create_task(queue.run_dispatcher(dispatch))
+    try:
+        results = await asyncio.gather(*futures)
+    finally:
+        dispatcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatcher
+
+    assert observed == ["tool-0", "tool-1", "tool-2"]
+    assert results == observed
+
+
+@pytest.mark.asyncio
+async def test_queue_full_returns_jsonrpc_error_response() -> None:
+    queue = CommandQueue(capacity=1)
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+    )
+
+    async with _client(app) as client:
+        session_id = await _initialize(client)
+        first = asyncio.create_task(
+            _call_tool(client, session_id=session_id, name="get_device_info", request_id=10)
+        )
+        await _wait_for_queue_depth(queue, 1)
+        second = await _call_tool(
+            client,
+            session_id=session_id,
+            name="get_head_angles",
+            request_id=11,
+        )
+        first.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await first
+
+    assert second.status_code == 200
+    payload = second.json()
+    assert payload["id"] == 11
+    assert payload["error"] == build_queue_full_error(1)
+
+
+@pytest.mark.asyncio
+async def test_auth_rejection_and_successful_bearer_reaches_dispatcher() -> None:
+    queue = CommandQueue(capacity=4)
+    dispatched: list[str] = []
+
+    async def dispatch(item: QueueItem):
+        dispatched.append(item.tool_name)
+        return [TextContent(type="text", text=json.dumps({"ok": True}))]
+
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        token="secret",
+        dispatch_fn=dispatch,
+    )
+
+    async with _client(app) as client:
+        missing = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers=_headers(),
+        )
+        wrong = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers=_headers(token="wrong"),
+        )
+        session_id = await _initialize(client, token="secret")
+        ok = await _call_tool(
+            client,
+            session_id=session_id,
+            token="secret",
+            name="get_device_info",
+        )
+
+    assert missing.status_code == 401
+    assert missing.text == AUTH_FAILURE_MESSAGE
+    assert wrong.status_code == 401
+    assert ok.status_code == 200
+    assert dispatched == ["get_device_info"]
+
+
+@pytest.mark.asyncio
+async def test_host_and_origin_rebinding_guards_return_403() -> None:
+    app = build_app(
+        CommandQueue(capacity=2),
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+    )
+
+    async with _client(app) as client:
+        bad_host = await client.get(
+            "/healthz",
+            headers={"host": "evil.example:8767"},
+        )
+        bad_origin = await client.get(
+            "/healthz",
+            headers={"origin": "http://evil.example:8767"},
+        )
+
+    assert bad_host.status_code == 403
+    assert bad_host.text == HOST_FAILURE_MESSAGE
+    assert bad_origin.status_code == 403
+    assert bad_origin.text == ORIGIN_FAILURE_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_wildcard_bind_allows_loopback_and_configured_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        MCP_HTTP_ALLOWED_HOSTS_ENV,
+        "192.168.1.10, https://stackchan.example.test:9443",
+    )
+    app = build_app(
+        CommandQueue(capacity=2),
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="0.0.0.0",
+        port=8767,
+    )
+
+    async with _client(app) as client:
+        loopback = await client.get("/healthz", headers={"host": "127.0.0.1:8767"})
+        lan = await client.get("/healthz", headers={"host": "192.168.1.10:8767"})
+        origin = await client.get(
+            "/healthz",
+            headers={
+                "host": "stackchan.example.test:9443",
+                "origin": "https://stackchan.example.test:9443",
+            },
+        )
+
+    assert loopback.status_code == 200
+    assert lan.status_code == 200
+    assert origin.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_response_correlation_for_two_concurrent_clients() -> None:
+    queue = CommandQueue(capacity=4)
+
+    async def dispatch(item: QueueItem):
+        await asyncio.sleep(0.01)
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "client_request_id": item.client_request_id,
+                        "tool_name": item.tool_name,
+                    }
+                ),
+            )
+        ]
+
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        dispatch_fn=dispatch,
+    )
+
+    async with _client(app) as client:
+        session_a = await _initialize(client, request_id=1)
+        session_b = await _initialize(client, request_id=2)
+        response_a, response_b = await asyncio.gather(
+            _call_tool(
+                client,
+                session_id=session_a,
+                name="get_device_info",
+                request_id="client-a",
+            ),
+            _call_tool(
+                client,
+                session_id=session_b,
+                name="get_head_angles",
+                request_id="client-b",
+            ),
+        )
+
+    payload_a = response_a.json()
+    payload_b = response_b.json()
+    assert payload_a["id"] == "client-a"
+    assert payload_b["id"] == "client-b"
+    body_a = json.loads(payload_a["result"]["content"][0]["text"])
+    body_b = json.loads(payload_b["result"]["content"][0]["text"])
+    assert body_a["client_request_id"] == "client-a"
+    assert body_b["client_request_id"] == "client-b"
+
+
+@pytest.mark.asyncio
+async def test_bypass_tool_get_status_does_not_enter_dispatcher() -> None:
+    assert BYPASS_TOOLS == frozenset({"get_status"})
+    queue = CommandQueue(capacity=2)
+
+    async def dispatch(_item: QueueItem):
+        raise AssertionError("get_status must bypass the command queue")
+
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        dispatch_fn=dispatch,
+    )
+
+    async with _client(app) as client:
+        session_id = await _initialize(client)
+        response = await _call_tool(client, session_id=session_id, name="get_status")
+
+    payload = response.json()
+    status = json.loads(payload["result"]["content"][0]["text"])
+    assert status["connected"] is True
+    assert queue.depth == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_returns_stdio_disconnect_payload_as_tool_result() -> None:
+    queue = CommandQueue(capacity=2)
+    gateway = FakeGateway(connected=False)
+    app = build_app(
+        queue,
+        gateway=gateway,
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        dispatch_fn=make_dispatch_fn(gateway),
+    )
+
+    async with _client(app) as client:
+        session_id = await _initialize(client)
+        response = await _call_tool(
+            client,
+            session_id=session_id,
+            name="get_device_info",
+        )
+
+    payload = response.json()
+    assert "error" not in payload
+    result_text = payload["result"]["content"][0]["text"]
+    assert json.loads(result_text) == DISCONNECTED_DEVICE_PAYLOAD
+
+
+@pytest.mark.asyncio
+async def test_healthz_and_status_shapes() -> None:
+    queue = CommandQueue(capacity=2)
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+    )
+
+    async with _client(app) as client:
+        health = await client.get("/healthz")
+        status = await client.get("/status")
+
+    assert health.json() == {
+        "ok": True,
+        "esp32_connected": True,
+        "queue_depth": 0,
+        "queue_capacity": 2,
+        "owner_id": "owner-test",
+    }
+    assert status.json()["connected"] is True
+    assert status.json()["queue_depth"] == 0
+    assert status.json()["connected_clients"] == 0
+
+
+@pytest.mark.asyncio
+async def test_command_queue_raises_queue_full_directly() -> None:
+    queue = CommandQueue(capacity=1)
+    loop = asyncio.get_running_loop()
+    queue.enqueue(
+        QueueItem(
+            correlation_id="first",
+            client_session_id=None,
+            client_request_id=1,
+            tool_name="get_device_info",
+            arguments={},
+            response_future=loop.create_future(),
+            enqueued_at=0.0,
+        )
+    )
+    with pytest.raises(QueueFull):
+        queue.enqueue(
+            QueueItem(
+                correlation_id="second",
+                client_session_id=None,
+                client_request_id=2,
+                tool_name="get_head_angles",
+                arguments={},
+                response_future=loop.create_future(),
+                enqueued_at=0.0,
+            )
+        )

--- a/gateway/tests/test_http_server.py
+++ b/gateway/tests/test_http_server.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 import httpx
 import pytest
 from mcp.server.streamable_http import MCP_SESSION_ID_HEADER
-from mcp.types import TextContent
+from mcp.types import ErrorData, TextContent
 
 from stackchan_mcp.http_server import (
     AUTH_FAILURE_MESSAGE,
@@ -123,6 +123,26 @@ async def _wait_for_queue_depth(queue: CommandQueue, depth: int) -> None:
     raise AssertionError(f"queue depth did not reach {depth}")
 
 
+class GatedCommandQueue(CommandQueue):
+    def __init__(self, capacity: int) -> None:
+        super().__init__(capacity=capacity)
+        self.allow_get = asyncio.Event()
+        self.get_started = asyncio.Event()
+        self.enqueued_task: asyncio.Task | None = None
+        self.last_enqueued_item: QueueItem | None = None
+
+    def enqueue(self, item: QueueItem) -> None:
+        task = asyncio.current_task()
+        self.enqueued_task = task if isinstance(task, asyncio.Task) else None
+        self.last_enqueued_item = item
+        super().enqueue(item)
+
+    async def get(self) -> QueueItem:
+        self.get_started.set()
+        await self.allow_get.wait()
+        return await super().get()
+
+
 @pytest.mark.asyncio
 async def test_queue_ordering_fifo_completion() -> None:
     queue = CommandQueue(capacity=3)
@@ -190,6 +210,96 @@ async def test_queue_full_returns_jsonrpc_error_response() -> None:
     payload = second.json()
     assert payload["id"] == 11
     assert payload["error"] == build_queue_full_error(1)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_client_item_is_not_dispatched() -> None:
+    queue = GatedCommandQueue(capacity=2)
+    dispatched: list[str] = []
+
+    async def dispatch(item: QueueItem):
+        dispatched.append(item.tool_name)
+        return [TextContent(type="text", text=json.dumps({"ok": True}))]
+
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        dispatch_fn=dispatch,
+    )
+
+    async with _client(app) as client:
+        session_id = await _initialize(client)
+        call_task = asyncio.create_task(
+            _call_tool(
+                client,
+                session_id=session_id,
+                name="get_device_info",
+            )
+        )
+        await _wait_for_queue_depth(queue, 1)
+
+        assert queue.enqueued_task is not None
+        queue.enqueued_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await call_task
+        assert queue.last_enqueued_item is not None
+        assert queue.last_enqueued_item.response_future.cancelled()
+
+        queue.allow_get.set()
+        await _wait_for_queue_depth(queue, 0)
+        await asyncio.sleep(0.01)
+
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_drains_pending_queue_items() -> None:
+    queue = GatedCommandQueue(capacity=3)
+    dispatched: list[str] = []
+
+    async def dispatch(item: QueueItem):
+        dispatched.append(item.tool_name)
+        return [TextContent(type="text", text=json.dumps({"ok": True}))]
+
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        dispatch_fn=dispatch,
+    )
+
+    loop = asyncio.get_running_loop()
+    futures = [loop.create_future() for _ in range(2)]
+
+    async with app.router.lifespan_context(app):
+        for index, future in enumerate(futures):
+            queue.enqueue(
+                QueueItem(
+                    correlation_id=f"pending-{index}",
+                    client_session_id=None,
+                    client_request_id=index,
+                    tool_name=f"tool-{index}",
+                    arguments={},
+                    response_future=future,
+                    enqueued_at=0.0,
+                )
+            )
+        await _wait_for_queue_depth(queue, 2)
+
+    assert queue.depth == 0
+    assert dispatched == []
+    for future in futures:
+        assert future.done()
+        result = future.result()
+        assert isinstance(result, ErrorData)
+        assert result.code == -32000
+        assert result.message == "stackchan MCP HTTP server is shutting down"
+        assert result.data == {"reason": "server_shutdown"}
 
 
 @pytest.mark.asyncio
@@ -405,7 +515,7 @@ async def test_dispatcher_returns_stdio_disconnect_payload_as_tool_result() -> N
 
 
 @pytest.mark.asyncio
-async def test_healthz_and_status_shapes() -> None:
+async def test_healthz_is_liveness_only_and_status_requires_auth_for_details() -> None:
     queue = CommandQueue(capacity=2)
     app = build_app(
         queue,
@@ -413,22 +523,27 @@ async def test_healthz_and_status_shapes() -> None:
         owner_id="owner-test",
         host="127.0.0.1",
         port=8767,
+        token="secret",
     )
 
     async with _client(app) as client:
         health = await client.get("/healthz")
-        status = await client.get("/status")
+        unauthenticated_status = await client.get("/status")
+        status = await client.get("/status", headers=_headers(token="secret"))
 
-    assert health.json() == {
-        "ok": True,
-        "esp32_connected": True,
-        "queue_depth": 0,
-        "queue_capacity": 2,
-        "owner_id": "owner-test",
-    }
-    assert status.json()["connected"] is True
-    assert status.json()["queue_depth"] == 0
-    assert status.json()["connected_clients"] == 0
+    assert health.status_code == 200
+    assert health.json() == {"ok": True}
+    assert set(health.json()) == {"ok"}
+    assert unauthenticated_status.status_code == 401
+
+    status_payload = status.json()
+    assert status.status_code == 200
+    assert status_payload["connected"] is True
+    assert status_payload["esp32_connected"] is True
+    assert status_payload["queue_depth"] == 0
+    assert status_payload["queue_capacity"] == 2
+    assert status_payload["owner_id"] == "owner-test"
+    assert status_payload["connected_clients"] == 0
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_stackchan_event.py
+++ b/gateway/tests/test_stackchan_event.py
@@ -147,6 +147,7 @@ async def test_server_run_captures_active_session_before_first_message(monkeypat
 async def test_notify_stackchan_event_uses_active_session(monkeypatch):
     session = _FakeSession()
     monkeypatch.setattr(stdio_server, "_active_session", session)
+    monkeypatch.setattr(stdio_server, "_active_sessions", {})
 
     params = {
         "event_type": "touch",
@@ -166,11 +167,42 @@ async def test_notify_stackchan_event_uses_active_session(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_notify_stackchan_event_fans_out_to_active_sessions(monkeypatch):
+    session_a = _FakeSession()
+    session_b = _FakeSession()
+    monkeypatch.setattr(stdio_server, "_active_session", session_b)
+    monkeypatch.setattr(
+        stdio_server,
+        "_active_sessions",
+        {id(session_a): session_a, id(session_b): session_b},
+    )
+
+    params = {
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "ts": 333,
+        "session_id": "session-1",
+    }
+    await notify_stackchan_event(STACKCHAN_EVENT_METHOD, params)
+
+    expected = [
+        {
+            "method": STACKCHAN_EVENT_METHOD,
+            "params": params,
+        }
+    ]
+    assert session_a.notifications == expected
+    assert session_b.notifications == expected
+
+
+@pytest.mark.asyncio
 async def test_notify_stackchan_event_without_active_session_logs_and_returns(
     monkeypatch,
     caplog,
 ):
     monkeypatch.setattr(stdio_server, "_active_session", None)
+    monkeypatch.setattr(stdio_server, "_active_sessions", {})
 
     with caplog.at_level(logging.WARNING):
         await notify_stackchan_event(


### PR DESCRIPTION
## Summary

Land #178 Phase B stage 3 — the Streamable HTTP daemon transport with a bounded command queue, daemon-setup documentation, and the adversarial-review fixes on top.

Two commits on this branch:

1. `fbe42f5` — `feat(gateway): #178 Phase B stage 3 — Streamable HTTP daemon, queue dispatcher, tests, docs`. Real daemon entry replacing the chunk 2+3 `NotImplementedError` placeholder, single-flight queue dispatcher with `get_status` bypass, bearer-token auth, bind-safety policy, new `docs/178-daemon-setup.md`, full test coverage matrix.

2. `67d8426` — `fix(gateway): #178 Phase B stage 3 — cancel-safe queue dispatch and /healthz info hiding`. Pre-PR adversarial review surfaced two findings on the round-1 commit; this commit resolves both.
   - Wrap the HTTP `tools/call` handler's `await response_future` in `try/except asyncio.CancelledError/finally` so the queue dispatcher observes cancellation via `response_future.done()` and skips dispatch for items whose requester has gone away. On lifespan shutdown, cancel the dispatcher task first and complete every pending `QueueItem` future with a JSON-RPC `-32000` `server_shutdown` error so awaiting handlers return cleanly and no further ESP32 dispatch happens.
   - Narrow the unauthenticated `/healthz` endpoint to a liveness-only `{"ok": true}` payload. Move `esp32_connected`, `queue_depth`, `queue_capacity`, `owner_id`, and `connected_clients` to the bearer-authenticated `/status` endpoint so non-loopback binds that already require a token cannot be fingerprinted via `/healthz`.

## Test plan

- [x] `uv run pytest gateway/tests/test_http_server.py` — 15 tests pass (queue ordering, saturation, auth, response correlation, bypass, disconnect, lock lifecycle, bind safety, cancelled client, lifespan drain, healthz/status shape and auth split).
- [x] `uv run ruff check .` clean.
- [x] Pre-PR codex adversarial review identified two findings on `fbe42f5`; both resolved in `67d8426`.

## Validation

- Stdio path is unchanged in this stage (the chunk 4 refactor extracted `_dispatch_mcp_tool` from `stdio_server.py` in `fbe42f5` with bit-identical observable behavior, verified by the existing `test_stdio_server.py` suite).
- Cancelled-client items never reach `dispatch_fn` (test: `test_cancelled_client_item_is_not_dispatched`).
- Lifespan shutdown drains pending futures with a JSON-RPC shutdown error; no `dispatch_fn` invocation after stop (test: `test_lifespan_shutdown_drains_pending_queue_items`).
- `/healthz` unauthenticated payload contains only `{"ok": true}`; `/status` still requires bearer auth and exposes the detailed fields (test: `test_healthz_is_liveness_only_and_status_requires_auth_for_details`).

## Out of scope / follow-ups

- Resumability via Streamable HTTP `EventStore` is not implemented; reconnect semantics use the spec's basic stateful flow.
- Per-tool-lane queues (post-#73) and stateless JSON mode evaluation remain future work as called out in the Phase A spike doc.

Refs #178.
