### PR TITLE
feat(gateway): #265 opt-in event notification paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "kisaragi-mochi-channels",
+  "description": "Local stackchan-mcp channel plugin marketplace for kisaragi-mochi projects.",
+  "owner": {
+    "name": "kisaragi-mochi"
+  },
+  "plugins": [
+    {
+      "name": "stackchanmcp",
+      "description": "Stack-chan physical event channel for Claude Code — touch tap / stroke notifications from the desktop robot delivered as Channels messages.",
+      "author": {
+        "name": "kisaragi-mochi"
+      },
+      "category": "productivity",
+      "source": "./",
+      "homepage": "https://github.com/kisaragi-mochi/stackchan-mcp"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "stackchan-mcp",
+  "name": "stackchanmcp",
   "description": "Stack-chan physical event channel for Claude Code — touch tap / stroke notifications from the desktop robot delivered as Channels messages.",
   "version": "0.8.0",
   "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "stackchan-mcp",
+  "description": "Stack-chan physical event channel for Claude Code — touch tap / stroke notifications from the desktop robot delivered as Channels messages.",
+  "version": "0.8.0",
+  "keywords": [
+    "stackchan",
+    "mcp",
+    "channel",
+    "esp32",
+    "robotics",
+    "touch"
+  ],
+  "author": {
+    "name": "kisaragi-mochi"
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "stackchan-mcp": {
+    "stackchanmcp": {
       "command": "uv",
       "args": [
         "run",
@@ -8,7 +8,8 @@
         "${CLAUDE_PLUGIN_ROOT}/gateway",
         "python",
         "-m",
-        "stackchan_mcp"
+        "stackchan_mcp",
+        "serve"
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "stackchan-mcp": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${CLAUDE_PLUGIN_ROOT}/gateway",
+        "python",
+        "-m",
+        "stackchan_mcp"
+      ]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,16 @@ documented-only.
   wiring does not receive `<channel ...>` injections, that switching
   paths requires releasing the existing ESP32 ownership lock, and that
   `legacy_event` / `jsonl` remain compatible for users who keep the
-  pre-plugin wiring. (#266)
+  pre-plugin wiring.
+
+  The README startup command for the Channels path now includes the
+  required `--channels stackchan-mcp` argument (loading the plugin via
+  `--plugin-dir` alone is insufficient: Claude Code only attaches a
+  channel source and injects `<channel source="stackchan-mcp" ...>`
+  blocks when the server is explicitly registered in the session's
+  channels list). When allowlist restrictions block development
+  servers, the documented fallback is
+  `--dangerously-load-development-channels stackchan-mcp`. (#266)
 
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ documented-only.
     path: ~/.claude/stackchan-events.jsonl
   ```
 
+  README now documents the host-side receiver setup required to consume
+  the Channels path, including the Claude Code experimental
+  `--dangerously-load-development-channels server:stackchan-mcp` startup
+  flag and the JSONL fallback for hosts without a Channels receiver.
+  (#266)
+
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /
   `stroke`) forwarded from additive `stackchan-event` WebSocket frames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ documented-only.
 
 ### Gateway
 
+- BREAKING: gateway event emission paths now default to all OFF instead of
+  legacy `stackchan/event` notifications plus JSONL logging. Added three
+  independent opt-in switches (`legacy_event`, `channels`, `jsonl`) via
+  `~/.config/stackchan-mcp/notify.yml`, plus an additive `action` field in
+  event payloads for the human-axis avatar action. To restore the previous
+  behavior, create:
+
+  ```yaml
+  legacy_event:
+    enabled: true
+  jsonl:
+    enabled: true
+    path: ~/.claude/stackchan-events.jsonl
+  ```
+
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /
   `stroke`) forwarded from additive `stackchan-event` WebSocket frames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,6 @@ documented-only.
     path: ~/.claude/stackchan-events.jsonl
   ```
 
-  README now documents the host-side receiver setup required to consume
-  the Channels path, including the Claude Code experimental
-  `--dangerously-load-development-channels server:stackchan-mcp` startup
-  flag and the JSONL fallback for hosts without a Channels receiver.
-  (#266)
-
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /
   `stroke`) forwarded from additive `stackchan-event` WebSocket frames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,13 +64,13 @@ documented-only.
   pre-plugin wiring.
 
   The README startup command for the Channels path now includes the
-  required `--channels stackchan-mcp` argument (loading the plugin via
+  required `--channels server:stackchan-mcp` argument (loading the plugin via
   `--plugin-dir` alone is insufficient: Claude Code only attaches a
   channel source and injects `<channel source="stackchan-mcp" ...>`
   blocks when the server is explicitly registered in the session's
   channels list). When allowlist restrictions block development
   servers, the documented fallback is
-  `--dangerously-load-development-channels stackchan-mcp`. (#266)
+  `--dangerously-load-development-channels server:stackchan-mcp`. (#266)
 
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,11 @@ documented-only.
   ```
 
   README now documents the host-side receiver setup required to consume
-  the Channels path, including the Claude Code experimental
-  `--dangerously-load-development-channels server:stackchan-mcp` startup
-  flag and the JSONL fallback for hosts without a Channels receiver.
-  (#266)
+  the Channels path: load this repository as a Claude Code plugin via
+  `claude --plugin-dir <repo-checkout>` so Claude Code subscribes to the
+  advertised `claude/channel` capability. Marketplace publication is
+  tracked as a follow-up. The JSONL fallback remains for hosts without
+  a Channels receiver. (#266)
 
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,16 @@ documented-only.
   `claude --plugin-dir <repo-checkout>` so Claude Code subscribes to the
   advertised `claude/channel` capability. Marketplace publication is
   tracked as a follow-up. The JSONL fallback remains for hosts without
-  a Channels receiver. (#266)
+  a Channels receiver.
+
+  The Channels notification instructions now use `source="stackchan-mcp"`
+  to match the plugin / MCP server identifier (Claude Code derives the
+  channel source from the loaded plugin name, not from notification
+  params). README EN/JP also document that pre-plugin `~/.claude.json`
+  wiring does not receive `<channel ...>` injections, that switching
+  paths requires releasing the existing ESP32 ownership lock, and that
+  `legacy_event` / `jsonl` remain compatible for users who keep the
+  pre-plugin wiring. (#266)
 
 - Added: `stackchan/event` experimental MCP capability and server-initiated
   notification bridge for firmware-originated touch events (`tap` /

--- a/README.ja.md
+++ b/README.ja.md
@@ -461,19 +461,28 @@ Channels 通知を有効にするには:
 2. 受け口側 — ホストごとに開き方が異なります。
 
    - **Claude Code**: 本リポジトリを CC plugin として読み込み、
-     gateway が宣言する `claude/channel` capability を Claude Code が
-     購読するようにします。
+     かつ この plugin の MCP server を Channels source として登録する
+     ことで、gateway が宣言する `claude/channel` capability を
+     Claude Code が購読するようにします。
 
      ```bash
-     claude --plugin-dir /path/to/stackchan-mcp --agent <your-agent>
+     claude --plugin-dir /path/to/stackchan-mcp --channels stackchan-mcp --agent <your-agent>
      ```
 
      1 セッション限定のローカル開発では `--plugin-dir` に本リポジトリの
      作業コピーを指定してください。Claude Code は同梱の `.mcp.json`
      経由で `${CLAUDE_PLUGIN_ROOT}/gateway` 配下の gateway を起動します。
-     Marketplace 公開 (`--channels plugin:stackchan-mcp@<marketplace>`)
-     は follow-up として追跡し、manifest を marketplace へ提出した
-     タイミングで利用可能になります。
+     `--channels stackchan-mcp` 引数を付けることで Claude Code がこの
+     server を channel source として attach し、session に
+     `<channel source="stackchan-mcp" ...>` blocks を inject します。
+     付けないと plugin は読み込まれますが、channels の notification は
+     受信側で silent に drop されます。allowlist 制限により開発用 server
+     が登録できない場合は、代わりに
+     `--dangerously-load-development-channels stackchan-mcp` を使って
+     ください。Marketplace 公開
+     (`--channels plugin:stackchan-mcp@<marketplace>`) は follow-up
+     として追跡し、manifest を marketplace へ提出したタイミングで
+     利用可能になります。
 
      重要 — plugin 以前の起動経路では Channels が届きません: 以前
      `~/.claude.json` の `mcpServers` 経由でこの gateway を起動して

--- a/README.ja.md
+++ b/README.ja.md
@@ -466,19 +466,19 @@ Channels 通知を有効にするには:
      Claude Code が購読するようにします。
 
      ```bash
-     claude --plugin-dir /path/to/stackchan-mcp --channels stackchan-mcp --agent <your-agent>
+     claude --plugin-dir /path/to/stackchan-mcp --channels server:stackchan-mcp --agent <your-agent>
      ```
 
      1 セッション限定のローカル開発では `--plugin-dir` に本リポジトリの
      作業コピーを指定してください。Claude Code は同梱の `.mcp.json`
      経由で `${CLAUDE_PLUGIN_ROOT}/gateway` 配下の gateway を起動します。
-     `--channels stackchan-mcp` 引数を付けることで Claude Code がこの
+     `--channels server:stackchan-mcp` 引数を付けることで Claude Code がこの
      server を channel source として attach し、session に
      `<channel source="stackchan-mcp" ...>` blocks を inject します。
      付けないと plugin は読み込まれますが、channels の notification は
      受信側で silent に drop されます。allowlist 制限により開発用 server
      が登録できない場合は、代わりに
-     `--dangerously-load-development-channels stackchan-mcp` を使って
+     `--dangerously-load-development-channels server:stackchan-mcp` を使って
      ください。Marketplace 公開
      (`--channels plugin:stackchan-mcp@<marketplace>`) は follow-up
      として追跡し、manifest を marketplace へ提出したタイミングで

--- a/README.ja.md
+++ b/README.ja.md
@@ -443,39 +443,21 @@ Vosk・whisper.cpp・他のクラウドサービス等を `listen` API を変え
 ### 6. オプション: イベント通知の有効化
 
 Stack-chan の物理イベント（touch tap / stroke）は、ホスト側の対応状況に
-合わせて複数の通知経路で届けられます。すべての経路はデフォルトで無効
-です。有効化するには `~/.config/stackchan-mcp/notify.yml` で opt-in
+合わせて複数の通知経路で届けられます。CC ユーザーは Channels 機構で
+受け取れます。その他のホスト向け経路は今後追加できます。ホストが通知の
+受け取り口を持っていない場合は、フォールバックとして JSONL 出力を
+ホスト側 integration から読むこともできます。すべての経路はデフォルトで
+無効です。有効化するには `~/.config/stackchan-mcp/notify.yml` で opt-in
 してください。Channels 機構は実験的な MCP capability を使っており、
 今後変わる可能性があります。
 
-Channels 通知を有効にするには:
+Channels 通知を有効にする最小設定:
 
-1. Gateway 側 — `~/.config/stackchan-mcp/notify.yml` で Channels を
-   有効化します。
-
-   ```yaml
-   channels:
-     enabled: true
-   ```
-
-2. 受け口側 — ホストごとに開き方が異なります。
-
-   - **Claude Code**: 本 gateway が宣言する `claude/channel` capability
-     を Claude Code が購読するように、起動時にフラグを付けます。
-
-     ```bash
-     claude --dangerously-load-development-channels server:stackchan-mcp
-     ```
-
-     将来 plugin パッケージ版がリリースされたら
-     `--channels plugin:<name>@<marketplace>` に置き換わります。
-
-   - **`claude/channel` 互換の受け口を持つ他ホスト**: 当該ホストの
-     ドキュメントに従って受け口を開いてください。Claude Code 以外の
-     ホストとの互換性は当リポジトリでは未検証です。
-
-   - **Channels 受け口を持たないホスト**: JSONL フォールバックを
-     使ってください（下記参照）。
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+channels:
+  enabled: true
+```
 
 以前の常時有効だったイベント動作に戻す設定:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -475,6 +475,17 @@ Channels 通知を有効にするには:
      は follow-up として追跡し、manifest を marketplace へ提出した
      タイミングで利用可能になります。
 
+     重要 — plugin 以前の起動経路では Channels が届きません: 以前
+     `~/.claude.json` の `mcpServers` 経由でこの gateway を起動して
+     いた場合、その旧経路では `<channel ...>` の inject は届きません。
+     Claude Code は plugin 経由で起動された MCP server のみに channel
+     source を付ける仕様です。plugin 経路に移行する前に、既存の
+     stackchan-mcp gateway プロセスを停止して ESP32 ownership lock
+     を解放してください。そうしないと plugin 経由で起動した gateway
+     が lock 取得に失敗します。`~/.claude.json` 経由のまま使いたい
+     場合は、`channels` ではなく `legacy_event` / `jsonl` を使って
+     ください。どちらも plugin loading なしで動作します。
+
    - **`claude/channel` 互換の受け口を持つ他ホスト**: 当該ホストの
      ドキュメントに従って受け口を開いてください。Claude Code 以外の
      ホストとの互換性は当リポジトリでは未検証です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -440,6 +440,36 @@ Face キャッシュにダウンロードされ、以降は再利用されます
 Vosk・whisper.cpp・他のクラウドサービス等を `listen` API を変えずに
 後から追加できます。
 
+### 6. オプション: イベント通知の有効化
+
+Stack-chan の物理イベント（touch tap / stroke）は、ホスト側の対応状況に
+合わせて複数の通知経路で届けられます。CC ユーザーは Channels 機構で
+受け取れます。その他のホスト向け経路は今後追加できます。ホストが通知の
+受け取り口を持っていない場合は、フォールバックとして JSONL 出力を
+ホスト側 integration から読むこともできます。すべての経路はデフォルトで
+無効です。有効化するには `~/.config/stackchan-mcp/notify.yml` で opt-in
+してください。Channels 機構は実験的な MCP capability を使っており、
+今後変わる可能性があります。
+
+Channels 通知を有効にする最小設定:
+
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+channels:
+  enabled: true
+```
+
+以前の常時有効だったイベント動作に戻す設定:
+
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+legacy_event:
+  enabled: true
+jsonl:
+  enabled: true
+  path: ~/.claude/stackchan-events.jsonl
+```
+
 ## アバター画像について
 
 `firmware/main/boards/stackchan/avatar_images.cc` は **真っ黒 RGB565 のプレースホルダ** です。ビルドは通りますが、画面には何も表示されません。

--- a/README.ja.md
+++ b/README.ja.md
@@ -443,21 +443,39 @@ Vosk・whisper.cpp・他のクラウドサービス等を `listen` API を変え
 ### 6. オプション: イベント通知の有効化
 
 Stack-chan の物理イベント（touch tap / stroke）は、ホスト側の対応状況に
-合わせて複数の通知経路で届けられます。CC ユーザーは Channels 機構で
-受け取れます。その他のホスト向け経路は今後追加できます。ホストが通知の
-受け取り口を持っていない場合は、フォールバックとして JSONL 出力を
-ホスト側 integration から読むこともできます。すべての経路はデフォルトで
-無効です。有効化するには `~/.config/stackchan-mcp/notify.yml` で opt-in
+合わせて複数の通知経路で届けられます。すべての経路はデフォルトで無効
+です。有効化するには `~/.config/stackchan-mcp/notify.yml` で opt-in
 してください。Channels 機構は実験的な MCP capability を使っており、
 今後変わる可能性があります。
 
-Channels 通知を有効にする最小設定:
+Channels 通知を有効にするには:
 
-```yaml
-# ~/.config/stackchan-mcp/notify.yml
-channels:
-  enabled: true
-```
+1. Gateway 側 — `~/.config/stackchan-mcp/notify.yml` で Channels を
+   有効化します。
+
+   ```yaml
+   channels:
+     enabled: true
+   ```
+
+2. 受け口側 — ホストごとに開き方が異なります。
+
+   - **Claude Code**: 本 gateway が宣言する `claude/channel` capability
+     を Claude Code が購読するように、起動時にフラグを付けます。
+
+     ```bash
+     claude --dangerously-load-development-channels server:stackchan-mcp
+     ```
+
+     将来 plugin パッケージ版がリリースされたら
+     `--channels plugin:<name>@<marketplace>` に置き換わります。
+
+   - **`claude/channel` 互換の受け口を持つ他ホスト**: 当該ホストの
+     ドキュメントに従って受け口を開いてください。Claude Code 以外の
+     ホストとの互換性は当リポジトリでは未検証です。
+
+   - **Channels 受け口を持たないホスト**: JSONL フォールバックを
+     使ってください（下記参照）。
 
 以前の常時有効だったイベント動作に戻す設定:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -460,15 +460,20 @@ Channels 通知を有効にするには:
 
 2. 受け口側 — ホストごとに開き方が異なります。
 
-   - **Claude Code**: 本 gateway が宣言する `claude/channel` capability
-     を Claude Code が購読するように、起動時にフラグを付けます。
+   - **Claude Code**: 本リポジトリを CC plugin として読み込み、
+     gateway が宣言する `claude/channel` capability を Claude Code が
+     購読するようにします。
 
      ```bash
-     claude --dangerously-load-development-channels server:stackchan-mcp
+     claude --plugin-dir /path/to/stackchan-mcp --agent <your-agent>
      ```
 
-     将来 plugin パッケージ版がリリースされたら
-     `--channels plugin:<name>@<marketplace>` に置き換わります。
+     1 セッション限定のローカル開発では `--plugin-dir` に本リポジトリの
+     作業コピーを指定してください。Claude Code は同梱の `.mcp.json`
+     経由で `${CLAUDE_PLUGIN_ROOT}/gateway` 配下の gateway を起動します。
+     Marketplace 公開 (`--channels plugin:stackchan-mcp@<marketplace>`)
+     は follow-up として追跡し、manifest を marketplace へ提出した
+     タイミングで利用可能になります。
 
    - **`claude/channel` 互換の受け口を持つ他ホスト**: 当該ホストの
      ドキュメントに従って受け口を開いてください。Claude Code 以外の

--- a/README.md
+++ b/README.md
@@ -495,39 +495,20 @@ the `listen` API.
 ### 6. Optional: enable event notifications
 
 Stack-chan physical events (touch tap / stroke) can be delivered through
-several notification paths, depending on host capabilities. All paths are
-disabled by default; opt in via `~/.config/stackchan-mcp/notify.yml`. The
-Channels mechanism uses an experimental MCP capability and may evolve.
+several notification paths, depending on host capabilities. CC users can
+receive them via the Channels mechanism; other hosts can be added later.
+If your host doesn't expose a notification receiver, the fallback JSONL
+output can be consumed by host-side integration. All paths are disabled
+by default; opt in via `~/.config/stackchan-mcp/notify.yml`. The Channels
+mechanism uses an experimental MCP capability and may evolve.
 
 To enable Channels notifications:
 
-1. Gateway side — turn Channels on in `~/.config/stackchan-mcp/notify.yml`:
-
-   ```yaml
-   channels:
-     enabled: true
-   ```
-
-2. Receiver side — open a receiver on your host:
-
-   - **Claude Code**: start with the channels flag so Claude Code
-     subscribes to the `claude/channel` capability advertised by this
-     gateway.
-
-     ```bash
-     claude --dangerously-load-development-channels server:stackchan-mcp
-     ```
-
-     A future plugin-packaged release will replace this with
-     `--channels plugin:<name>@<marketplace>`.
-
-   - **Other hosts with a `claude/channel`-compatible receiver**: open
-     that receiver per the host's documentation. Compatibility with
-     hosts other than Claude Code has not been verified in this
-     repository.
-
-   - **Hosts without a Channels receiver**: use the JSONL fallback (see
-     below).
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+channels:
+  enabled: true
+```
 
 To restore the previous always-on event behavior:
 

--- a/README.md
+++ b/README.md
@@ -510,17 +510,25 @@ To enable Channels notifications:
 
 2. Receiver side — open a receiver on your host:
 
-   - **Claude Code**: load this repository as a CC plugin so Claude
-     Code subscribes to the `claude/channel` capability advertised by
-     this gateway.
+   - **Claude Code**: load this repository as a CC plugin AND register
+     this plugin's MCP server as a Channels source so Claude Code
+     subscribes to the `claude/channel` capability advertised by this
+     gateway.
 
      ```bash
-     claude --plugin-dir /path/to/stackchan-mcp --agent <your-agent>
+     claude --plugin-dir /path/to/stackchan-mcp --channels stackchan-mcp --agent <your-agent>
      ```
 
      For one-session local development, point `--plugin-dir` at your
      working copy of this repository; Claude Code starts the gateway
      under `${CLAUDE_PLUGIN_ROOT}/gateway` via the bundled `.mcp.json`.
+     The `--channels stackchan-mcp` argument is what makes Claude Code
+     attach the channel source to this server and inject
+     `<channel source="stackchan-mcp" ...>` blocks into the session;
+     without it the plugin loads but channels notifications are
+     silently dropped on the receiving side. If allowlist restrictions
+     block a development server from being added, use
+     `--dangerously-load-development-channels stackchan-mcp` instead.
      Marketplace publication (`--channels plugin:stackchan-mcp@<marketplace>`)
      is tracked as a follow-up and will land once the manifest is
      submitted to a marketplace.

--- a/README.md
+++ b/README.md
@@ -495,20 +495,39 @@ the `listen` API.
 ### 6. Optional: enable event notifications
 
 Stack-chan physical events (touch tap / stroke) can be delivered through
-several notification paths, depending on host capabilities. CC users can
-receive them via the Channels mechanism; other hosts can be added later.
-If your host doesn't expose a notification receiver, the fallback JSONL
-output can be consumed by host-side integration. All paths are disabled
-by default; opt in via `~/.config/stackchan-mcp/notify.yml`. The Channels
-mechanism uses an experimental MCP capability and may evolve.
+several notification paths, depending on host capabilities. All paths are
+disabled by default; opt in via `~/.config/stackchan-mcp/notify.yml`. The
+Channels mechanism uses an experimental MCP capability and may evolve.
 
 To enable Channels notifications:
 
-```yaml
-# ~/.config/stackchan-mcp/notify.yml
-channels:
-  enabled: true
-```
+1. Gateway side — turn Channels on in `~/.config/stackchan-mcp/notify.yml`:
+
+   ```yaml
+   channels:
+     enabled: true
+   ```
+
+2. Receiver side — open a receiver on your host:
+
+   - **Claude Code**: start with the channels flag so Claude Code
+     subscribes to the `claude/channel` capability advertised by this
+     gateway.
+
+     ```bash
+     claude --dangerously-load-development-channels server:stackchan-mcp
+     ```
+
+     A future plugin-packaged release will replace this with
+     `--channels plugin:<name>@<marketplace>`.
+
+   - **Other hosts with a `claude/channel`-compatible receiver**: open
+     that receiver per the host's documentation. Compatibility with
+     hosts other than Claude Code has not been verified in this
+     repository.
+
+   - **Hosts without a Channels receiver**: use the JSONL fallback (see
+     below).
 
 To restore the previous always-on event behavior:
 

--- a/README.md
+++ b/README.md
@@ -510,16 +510,20 @@ To enable Channels notifications:
 
 2. Receiver side — open a receiver on your host:
 
-   - **Claude Code**: start with the channels flag so Claude Code
-     subscribes to the `claude/channel` capability advertised by this
-     gateway.
+   - **Claude Code**: load this repository as a CC plugin so Claude
+     Code subscribes to the `claude/channel` capability advertised by
+     this gateway.
 
      ```bash
-     claude --dangerously-load-development-channels server:stackchan-mcp
+     claude --plugin-dir /path/to/stackchan-mcp --agent <your-agent>
      ```
 
-     A future plugin-packaged release will replace this with
-     `--channels plugin:<name>@<marketplace>`.
+     For one-session local development, point `--plugin-dir` at your
+     working copy of this repository; Claude Code starts the gateway
+     under `${CLAUDE_PLUGIN_ROOT}/gateway` via the bundled `.mcp.json`.
+     Marketplace publication (`--channels plugin:stackchan-mcp@<marketplace>`)
+     is tracked as a follow-up and will land once the manifest is
+     submitted to a marketplace.
 
    - **Other hosts with a `claude/channel`-compatible receiver**: open
      that receiver per the host's documentation. Compatibility with

--- a/README.md
+++ b/README.md
@@ -492,6 +492,35 @@ success. The STT framework is engine-agnostic — additional engines
 (Vosk, whisper.cpp, cloud providers) can be added without changing
 the `listen` API.
 
+### 6. Optional: enable event notifications
+
+Stack-chan physical events (touch tap / stroke) can be delivered through
+several notification paths, depending on host capabilities. CC users can
+receive them via the Channels mechanism; other hosts can be added later.
+If your host doesn't expose a notification receiver, the fallback JSONL
+output can be consumed by host-side integration. All paths are disabled
+by default; opt in via `~/.config/stackchan-mcp/notify.yml`. The Channels
+mechanism uses an experimental MCP capability and may evolve.
+
+To enable Channels notifications:
+
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+channels:
+  enabled: true
+```
+
+To restore the previous always-on event behavior:
+
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+legacy_event:
+  enabled: true
+jsonl:
+  enabled: true
+  path: ~/.claude/stackchan-events.jsonl
+```
+
 ## About the avatar images
 
 `firmware/main/boards/stackchan/avatar_images.cc` is a **pure black RGB565 placeholder**. The firmware builds and runs, but the screen will display nothing.

--- a/README.md
+++ b/README.md
@@ -516,19 +516,19 @@ To enable Channels notifications:
      gateway.
 
      ```bash
-     claude --plugin-dir /path/to/stackchan-mcp --channels stackchan-mcp --agent <your-agent>
+     claude --plugin-dir /path/to/stackchan-mcp --channels server:stackchan-mcp --agent <your-agent>
      ```
 
      For one-session local development, point `--plugin-dir` at your
      working copy of this repository; Claude Code starts the gateway
      under `${CLAUDE_PLUGIN_ROOT}/gateway` via the bundled `.mcp.json`.
-     The `--channels stackchan-mcp` argument is what makes Claude Code
+     The `--channels server:stackchan-mcp` argument is what makes Claude Code
      attach the channel source to this server and inject
      `<channel source="stackchan-mcp" ...>` blocks into the session;
      without it the plugin loads but channels notifications are
      silently dropped on the receiving side. If allowlist restrictions
      block a development server from being added, use
-     `--dangerously-load-development-channels stackchan-mcp` instead.
+     `--dangerously-load-development-channels server:stackchan-mcp` instead.
      Marketplace publication (`--channels plugin:stackchan-mcp@<marketplace>`)
      is tracked as a follow-up and will land once the manifest is
      submitted to a marketplace.

--- a/README.md
+++ b/README.md
@@ -525,6 +525,17 @@ To enable Channels notifications:
      is tracked as a follow-up and will land once the manifest is
      submitted to a marketplace.
 
+     Important — pre-plugin wiring does not receive Channels: if you
+     previously wired this gateway via `~/.claude.json` `mcpServers`
+     (the pre-plugin path), that wiring does not receive `<channel ...>`
+     injections. Claude Code only attaches a channel source to
+     plugin-loaded MCP servers. Before switching to the plugin path,
+     stop any existing stackchan-mcp gateway process to release the
+     ESP32 ownership lock; the plugin-loaded gateway will otherwise
+     fail to acquire it. If you prefer to keep the `~/.claude.json`
+     wiring, use `legacy_event` and `jsonl` instead of `channels` —
+     both work without plugin loading.
+
    - **Other hosts with a `claude/channel`-compatible receiver**: open
      that receiver per the host's documentation. Compatibility with
      hosts other than Claude Code has not been verified in this

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "websockets>=12",
     "pydantic>=2",
     "python-dotenv",
+    "PyYAML>=6",
     # The stdio server captures the active ServerSession via a subclassed
     # Server.run() loop because the public MCP SDK does not yet expose a
     # stable hook for server-side notifications. That subclass relies on
@@ -121,4 +122,5 @@ packages = ["stackchan_mcp"]
 artifacts = [
     "stackchan_mcp/_libs/opus.dll",
     "stackchan_mcp/_libs/SOURCES.md",
+    "stackchan_mcp/notify.example.yml",
 ]

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -697,9 +697,15 @@ async def _run(*, advertise_mdns: bool = True) -> None:
 
     from .event_log import rotate_old_entries
     from .gateway import get_gateway
+    from .notify_config import load_notify_config
     from .stdio_server import run_stdio_server
 
+    notify_config = load_notify_config()
     gateway = get_gateway()
+    esp32 = getattr(gateway, "esp32", None)
+    set_notify_config = getattr(esp32, "set_notify_config", None)
+    if callable(set_notify_config):
+        set_notify_config(notify_config)
 
     loop = asyncio.get_running_loop()
     main_task = asyncio.current_task()
@@ -711,19 +717,18 @@ async def _run(*, advertise_mdns: bool = True) -> None:
     if sys.platform != "win32":
         loop.add_signal_handler(signal.SIGTERM, _handle_sigterm)
 
-    # Prune stale stackchan-event log entries (older than the helper's
-    # retention window) exactly once per startup. Long-running gateways
-    # are not re-rotated mid-flight; downstream readers filter by
-    # ``ts_unix`` themselves. Failures inside ``rotate_old_entries`` are
-    # logged and swallowed, so a broken log file cannot block startup.
-    rotate_old_entries()
+    # Prune stale stackchan-event log entries only when the JSONL path is
+    # explicitly enabled. With the default all-OFF notify config, gateway
+    # startup must not create or rewrite any persistent event-log files.
+    if notify_config.jsonl_enabled:
+        rotate_old_entries(path=notify_config.jsonl_path)
 
     await gateway.start(advertise_mdns=advertise_mdns)
     logger.info("Gateway started, waiting for ESP32 connections...")
 
     try:
         # Run stdio MCP server (blocks until MCP client disconnects)
-        await run_stdio_server()
+        await run_stdio_server(notify_config=notify_config)
     except asyncio.CancelledError:
         logger.info("Received termination signal, shutting down...")
     finally:
@@ -828,12 +833,19 @@ async def _run_streamable_http_daemon(
 
     from .event_log import rotate_old_entries
     from .gateway import get_gateway
+    from .notify_config import load_notify_config
     from .http_server import build_app, make_dispatch_fn
     from .queue import CommandQueue
 
-    rotate_old_entries()
+    notify_config = load_notify_config()
+    if notify_config.jsonl_enabled:
+        rotate_old_entries(path=notify_config.jsonl_path)
 
     gateway = get_gateway()
+    esp32 = getattr(gateway, "esp32", None)
+    set_notify_config = getattr(esp32, "set_notify_config", None)
+    if callable(set_notify_config):
+        set_notify_config(notify_config)
     queue = CommandQueue()
     app = build_app(
         queue,

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -855,6 +855,7 @@ async def _run_streamable_http_daemon(
         port=port,
         token=token,
         dispatch_fn=make_dispatch_fn(gateway),
+        notify_config=notify_config,
     )
     config = uvicorn.Config(
         app,

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 import json
 import logging
 import os
+import time
 import uuid
 from typing import Any
 
@@ -25,6 +26,12 @@ from .audio_stream import (
     is_recording_session,
     start_recording,
     stop_recording,
+)
+from .notify_config import (
+    DEFAULT_MESSAGE_TEMPLATES,
+    NotifyConfig,
+    load_notify_config,
+    render_template,
 )
 from .protocol import HelloResponse, make_mcp_message, parse_jsonrpc_response
 
@@ -354,10 +361,11 @@ class ESP32Manager:
     Currently supports a single device connection.
     """
 
-    def __init__(self):
+    def __init__(self, notify_config: NotifyConfig | None = None):
         self._connection: ESP32Connection | None = None
         self._server: Any = None
         self._lock = asyncio.Lock()
+        self._notify_config = notify_config or load_notify_config()
         self._init_tasks: list[asyncio.Task] = []
         self._vision_url: str = ""
         self._vision_token: str = ""
@@ -417,6 +425,10 @@ class ESP32Manager:
             "status": asyncio.Lock(),
             "default": asyncio.Lock(),
         }
+
+    def set_notify_config(self, notify_config: NotifyConfig) -> None:
+        """Replace the startup notification config used for future events."""
+        self._notify_config = notify_config
 
     @property
     def device_connected(self) -> bool:
@@ -757,48 +769,74 @@ class ESP32Manager:
             logger.warning("Malformed stackchan-event frame: session_id=%r", session_id)
             return
 
+        config = self._notify_config
+        message = config.messages.get(
+            (event_type, subtype),
+            DEFAULT_MESSAGE_TEMPLATES[(event_type, subtype)],
+        )
+        ts_unix = time.time()
         params = {
             "event_type": event_type,
             "subtype": subtype,
             "duration_ms": duration_ms,
+            "action": message.action,
             "ts": ts,
+            "ts_unix": ts_unix,
             "session_id": session_id,
         }
         logger.info(
-            "stackchan-event: %s/%s duration=%sms ts=%s session=%s",
+            "stackchan-event: %s/%s action=%s duration=%sms ts=%s session=%s",
             event_type,
             subtype,
+            message.action,
             duration_ms,
             ts,
             session_id,
         )
 
-        # Persist the validated event to the JSONL log so downstream
-        # consumers (e.g. an MCP client UserPromptSubmit hook that
-        # injects events into the next agent turn) can pick it up
-        # between the firmware reaction and the next conversational
-        # turn. ``log_event`` swallows OS / permission errors
-        # internally; the broad except below is a second-tier guard so
-        # any unforeseen helper bug cannot break the MCP notification
-        # path that follows.
-        from .event_log import log_event
-
-        try:
-            log_event(
-                event_type=event_type,
-                subtype=subtype,
-                duration_ms=duration_ms,
-                ts=ts,
-                session_id=session_id,
+        if not (
+            config.legacy_event_enabled
+            or config.channels_enabled
+            or config.jsonl_enabled
+        ):
+            logger.info(
+                "stackchan-event received and dropped: notification paths disabled"
             )
-        except Exception as exc:  # pragma: no cover - defensive guard
-            logger.warning(
-                "stackchan-event log persistence raised unexpectedly: %s", exc
-            )
+            return
 
         from .stdio_server import notify_stackchan_event
 
-        await notify_stackchan_event("stackchan/event", params)
+        if config.legacy_event_enabled:
+            await notify_stackchan_event("stackchan/event", params)
+
+        if config.channels_enabled:
+            content = render_template(message.template, params)
+            await notify_stackchan_event(
+                "notifications/claude/channel",
+                {"content": content, "meta": params},
+            )
+
+        if config.jsonl_enabled:
+            # ``log_event`` swallows OS / permission errors internally; the
+            # broad except below is a second-tier guard so any unforeseen
+            # helper bug cannot break the in-band notification paths above.
+            from .event_log import log_event
+
+            try:
+                log_event(
+                    event_type=event_type,
+                    subtype=subtype,
+                    duration_ms=duration_ms,
+                    ts=ts,
+                    session_id=session_id,
+                    action=message.action,
+                    path=config.jsonl_path,
+                    ts_unix=ts_unix,
+                )
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.warning(
+                    "stackchan-event log persistence raised unexpectedly: %s", exc
+                )
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any]

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -775,13 +775,21 @@ class ESP32Manager:
             DEFAULT_MESSAGE_TEMPLATES[(event_type, subtype)],
         )
         ts_unix = time.time()
-        params = {
+        event_payload = {
             "event_type": event_type,
             "subtype": subtype,
             "duration_ms": duration_ms,
             "action": message.action,
             "ts": ts,
             "ts_unix": ts_unix,
+            "session_id": session_id,
+        }
+        legacy_params = {
+            "event_type": event_type,
+            "subtype": subtype,
+            "duration_ms": duration_ms,
+            "action": message.action,
+            "ts": ts,
             "session_id": session_id,
         }
         logger.info(
@@ -807,13 +815,13 @@ class ESP32Manager:
         from .stdio_server import notify_stackchan_event
 
         if config.legacy_event_enabled:
-            await notify_stackchan_event("stackchan/event", params)
+            await notify_stackchan_event("stackchan/event", legacy_params)
 
         if config.channels_enabled:
-            content = render_template(message.template, params)
+            content = render_template(message.template, event_payload)
             await notify_stackchan_event(
                 "notifications/claude/channel",
-                {"content": content, "meta": params},
+                {"content": content, "meta": event_payload},
             )
 
         if config.jsonl_enabled:

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -819,9 +819,21 @@ class ESP32Manager:
 
         if config.channels_enabled:
             content = render_template(message.template, event_payload)
+            # Channel notification meta must be all-string per CC binary's
+            # Zod schema (matches public plugins: telegram/discord/imessage
+            # all use string fields like chat_id, message_id, ts in ISO).
+            channel_meta = {
+                "event_type": event_type,
+                "subtype": subtype,
+                "duration_ms": str(duration_ms),
+                "action": message.action,
+                "ts": str(ts),
+                "ts_unix": str(ts_unix),
+                "session_id": session_id,
+            }
             await notify_stackchan_event(
                 "notifications/claude/channel",
-                {"content": content, "meta": event_payload},
+                {"content": content, "meta": channel_meta},
             )
 
         if config.jsonl_enabled:

--- a/gateway/stackchan_mcp/event_log.py
+++ b/gateway/stackchan_mcp/event_log.py
@@ -1,15 +1,13 @@
 """Event log writer for firmware-originated stackchan events.
 
-The gateway appends each successfully-validated ``stackchan-event`` frame
-to a JSONL file (default ``~/.claude/stackchan-events.jsonl``) so that
-downstream consumers — most notably an MCP client hook that injects the
-event into the next agent turn as additional context — can read events
-between the firmware reaction and the next conversational turn. This is
-the gateway-side half of the "touch event reaches the LLM client" path;
-the MCP notification path itself remains unchanged and is the primary
-delivery channel for capability-aware clients.
+When the JSONL notification path is enabled, the gateway appends each
+successfully-validated ``stackchan-event`` frame to a JSONL file (default
+``~/.claude/stackchan-events.jsonl``) so downstream host integrations can
+read events between the firmware reaction and the next conversational
+turn. MCP notification paths are configured independently.
 
-The log file path is overridable via ``STACKCHAN_EVENTS_PATH``. Entries
+The log file path is overridable via ``STACKCHAN_EVENTS_PATH`` or an
+explicit caller-provided path. Entries
 whose ``ts_unix`` is older than ``RETENTION_DAYS`` are pruned exactly
 once on gateway startup via :func:`rotate_old_entries`. Long-running
 gateways are not re-rotated mid-flight; downstream readers are expected
@@ -60,6 +58,8 @@ def log_event(
     ts: int,
     session_id: str,
     *,
+    action: str | None = None,
+    path: Path | None = None,
     ts_unix: float | None = None,
 ) -> None:
     """Append a single stackchan event to the JSONL log.
@@ -72,6 +72,11 @@ def log_event(
         in milliseconds (monotonic); ``ts_unix`` is the wall-clock
         moment the gateway recorded the event and is what hook
         consumers should use for ``"how long ago"`` calculations.
+    action
+        Optional human-axis avatar action to include in the JSONL payload.
+    path
+        Optional resolved log path from notify.yml. When omitted, the legacy
+        ``STACKCHAN_EVENTS_PATH`` / default path resolution is used.
     ts_unix
         Optional override for the wall-clock timestamp. Defaults to
         ``time.time()`` at append time. Exposed for tests.
@@ -82,7 +87,8 @@ def log_event(
     if ts_unix is None:
         ts_unix = time.time()
 
-    path = resolve_log_path()
+    if path is None:
+        path = resolve_log_path()
     line = {
         "event_type": event_type,
         "subtype": subtype,
@@ -91,6 +97,8 @@ def log_event(
         "ts_unix": ts_unix,
         "session_id": session_id,
     }
+    if action is not None:
+        line["action"] = action
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as f:
@@ -104,7 +112,11 @@ def log_event(
         )
 
 
-def rotate_old_entries(*, now_unix: float | None = None) -> None:
+def rotate_old_entries(
+    *,
+    path: Path | None = None,
+    now_unix: float | None = None,
+) -> None:
     """Prune log entries older than ``RETENTION_DAYS`` from the log file.
 
     Intended to be called exactly once at gateway startup. Reads every
@@ -117,7 +129,8 @@ def rotate_old_entries(*, now_unix: float | None = None) -> None:
     rotation is logged at WARNING and swallowed so a broken log file
     cannot prevent the gateway from starting up.
     """
-    path = resolve_log_path()
+    if path is None:
+        path = resolve_log_path()
     if not path.exists():
         return
     if now_unix is None:

--- a/gateway/stackchan_mcp/http_server.py
+++ b/gateway/stackchan_mcp/http_server.py
@@ -23,6 +23,7 @@ from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route
 from starlette.types import Receive, Scope, Send
 
+from .notify_config import NotifyConfig
 from .queue import CommandQueue, QueueFull, QueueItem, build_queue_full_error
 from .stdio_server import _dispatch_mcp_tool, create_server
 
@@ -97,9 +98,10 @@ def build_app(
     port: int,
     token: str | None = None,
     dispatch_fn: DispatchFn | None = None,
+    notify_config: NotifyConfig | None = None,
 ) -> _GuardedASGIApp:
     """Build the ASGI app for Streamable HTTP MCP plus health endpoints."""
-    server = create_server()
+    server = create_server(notify_config=notify_config)
     session_manager = StreamableHTTPSessionManager(
         app=server,
         json_response=True,

--- a/gateway/stackchan_mcp/notify.example.yml
+++ b/gateway/stackchan_mcp/notify.example.yml
@@ -1,0 +1,16 @@
+# ~/.config/stackchan-mcp/notify.yml
+legacy_event:
+  enabled: false          # self-defined method "stackchan/event" (existing, backward-compat)
+channels:
+  enabled: false          # standard "notifications/claude/channel"
+jsonl:
+  enabled: false          # JSONL append for out-of-process host integration
+  path: ~/.claude/stackchan-events.jsonl
+messages:
+  touch:
+    tap:
+      action: head_pat
+      template: "(head pat)"
+    stroke:
+      action: head_stroke
+      template: "(head stroke, {duration_ms}ms)"

--- a/gateway/stackchan_mcp/notify_config.py
+++ b/gateway/stackchan_mcp/notify_config.py
@@ -91,10 +91,17 @@ def load_notify_config() -> NotifyConfig:
 
 
 def render_template(template: str, payload: dict[str, Any]) -> str:
-    """Render a user template while preserving unknown placeholders."""
+    """Render a user template while preserving unknown placeholders.
+
+    A malformed-but-yaml-valid template (e.g. ``{duration_ms.foo}`` or
+    ``{unknown[0]}``) can raise ``AttributeError`` or ``TypeError`` from
+    ``str.format_map``. These are caught here so a single bad user template
+    cannot crash the channels dispatch path on every physical event; the
+    original template string is returned as a defensive fallback.
+    """
     try:
         return template.format_map(_SafeFormatDict(payload))
-    except (IndexError, KeyError, ValueError):
+    except (IndexError, KeyError, ValueError, AttributeError, TypeError):
         return template
 
 

--- a/gateway/stackchan_mcp/notify_config.py
+++ b/gateway/stackchan_mcp/notify_config.py
@@ -1,0 +1,228 @@
+"""Notification configuration for Stack-chan physical events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+from .event_log import DEFAULT_LOG_PATH, PATH_ENV_VAR
+
+logger = logging.getLogger(__name__)
+
+CONFIG_ENV_VAR: Final[str] = "STACKCHAN_NOTIFY_CONFIG"
+CONFIG_FILENAME: Final[str] = "stackchan-mcp/notify.yml"
+
+
+@dataclass(frozen=True)
+class MessageTemplate:
+    action: str
+    template: str
+
+
+@dataclass(frozen=True)
+class NotifyConfig:
+    legacy_event_enabled: bool
+    channels_enabled: bool
+    jsonl_enabled: bool
+    jsonl_path: Path
+    messages: dict[tuple[str, str], MessageTemplate]
+
+
+DEFAULT_MESSAGE_TEMPLATES: Final[dict[tuple[str, str], MessageTemplate]] = {
+    ("touch", "tap"): MessageTemplate(
+        action="head_pat",
+        template="(head pat)",
+    ),
+    ("touch", "stroke"): MessageTemplate(
+        action="head_stroke",
+        template="(head stroke, {duration_ms}ms)",
+    ),
+}
+
+
+def resolve_notify_config_path() -> Path | None:
+    """Return the first existing notify.yml path, or None."""
+    override = os.environ.get(CONFIG_ENV_VAR)
+    if override:
+        path = Path(override).expanduser()
+        if path.exists():
+            return path
+        logger.warning(
+            "%s points to a non-existent file: %s",
+            CONFIG_ENV_VAR,
+            path,
+        )
+        return None
+
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    candidates = []
+    if xdg_config_home:
+        candidates.append(Path(xdg_config_home).expanduser() / CONFIG_FILENAME)
+    candidates.append(Path.home() / ".config" / CONFIG_FILENAME)
+
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def load_notify_config() -> NotifyConfig:
+    """Load the notification config, falling back to all-OFF on errors."""
+    path = resolve_notify_config_path()
+    if path is None:
+        return _default_config()
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+        return _parse_config(raw)
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as exc:
+        logger.warning(
+            "Failed to load Stack-chan notify config from %s: %s",
+            path,
+            exc,
+        )
+        return _default_config()
+
+
+def render_template(template: str, payload: dict[str, Any]) -> str:
+    """Render a user template while preserving unknown placeholders."""
+    try:
+        return template.format_map(_SafeFormatDict(payload))
+    except (IndexError, KeyError, ValueError):
+        return template
+
+
+def _default_config() -> NotifyConfig:
+    return NotifyConfig(
+        legacy_event_enabled=False,
+        channels_enabled=False,
+        jsonl_enabled=False,
+        jsonl_path=_resolve_jsonl_path(None),
+        messages=_default_messages(),
+    )
+
+
+def _default_messages() -> dict[tuple[str, str], MessageTemplate]:
+    return dict(DEFAULT_MESSAGE_TEMPLATES)
+
+
+def _parse_config(raw: Any) -> NotifyConfig:
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise ValueError("notify config root must be a mapping")
+
+    legacy_event_enabled = _parse_enabled(raw, "legacy_event")
+    channels_enabled = _parse_enabled(raw, "channels")
+    jsonl_section = _parse_section(raw, "jsonl")
+    jsonl_enabled = _parse_enabled(raw, "jsonl")
+    jsonl_path = _resolve_jsonl_path(_optional_string(jsonl_section, "path"))
+    messages = _parse_messages(raw.get("messages"))
+
+    return NotifyConfig(
+        legacy_event_enabled=legacy_event_enabled,
+        channels_enabled=channels_enabled,
+        jsonl_enabled=jsonl_enabled,
+        jsonl_path=jsonl_path,
+        messages=messages,
+    )
+
+
+def _parse_enabled(root: dict[Any, Any], section_name: str) -> bool:
+    section = _parse_section(root, section_name)
+    enabled = section.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError(f"{section_name}.enabled must be a boolean")
+    return enabled
+
+
+def _parse_section(root: dict[Any, Any], section_name: str) -> dict[Any, Any]:
+    section = root.get(section_name, {})
+    if section is None:
+        return {}
+    if not isinstance(section, dict):
+        raise ValueError(f"{section_name} must be a mapping")
+    return section
+
+
+def _optional_string(section: dict[Any, Any], key: str) -> str | None:
+    value = section.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _parse_messages(raw_messages: Any) -> dict[tuple[str, str], MessageTemplate]:
+    messages = _default_messages()
+    if raw_messages is None:
+        return messages
+    if not isinstance(raw_messages, dict):
+        raise ValueError("messages must be a mapping")
+
+    for event_type, subtypes in raw_messages.items():
+        if not isinstance(event_type, str) or not event_type:
+            raise ValueError("messages event_type keys must be non-empty strings")
+        if not isinstance(subtypes, dict):
+            raise ValueError(f"messages.{event_type} must be a mapping")
+        for subtype, message in subtypes.items():
+            if not isinstance(subtype, str) or not subtype:
+                raise ValueError("messages subtype keys must be non-empty strings")
+            if not isinstance(message, dict):
+                raise ValueError(f"messages.{event_type}.{subtype} must be a mapping")
+            action = message.get("action")
+            template = message.get("template")
+            if not isinstance(action, str) or not action:
+                raise ValueError(
+                    f"messages.{event_type}.{subtype}.action must be a non-empty string"
+                )
+            if not isinstance(template, str) or not template:
+                raise ValueError(
+                    f"messages.{event_type}.{subtype}.template must be a non-empty string"
+                )
+            messages[(event_type, subtype)] = MessageTemplate(
+                action=action,
+                template=template,
+            )
+    return messages
+
+
+def _resolve_jsonl_path(configured_path: str | None) -> Path:
+    override = os.environ.get(PATH_ENV_VAR)
+    if override:
+        return _absolute_path(override)
+    if configured_path:
+        return _absolute_path(configured_path)
+    return DEFAULT_LOG_PATH
+
+
+def _absolute_path(raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if path.is_absolute():
+        return path
+    return path.resolve()
+
+
+class _SafeFormatDict(dict[str, Any]):
+    def __missing__(self, key: str) -> "_MissingPlaceholder":
+        return _MissingPlaceholder(key)
+
+
+class _MissingPlaceholder:
+    def __init__(self, key: str) -> None:
+        self._key = key
+
+    def __format__(self, spec: str) -> str:
+        if spec:
+            return "{" + self._key + ":" + spec + "}"
+        return "{" + self._key + "}"
+
+    def __str__(self) -> str:
+        return "{" + self._key + "}"

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -20,12 +20,16 @@ from mcp.types import Notification, TextContent, Tool
 
 from . import __version__
 from .gateway import get_gateway
+from .notify_config import NotifyConfig, load_notify_config
 from .stt import listen_and_transcribe
 from .tts import synthesize_and_send
 
 logger = logging.getLogger(__name__)
 
 STACKCHAN_EVENT_METHOD = "stackchan/event"
+CHANNEL_NOTIFICATION_METHOD = "notifications/claude/channel"
+CHANNEL_CAPABILITY = "claude/channel"
+_SUPPORTED_EVENT_METHODS = {STACKCHAN_EVENT_METHOD, CHANNEL_NOTIFICATION_METHOD}
 STACKCHAN_EVENT_INSTRUCTIONS = (
     "Stack-chan physical events arrive as server-initiated "
     "notifications with method='stackchan/event'. Params include "
@@ -35,6 +39,16 @@ STACKCHAN_EVENT_INSTRUCTIONS = (
     "(set_avatar, say, set_mouth, set_leds, move_head). There is "
     "no dedicated reply tool — the existing tool palette is the "
     "reaction surface."
+)
+STACKCHAN_CHANNEL_INSTRUCTIONS = (
+    'Stack-chan physical events arrive as Channels notifications under '
+    '<channel source="stackchan" action="..." subtype="..." '
+    'duration_ms="...">. React naturally using existing tools '
+    '(set_avatar, say, set_mouth, set_leds, move_head).'
+)
+STACKCHAN_JSONL_INSTRUCTIONS = (
+    "Stack-chan physical events are persisted to the JSONL log; host "
+    "integration consumes them externally."
 )
 
 PRESET_DPS = {
@@ -57,6 +71,13 @@ class StackChanEventNotification(
     Notification[dict[str, Any], Literal["stackchan/event"]]
 ):
     method: Literal["stackchan/event"] = "stackchan/event"
+    params: dict[str, Any]
+
+
+class StackChanChannelNotification(
+    Notification[dict[str, Any], Literal["notifications/claude/channel"]]
+):
+    method: Literal["notifications/claude/channel"] = "notifications/claude/channel"
     params: dict[str, Any]
 
 
@@ -150,7 +171,7 @@ def _latest_active_session() -> Any | None:
 
 async def notify_stackchan_event(method: str, params: dict[str, Any]) -> None:
     """Forward a stackchan event to the connected MCP client."""
-    if method != STACKCHAN_EVENT_METHOD:
+    if method not in _SUPPORTED_EVENT_METHODS:
         logger.warning("Unsupported stackchan event notification method: %s", method)
         return
 
@@ -158,26 +179,68 @@ async def notify_stackchan_event(method: str, params: dict[str, Any]) -> None:
     if not sessions and _active_session is not None:
         sessions = [_active_session]
     if not sessions:
-        logger.warning("Cannot emit stackchan/event notification: no active MCP session")
+        logger.warning("Cannot emit %s notification: no active MCP session", method)
         return
 
-    notification = StackChanEventNotification(params=params)
+    notification = _build_stackchan_notification(method, params)
     for session in sessions:
         try:
             await session.send_notification(cast(Any, notification))
         except Exception as exc:  # pragma: no cover - depends on client transport failure
-            logger.warning("Failed to emit stackchan/event notification: %s", exc)
+            logger.warning("Failed to emit %s notification: %s", method, exc)
 
 
-def _create_initialization_options(server: Server) -> InitializationOptions:
+def _build_stackchan_notification(
+    method: str,
+    params: dict[str, Any],
+) -> StackChanEventNotification | StackChanChannelNotification:
+    if method == STACKCHAN_EVENT_METHOD:
+        return StackChanEventNotification(params=params)
+    return StackChanChannelNotification(params=params)
+
+
+def _build_experimental_capabilities(
+    notify_config: NotifyConfig,
+) -> dict[str, dict[str, Any]]:
+    capabilities: dict[str, dict[str, Any]] = {}
+    if notify_config.legacy_event_enabled:
+        capabilities[STACKCHAN_EVENT_METHOD] = {}
+    if notify_config.channels_enabled:
+        capabilities[CHANNEL_CAPABILITY] = {}
+    return capabilities
+
+
+def _build_stackchan_event_instructions(notify_config: NotifyConfig) -> str | None:
+    fragments = []
+    if notify_config.channels_enabled:
+        fragments.append(STACKCHAN_CHANNEL_INSTRUCTIONS)
+    if notify_config.legacy_event_enabled:
+        fragments.append(STACKCHAN_EVENT_INSTRUCTIONS)
+    if (
+        notify_config.jsonl_enabled
+        and not notify_config.channels_enabled
+        and not notify_config.legacy_event_enabled
+    ):
+        fragments.append(STACKCHAN_JSONL_INSTRUCTIONS)
+    if not fragments:
+        return None
+    return "\n\n".join(fragments)
+
+
+def _create_initialization_options(
+    server: Server,
+    notify_config: NotifyConfig | None = None,
+) -> InitializationOptions:
+    if notify_config is None:
+        notify_config = load_notify_config()
     return InitializationOptions(
         server_name="stackchan-mcp",
         server_version=__version__,
         capabilities=server.get_capabilities(
             notification_options=NotificationOptions(),
-            experimental_capabilities={STACKCHAN_EVENT_METHOD: {}},
+            experimental_capabilities=_build_experimental_capabilities(notify_config),
         ),
-        instructions=STACKCHAN_EVENT_INSTRUCTIONS,
+        instructions=_build_stackchan_event_instructions(notify_config),
     )
 
 
@@ -1284,9 +1347,13 @@ def create_server() -> Server:
     return server
 
 
-async def run_stdio_server() -> None:
+async def run_stdio_server(notify_config: NotifyConfig | None = None) -> None:
     """Run the MCP server on stdio."""
     server = create_server()
     async with stdio_server() as (read_stream, write_stream):
         logger.info("stdio MCP server starting")
-        await server.run(read_stream, write_stream, _create_initialization_options(server))
+        await server.run(
+            read_stream,
+            write_stream,
+            _create_initialization_options(server, notify_config=notify_config),
+        )

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -42,7 +42,7 @@ STACKCHAN_EVENT_INSTRUCTIONS = (
 )
 STACKCHAN_CHANNEL_INSTRUCTIONS = (
     'Stack-chan physical events arrive as Channels notifications under '
-    '<channel source="stackchan" action="..." subtype="..." '
+    '<channel source="stackchan-mcp" action="..." subtype="..." '
     'duration_ms="...">. React naturally using existing tools '
     '(set_avatar, say, set_mouth, set_leds, move_head).'
 )

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -82,13 +82,17 @@ class StackChanChannelNotification(
 
 
 class StackChanServer(Server):
+    def __init__(self, name: str, *, notify_config: NotifyConfig) -> None:
+        super().__init__(name)
+        self._notify_config = notify_config
+
     def create_initialization_options(
         self,
         notification_options: NotificationOptions | None = None,
         experimental_capabilities: dict[str, dict[str, Any]] | None = None,
     ) -> InitializationOptions:
         if notification_options is None and experimental_capabilities is None:
-            return _create_initialization_options(self)
+            return _create_initialization_options(self, self._notify_config)
         return super().create_initialization_options(
             notification_options=notification_options,
             experimental_capabilities=experimental_capabilities,
@@ -229,10 +233,8 @@ def _build_stackchan_event_instructions(notify_config: NotifyConfig) -> str | No
 
 def _create_initialization_options(
     server: Server,
-    notify_config: NotifyConfig | None = None,
+    notify_config: NotifyConfig,
 ) -> InitializationOptions:
-    if notify_config is None:
-        notify_config = load_notify_config()
     return InitializationOptions(
         server_name="stackchan-mcp",
         server_version=__version__,
@@ -587,10 +589,12 @@ async def _dispatch_mcp_tool(
     return [TextContent(type="text", text=str(result))]
 
 
-def create_server() -> Server:
+def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
     """Create and configure the MCP server with tool handlers."""
     _verify_mcp_sdk_compatibility()
-    server = StackChanServer("stackchan-mcp")
+    if notify_config is None:
+        notify_config = load_notify_config()
+    server = StackChanServer("stackchan-mcp", notify_config=notify_config)
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
@@ -1349,11 +1353,13 @@ def create_server() -> Server:
 
 async def run_stdio_server(notify_config: NotifyConfig | None = None) -> None:
     """Run the MCP server on stdio."""
-    server = create_server()
+    if notify_config is None:
+        notify_config = load_notify_config()
+    server = create_server(notify_config=notify_config)
     async with stdio_server() as (read_stream, write_stream):
         logger.info("stdio MCP server starting")
         await server.run(
             read_stream,
             write_stream,
-            _create_initialization_options(server, notify_config=notify_config),
+            _create_initialization_options(server, notify_config),
         )

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -237,7 +237,7 @@ async def test_run_sigterm_handler_cancels_and_stops_gateway(
         async def stop(self) -> None:
             events.append("stop")
 
-    async def fake_run_stdio_server() -> None:
+    async def fake_run_stdio_server(*, notify_config=None) -> None:
         events.append("stdio")
         handler = registered_handlers[signal.SIGTERM]
         assert callable(handler)
@@ -257,6 +257,67 @@ async def test_run_sigterm_handler_cancels_and_stops_gateway(
     assert registered_handlers.keys() == {signal.SIGTERM}
     assert events == [("start", False), "stdio", "stop"]
 
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("jsonl_enabled", [False, True])
+async def test_run_rotates_event_log_only_when_jsonl_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    jsonl_enabled: bool,
+) -> None:
+    from stackchan_mcp import event_log as event_log_module
+    from stackchan_mcp import gateway as gateway_module
+    from stackchan_mcp import notify_config as notify_config_module
+    from stackchan_mcp import stdio_server
+    from stackchan_mcp.notify_config import DEFAULT_MESSAGE_TEMPLATES, NotifyConfig
+
+    events: list[object] = []
+    rotate_calls: list[Path] = []
+    jsonl_path = tmp_path / "events.jsonl"
+    config = NotifyConfig(
+        legacy_event_enabled=False,
+        channels_enabled=False,
+        jsonl_enabled=jsonl_enabled,
+        jsonl_path=jsonl_path,
+        messages=dict(DEFAULT_MESSAGE_TEMPLATES),
+    )
+
+    class FakeESP32:
+        def set_notify_config(self, notify_config: NotifyConfig) -> None:
+            events.append(("set_notify_config", notify_config))
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+        async def start(self, *, advertise_mdns: bool = True) -> None:
+            events.append(("start", advertise_mdns))
+
+        async def stop(self) -> None:
+            events.append("stop")
+
+    async def fake_run_stdio_server(*, notify_config=None) -> None:
+        events.append("stdio")
+
+    def fake_rotate_old_entries(*, path: Path, now_unix: float | None = None) -> None:
+        rotate_calls.append(path)
+
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(notify_config_module, "load_notify_config", lambda: config)
+    monkeypatch.setattr(event_log_module, "rotate_old_entries", fake_rotate_old_entries)
+    monkeypatch.setattr(gateway_module, "get_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(stdio_server, "run_stdio_server", fake_run_stdio_server)
+
+    await cli._run(advertise_mdns=False)
+
+    assert (rotate_calls == [jsonl_path]) == jsonl_enabled
+    assert events == [
+        ("set_notify_config", config),
+        ("start", False),
+        "stdio",
+        "stop",
+    ]
 
 def test_main_check_flag_remains_side_effect_free_with_no_mdns(
     monkeypatch: pytest.MonkeyPatch,

--- a/gateway/tests/test_event_dispatch.py
+++ b/gateway/tests/test_event_dispatch.py
@@ -6,11 +6,13 @@ import pytest
 
 from stackchan_mcp import esp32_client, event_log, stdio_server
 from stackchan_mcp.esp32_client import ESP32Manager
+from stackchan_mcp.http_server import build_app
 from stackchan_mcp.notify_config import (
     DEFAULT_MESSAGE_TEMPLATES,
     MessageTemplate,
     NotifyConfig,
 )
+from stackchan_mcp.queue import CommandQueue
 
 
 @pytest.mark.asyncio
@@ -69,7 +71,7 @@ async def test_emit_stackchan_event_dispatches_selected_paths(
 
     if legacy_enabled:
         legacy_params = dict(notify_calls[0][1])
-        assert legacy_params == _expected_meta()
+        assert legacy_params == _expected_legacy_params()
         assert legacy_params["action"] == "head_pat"
 
     if channels_enabled:
@@ -142,6 +144,104 @@ async def test_custom_message_overrides_action_and_channel_content(monkeypatch):
     ]
 
 
+@pytest.mark.asyncio
+async def test_legacy_event_params_exclude_ts_unix(monkeypatch):
+    notify_calls, log_calls = await _capture_emit(
+        monkeypatch,
+        _notify_config(legacy=True, channels=False, jsonl=False),
+    )
+
+    assert notify_calls == [
+        (stdio_server.STACKCHAN_EVENT_METHOD, _expected_legacy_params())
+    ]
+    assert set(notify_calls[0][1]) == {
+        "event_type",
+        "subtype",
+        "duration_ms",
+        "action",
+        "ts",
+        "session_id",
+    }
+    assert log_calls == []
+
+
+@pytest.mark.asyncio
+async def test_channels_meta_includes_ts_unix(monkeypatch):
+    notify_calls, log_calls = await _capture_emit(
+        monkeypatch,
+        _notify_config(legacy=False, channels=True, jsonl=False),
+    )
+
+    assert notify_calls == [
+        (
+            stdio_server.CHANNEL_NOTIFICATION_METHOD,
+            {"content": "(head pat)", "meta": _expected_meta()},
+        )
+    ]
+    assert notify_calls[0][1]["meta"]["ts_unix"] == 1717000000.25
+    assert log_calls == []
+
+
+@pytest.mark.asyncio
+async def test_jsonl_payload_includes_ts_unix(monkeypatch):
+    notify_calls, log_calls = await _capture_emit(
+        monkeypatch,
+        _notify_config(legacy=False, channels=False, jsonl=True),
+    )
+
+    assert notify_calls == []
+    assert log_calls[0]["ts_unix"] == 1717000000.25
+
+
+@pytest.mark.asyncio
+async def test_mixed_legacy_and_channels(monkeypatch):
+    notify_calls, log_calls = await _capture_emit(
+        monkeypatch,
+        _notify_config(legacy=True, channels=True, jsonl=False),
+    )
+
+    assert notify_calls == [
+        (stdio_server.STACKCHAN_EVENT_METHOD, _expected_legacy_params()),
+        (
+            stdio_server.CHANNEL_NOTIFICATION_METHOD,
+            {"content": "(head pat)", "meta": _expected_meta()},
+        ),
+    ]
+    legacy_params = notify_calls[0][1]
+    channel_meta = notify_calls[1][1]["meta"]
+    assert {key: channel_meta[key] for key in legacy_params} == legacy_params
+    assert "ts_unix" in channel_meta
+    assert "ts_unix" not in legacy_params
+    assert log_calls == []
+
+
+def test_http_session_uses_startup_notify_config(monkeypatch):
+    startup_config = _notify_config(legacy=False, channels=True, jsonl=False)
+    post_startup_config = _notify_config(legacy=False, channels=False, jsonl=False)
+    load_calls = []
+
+    def load_post_startup_config():
+        load_calls.append("load")
+        return post_startup_config
+
+    monkeypatch.setattr(stdio_server, "load_notify_config", load_post_startup_config)
+    app = build_app(
+        CommandQueue(),
+        gateway=_FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        notify_config=startup_config,
+    )
+
+    server = app.state.session_manager.app
+    options = server.create_initialization_options()
+
+    assert load_calls == []
+    assert options.capabilities.experimental == {stdio_server.CHANNEL_CAPABILITY: {}}
+    assert options.instructions == stdio_server.STACKCHAN_CHANNEL_INSTRUCTIONS
+
+
 def _notify_config(
     *,
     legacy: bool,
@@ -159,11 +259,42 @@ def _notify_config(
     )
 
 
+async def _capture_emit(monkeypatch, notify_config: NotifyConfig):
+    notify_calls: list[tuple[str, dict]] = []
+    log_calls: list[dict] = []
+
+    async def fake_notify(method, params):
+        notify_calls.append((method, params))
+
+    def fake_log_event(**kwargs):
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
+    monkeypatch.setattr(event_log, "log_event", fake_log_event)
+    monkeypatch.setattr(esp32_client.time, "time", lambda: 1717000000.25)
+
+    manager = ESP32Manager(notify_config=notify_config)
+    await manager._emit_stackchan_event(_payload())
+
+    return notify_calls, log_calls
+
+
 def _payload() -> dict:
     return {
         "event_type": "touch",
         "subtype": "tap",
         "duration_ms": 350,
+        "ts": 123456,
+        "session_id": "session-1",
+    }
+
+
+def _expected_legacy_params() -> dict:
+    return {
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "action": "head_pat",
         "ts": 123456,
         "session_id": "session-1",
     }
@@ -179,3 +310,14 @@ def _expected_meta() -> dict:
         "ts_unix": 1717000000.25,
         "session_id": "session-1",
     }
+
+
+class _FakeESP32:
+    device_connected = True
+
+    def get_status(self) -> dict:
+        return {"connected": True}
+
+
+class _FakeGateway:
+    esp32 = _FakeESP32()

--- a/gateway/tests/test_event_dispatch.py
+++ b/gateway/tests/test_event_dispatch.py
@@ -1,0 +1,181 @@
+"""Tests for Stack-chan event notification dispatch modes."""
+
+from pathlib import Path
+
+import pytest
+
+from stackchan_mcp import esp32_client, event_log, stdio_server
+from stackchan_mcp.esp32_client import ESP32Manager
+from stackchan_mcp.notify_config import (
+    DEFAULT_MESSAGE_TEMPLATES,
+    MessageTemplate,
+    NotifyConfig,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("legacy_enabled", "channels_enabled", "jsonl_enabled"),
+    [
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+        (True, True, False),
+        (True, False, True),
+        (False, True, True),
+        (True, True, True),
+    ],
+)
+async def test_emit_stackchan_event_dispatches_selected_paths(
+    monkeypatch,
+    caplog,
+    legacy_enabled,
+    channels_enabled,
+    jsonl_enabled,
+):
+    notify_calls: list[tuple[str, dict]] = []
+    log_calls: list[dict] = []
+
+    async def fake_notify(method, params):
+        notify_calls.append((method, params))
+
+    def fake_log_event(**kwargs):
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
+    monkeypatch.setattr(event_log, "log_event", fake_log_event)
+    monkeypatch.setattr(esp32_client.time, "time", lambda: 1717000000.25)
+
+    jsonl_path = Path("/tmp/stackchan-events-test.jsonl")
+    manager = ESP32Manager(
+        notify_config=_notify_config(
+            legacy=legacy_enabled,
+            channels=channels_enabled,
+            jsonl=jsonl_enabled,
+            jsonl_path=jsonl_path,
+        )
+    )
+
+    with caplog.at_level("INFO"):
+        await manager._emit_stackchan_event(_payload())
+
+    expected_notify_methods = []
+    if legacy_enabled:
+        expected_notify_methods.append(stdio_server.STACKCHAN_EVENT_METHOD)
+    if channels_enabled:
+        expected_notify_methods.append(stdio_server.CHANNEL_NOTIFICATION_METHOD)
+    assert [method for method, _ in notify_calls] == expected_notify_methods
+
+    if legacy_enabled:
+        legacy_params = dict(notify_calls[0][1])
+        assert legacy_params == _expected_meta()
+        assert legacy_params["action"] == "head_pat"
+
+    if channels_enabled:
+        channel_index = expected_notify_methods.index(stdio_server.CHANNEL_NOTIFICATION_METHOD)
+        channel_params = notify_calls[channel_index][1]
+        assert channel_params == {
+            "content": "(head pat)",
+            "meta": _expected_meta(),
+        }
+        assert channel_params["meta"]["action"] == "head_pat"
+
+    if jsonl_enabled:
+        assert log_calls == [
+            {
+                "event_type": "touch",
+                "subtype": "tap",
+                "duration_ms": 350,
+                "ts": 123456,
+                "session_id": "session-1",
+                "action": "head_pat",
+                "path": jsonl_path,
+                "ts_unix": 1717000000.25,
+            }
+        ]
+    else:
+        assert log_calls == []
+
+    if not (legacy_enabled or channels_enabled or jsonl_enabled):
+        assert notify_calls == []
+        assert "received and dropped" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_custom_message_overrides_action_and_channel_content(monkeypatch):
+    notify_calls: list[tuple[str, dict]] = []
+
+    async def fake_notify(method, params):
+        notify_calls.append((method, params))
+
+    monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
+    monkeypatch.setattr(esp32_client.time, "time", lambda: 1717000000.25)
+
+    messages = dict(DEFAULT_MESSAGE_TEMPLATES)
+    messages[("touch", "tap")] = MessageTemplate(
+        action="head_knock",
+        template="(head knock, {duration_ms}ms)",
+    )
+    manager = ESP32Manager(
+        notify_config=_notify_config(
+            legacy=False,
+            channels=True,
+            jsonl=False,
+            messages=messages,
+        )
+    )
+
+    await manager._emit_stackchan_event(_payload())
+
+    assert notify_calls == [
+        (
+            stdio_server.CHANNEL_NOTIFICATION_METHOD,
+            {
+                "content": "(head knock, 350ms)",
+                "meta": {
+                    **_expected_meta(),
+                    "action": "head_knock",
+                },
+            },
+        )
+    ]
+
+
+def _notify_config(
+    *,
+    legacy: bool,
+    channels: bool,
+    jsonl: bool,
+    jsonl_path: Path = Path("/tmp/stackchan-events-test.jsonl"),
+    messages: dict[tuple[str, str], MessageTemplate] | None = None,
+) -> NotifyConfig:
+    return NotifyConfig(
+        legacy_event_enabled=legacy,
+        channels_enabled=channels,
+        jsonl_enabled=jsonl,
+        jsonl_path=jsonl_path,
+        messages=messages or dict(DEFAULT_MESSAGE_TEMPLATES),
+    )
+
+
+def _payload() -> dict:
+    return {
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "ts": 123456,
+        "session_id": "session-1",
+    }
+
+
+def _expected_meta() -> dict:
+    return {
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "action": "head_pat",
+        "ts": 123456,
+        "ts_unix": 1717000000.25,
+        "session_id": "session-1",
+    }

--- a/gateway/tests/test_event_dispatch.py
+++ b/gateway/tests/test_event_dispatch.py
@@ -178,7 +178,7 @@ async def test_channels_meta_includes_ts_unix(monkeypatch):
             {"content": "(head pat)", "meta": _expected_meta()},
         )
     ]
-    assert notify_calls[0][1]["meta"]["ts_unix"] == 1717000000.25
+    assert notify_calls[0][1]["meta"]["ts_unix"] == "1717000000.25"
     assert log_calls == []
 
 
@@ -209,7 +209,13 @@ async def test_mixed_legacy_and_channels(monkeypatch):
     ]
     legacy_params = notify_calls[0][1]
     channel_meta = notify_calls[1][1]["meta"]
-    assert {key: channel_meta[key] for key in legacy_params} == legacy_params
+    # Channel meta stringifies numeric fields per CC binary Zod schema; legacy
+    # path keeps typed values. Compare common keys after stringification.
+    expected_channel_subset = {
+        key: str(value) if isinstance(value, (int, float)) else value
+        for key, value in legacy_params.items()
+    }
+    assert {key: channel_meta[key] for key in legacy_params} == expected_channel_subset
     assert "ts_unix" in channel_meta
     assert "ts_unix" not in legacy_params
     assert log_calls == []
@@ -304,10 +310,10 @@ def _expected_meta() -> dict:
     return {
         "event_type": "touch",
         "subtype": "tap",
-        "duration_ms": 350,
+        "duration_ms": "350",
         "action": "head_pat",
-        "ts": 123456,
-        "ts_unix": 1717000000.25,
+        "ts": "123456",
+        "ts_unix": "1717000000.25",
         "session_id": "session-1",
     }
 

--- a/gateway/tests/test_event_log.py
+++ b/gateway/tests/test_event_log.py
@@ -65,6 +65,32 @@ def test_log_event_appends_line_to_jsonl(monkeypatch, tmp_path):
     }
 
 
+def test_log_event_accepts_action_and_explicit_path(tmp_path):
+    path = tmp_path / "configured-events.jsonl"
+
+    log_event(
+        event_type="touch",
+        subtype="tap",
+        duration_ms=350,
+        ts=123456,
+        session_id="session-1",
+        action="head_pat",
+        path=path,
+        ts_unix=1717000000.5,
+    )
+
+    entry = json.loads(path.read_text(encoding="utf-8").splitlines()[-1])
+    assert entry == {
+        "event_type": "touch",
+        "subtype": "tap",
+        "duration_ms": 350,
+        "ts": 123456,
+        "ts_unix": 1717000000.5,
+        "session_id": "session-1",
+        "action": "head_pat",
+    }
+
+
 def test_log_event_appends_multiple_lines_in_order(monkeypatch, tmp_path):
     path = tmp_path / "events.jsonl"
     monkeypatch.setenv(PATH_ENV_VAR, str(path))

--- a/gateway/tests/test_notify_config.py
+++ b/gateway/tests/test_notify_config.py
@@ -203,3 +203,29 @@ def test_render_template_substitutes_and_preserves_unknown_placeholders():
     )
 
     assert rendered == "tap 350ms {unknown}"
+
+
+def test_render_template_falls_back_on_malformed_format_strings():
+    """A schema-valid but malformed template must not crash the dispatch path.
+
+    Python ``str.format_map`` can raise ``AttributeError`` for ``{x.attr}`` on
+    a non-attribute value and ``TypeError`` for ``{x[idx]}`` on a non-
+    subscriptable value. ``render_template`` must swallow both and return
+    the original template string so a single bad user template cannot kill
+    every channels-mode tap event.
+    """
+    payload = {"duration_ms": 350}
+
+    # ``{duration_ms.foo}`` triggers AttributeError on int's .foo access.
+    attr_template = "tap {duration_ms.foo}ms"
+    assert render_template(attr_template, payload) == attr_template
+
+    # ``{duration_ms[bad]}`` triggers TypeError on int subscript.
+    item_template = "tap {duration_ms[bad]}ms"
+    assert render_template(item_template, payload) == item_template
+
+    # ``{unknown.foo}`` exercises the _SafeFormatDict missing key path
+    # combined with a downstream attribute access; the fallback should also
+    # return the original template here rather than raise.
+    unknown_attr_template = "tap {unknown.foo}ms"
+    assert render_template(unknown_attr_template, payload) == unknown_attr_template

--- a/gateway/tests/test_notify_config.py
+++ b/gateway/tests/test_notify_config.py
@@ -1,0 +1,205 @@
+"""Tests for Stack-chan notification config loading."""
+
+import logging
+from pathlib import Path
+
+from stackchan_mcp.event_log import DEFAULT_LOG_PATH, PATH_ENV_VAR
+from stackchan_mcp.notify_config import (
+    CONFIG_ENV_VAR,
+    MessageTemplate,
+    load_notify_config,
+    render_template,
+    resolve_notify_config_path,
+)
+
+
+def _isolate_config_env(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    home = tmp_path / "home"
+    xdg = tmp_path / "xdg"
+    home.mkdir()
+    xdg.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+    monkeypatch.delenv(PATH_ENV_VAR, raising=False)
+    return home, xdg
+
+
+def _write_xdg_config(xdg: Path, body: str) -> Path:
+    path = xdg / "stackchan-mcp" / "notify.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_default_no_env_no_file_returns_all_off(monkeypatch, tmp_path):
+    _isolate_config_env(monkeypatch, tmp_path)
+
+    config = load_notify_config()
+
+    assert config.legacy_event_enabled is False
+    assert config.channels_enabled is False
+    assert config.jsonl_enabled is False
+    assert config.jsonl_path == DEFAULT_LOG_PATH
+    assert config.messages[("touch", "tap")] == MessageTemplate(
+        action="head_pat",
+        template="(head pat)",
+    )
+    assert config.messages[("touch", "stroke")] == MessageTemplate(
+        action="head_stroke",
+        template="(head stroke, {duration_ms}ms)",
+    )
+
+
+def test_yaml_legacy_event_only(monkeypatch, tmp_path):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    _write_xdg_config(xdg, "legacy_event:\n  enabled: true\n")
+
+    config = load_notify_config()
+
+    assert config.legacy_event_enabled is True
+    assert config.channels_enabled is False
+    assert config.jsonl_enabled is False
+
+
+def test_yaml_channels_only(monkeypatch, tmp_path):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    _write_xdg_config(xdg, "channels:\n  enabled: true\n")
+
+    config = load_notify_config()
+
+    assert config.legacy_event_enabled is False
+    assert config.channels_enabled is True
+    assert config.jsonl_enabled is False
+
+
+def test_yaml_jsonl_only_with_custom_path(monkeypatch, tmp_path):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    custom_path = tmp_path / "events.jsonl"
+    _write_xdg_config(
+        xdg,
+        f"jsonl:\n  enabled: true\n  path: {custom_path}\n",
+    )
+
+    config = load_notify_config()
+
+    assert config.legacy_event_enabled is False
+    assert config.channels_enabled is False
+    assert config.jsonl_enabled is True
+    assert config.jsonl_path == custom_path
+
+
+def test_yaml_all_three_on(monkeypatch, tmp_path):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    _write_xdg_config(
+        xdg,
+        "legacy_event:\n"
+        "  enabled: true\n"
+        "channels:\n"
+        "  enabled: true\n"
+        "jsonl:\n"
+        "  enabled: true\n",
+    )
+
+    config = load_notify_config()
+
+    assert config.legacy_event_enabled is True
+    assert config.channels_enabled is True
+    assert config.jsonl_enabled is True
+
+
+def test_stackchan_events_path_overrides_yaml_jsonl_path(monkeypatch, tmp_path):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    yaml_path = tmp_path / "from-yaml.jsonl"
+    env_path = tmp_path / "from-env.jsonl"
+    _write_xdg_config(
+        xdg,
+        f"jsonl:\n  enabled: true\n  path: {yaml_path}\n",
+    )
+    monkeypatch.setenv(PATH_ENV_VAR, str(env_path))
+
+    config = load_notify_config()
+
+    assert config.jsonl_enabled is True
+    assert config.jsonl_path == env_path
+
+
+def test_stackchan_notify_config_env_loads_that_path(monkeypatch, tmp_path):
+    _isolate_config_env(monkeypatch, tmp_path)
+    config_path = tmp_path / "explicit-notify.yml"
+    config_path.write_text("channels:\n  enabled: true\n", encoding="utf-8")
+    monkeypatch.setenv(CONFIG_ENV_VAR, str(config_path))
+
+    assert resolve_notify_config_path() == config_path
+    assert load_notify_config().channels_enabled is True
+
+
+def test_stackchan_notify_config_env_missing_warns_and_returns_none(
+    monkeypatch,
+    tmp_path,
+    caplog,
+):
+    _isolate_config_env(monkeypatch, tmp_path)
+    missing = tmp_path / "missing.yml"
+    monkeypatch.setenv(CONFIG_ENV_VAR, str(missing))
+
+    with caplog.at_level(logging.WARNING):
+        path = resolve_notify_config_path()
+
+    assert path is None
+    assert "non-existent file" in caplog.text
+
+
+def test_malformed_yaml_falls_back_to_all_off(monkeypatch, tmp_path, caplog):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    _write_xdg_config(xdg, "legacy_event: [\n")
+
+    with caplog.at_level(logging.WARNING):
+        config = load_notify_config()
+
+    assert config.legacy_event_enabled is False
+    assert config.channels_enabled is False
+    assert config.jsonl_enabled is False
+    assert "Failed to load Stack-chan notify config" in caplog.text
+
+
+def test_custom_messages_override_matching_default(monkeypatch, tmp_path):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    _write_xdg_config(
+        xdg,
+        "messages:\n"
+        "  touch:\n"
+        "    tap:\n"
+        "      action: head_knock\n"
+        "      template: \"(head knock, {duration_ms}ms)\"\n",
+    )
+
+    config = load_notify_config()
+
+    assert config.messages[("touch", "tap")] == MessageTemplate(
+        action="head_knock",
+        template="(head knock, {duration_ms}ms)",
+    )
+    assert config.messages[("touch", "stroke")].action == "head_stroke"
+
+
+def test_schema_error_falls_back_to_all_off(monkeypatch, tmp_path, caplog):
+    _, xdg = _isolate_config_env(monkeypatch, tmp_path)
+    _write_xdg_config(xdg, "legacy_event:\n  enabled: yes please\n")
+
+    with caplog.at_level(logging.WARNING):
+        config = load_notify_config()
+
+    assert config.legacy_event_enabled is False
+    assert config.channels_enabled is False
+    assert config.jsonl_enabled is False
+    assert "legacy_event.enabled must be a boolean" in caplog.text
+
+
+def test_render_template_substitutes_and_preserves_unknown_placeholders():
+    rendered = render_template(
+        "tap {duration_ms}ms {unknown}",
+        {"duration_ms": 350},
+    )
+
+    assert rendered == "tap 350ms {unknown}"

--- a/gateway/tests/test_stackchan_event.py
+++ b/gateway/tests/test_stackchan_event.py
@@ -56,7 +56,6 @@ async def test_stackchan_event_frame_dispatches_to_notify_bridge(monkeypatch):
                 "duration_ms": 350,
                 "action": "head_pat",
                 "ts": 123456,
-                "ts_unix": 1717000000.25,
                 "session_id": "session-1",
             },
         )
@@ -143,9 +142,10 @@ async def test_server_run_captures_active_session_before_first_message(monkeypat
             return None
 
     monkeypatch.setattr(stdio_server, "ServerSession", FakeServerSession)
-    server = create_server()
+    config = _notify_config()
+    server = create_server(notify_config=config)
 
-    await server.run(None, None, _create_initialization_options(server))
+    await server.run(None, None, _create_initialization_options(server, config))
 
     assert len(observed) == 1
     assert isinstance(observed[0], FakeServerSession)

--- a/gateway/tests/test_stackchan_event.py
+++ b/gateway/tests/test_stackchan_event.py
@@ -2,10 +2,13 @@
 
 import json
 import logging
+from pathlib import Path
 
 import pytest
 
+from stackchan_mcp import esp32_client
 from stackchan_mcp.esp32_client import ESP32Manager
+from stackchan_mcp.notify_config import DEFAULT_MESSAGE_TEMPLATES, NotifyConfig
 import stackchan_mcp.stdio_server as stdio_server
 from stackchan_mcp.stdio_server import (
     STACKCHAN_EVENT_INSTRUCTIONS,
@@ -24,7 +27,8 @@ async def test_stackchan_event_frame_dispatches_to_notify_bridge(monkeypatch):
         calls.append((method, params))
 
     monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
-    manager = ESP32Manager()
+    monkeypatch.setattr(esp32_client.time, "time", lambda: 1717000000.25)
+    manager = ESP32Manager(notify_config=_notify_config(legacy=True))
 
     await manager._handler(
         _FakeWebSocket(
@@ -50,7 +54,9 @@ async def test_stackchan_event_frame_dispatches_to_notify_bridge(monkeypatch):
                 "event_type": "touch",
                 "subtype": "tap",
                 "duration_ms": 350,
+                "action": "head_pat",
                 "ts": 123456,
+                "ts_unix": 1717000000.25,
                 "session_id": "session-1",
             },
         )
@@ -85,7 +91,7 @@ async def test_stackchan_event_malformed_frame_warns_without_notify(
         calls.append((method, params))
 
     monkeypatch.setattr(stdio_server, "notify_stackchan_event", fake_notify)
-    manager = ESP32Manager()
+    manager = ESP32Manager(notify_config=_notify_config())
     payload = {
         "session_id": "session-1",
         "type": "stackchan-event",
@@ -105,7 +111,10 @@ async def test_stackchan_event_malformed_frame_warns_without_notify(
 
 def test_stackchan_event_capability_and_instructions_are_declared():
     server = create_server()
-    options = _create_initialization_options(server)
+    options = _create_initialization_options(
+        server,
+        notify_config=_notify_config(legacy=True),
+    )
 
     assert options.capabilities.experimental == {STACKCHAN_EVENT_METHOD: {}}
     assert options.instructions == STACKCHAN_EVENT_INSTRUCTIONS
@@ -217,6 +226,16 @@ async def test_notify_stackchan_event_without_active_session_logs_and_returns(
         )
 
     assert "no active MCP session" in caplog.text
+
+
+def _notify_config(*, legacy: bool = False) -> NotifyConfig:
+    return NotifyConfig(
+        legacy_event_enabled=legacy,
+        channels_enabled=False,
+        jsonl_enabled=False,
+        jsonl_path=Path("/tmp/stackchan-events-test.jsonl"),
+        messages=dict(DEFAULT_MESSAGE_TEMPLATES),
+    )
 
 
 class _FakeWebSocket:

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -1,11 +1,27 @@
 """Tests for stdio MCP server tool definitions."""
 
 import json
+from pathlib import Path
 
 import pytest
 from mcp.types import CallToolRequest, ListToolsRequest
 
-from stackchan_mcp.stdio_server import SPEED_DESCRIPTION, create_server, _resolve_speed_dps
+from stackchan_mcp.notify_config import DEFAULT_MESSAGE_TEMPLATES, NotifyConfig
+from stackchan_mcp.stdio_server import (
+    CHANNEL_CAPABILITY,
+    CHANNEL_NOTIFICATION_METHOD,
+    STACKCHAN_CHANNEL_INSTRUCTIONS,
+    STACKCHAN_EVENT_INSTRUCTIONS,
+    STACKCHAN_EVENT_METHOD,
+    STACKCHAN_JSONL_INSTRUCTIONS,
+    SPEED_DESCRIPTION,
+    _build_experimental_capabilities,
+    _build_stackchan_event_instructions,
+    _create_initialization_options,
+    _resolve_speed_dps,
+    create_server,
+    notify_stackchan_event,
+)
 from stackchan_mcp.tts import get_registry
 
 
@@ -643,3 +659,130 @@ async def test_move_head_rejects_boolean_pitch(monkeypatch, pitch):
     )
 
     _assert_rejected_without_dispatch(result, calls)
+
+
+# ---------------------------------------------------------------------------
+# Stack-chan event notification config: capabilities, instructions, allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "legacy",
+        "channels",
+        "jsonl",
+        "expected_capabilities",
+        "expected_instructions",
+    ),
+    [
+        (
+            False,
+            True,
+            False,
+            {CHANNEL_CAPABILITY: {}},
+            STACKCHAN_CHANNEL_INSTRUCTIONS,
+        ),
+        (
+            True,
+            False,
+            False,
+            {STACKCHAN_EVENT_METHOD: {}},
+            STACKCHAN_EVENT_INSTRUCTIONS,
+        ),
+        (
+            False,
+            False,
+            True,
+            {},
+            STACKCHAN_JSONL_INSTRUCTIONS,
+        ),
+        (
+            True,
+            True,
+            False,
+            {STACKCHAN_EVENT_METHOD: {}, CHANNEL_CAPABILITY: {}},
+            STACKCHAN_CHANNEL_INSTRUCTIONS + "\n\n" + STACKCHAN_EVENT_INSTRUCTIONS,
+        ),
+        (
+            False,
+            False,
+            False,
+            {},
+            None,
+        ),
+    ],
+)
+def test_stackchan_event_capabilities_and_instructions_follow_notify_config(
+    legacy,
+    channels,
+    jsonl,
+    expected_capabilities,
+    expected_instructions,
+):
+    config = _notify_config(legacy=legacy, channels=channels, jsonl=jsonl)
+    server = create_server()
+    options = _create_initialization_options(server, notify_config=config)
+
+    assert _build_experimental_capabilities(config) == expected_capabilities
+    assert options.capabilities.experimental == expected_capabilities
+    assert _build_stackchan_event_instructions(config) == expected_instructions
+    assert options.instructions == expected_instructions
+
+
+@pytest.mark.asyncio
+async def test_notify_stackchan_event_accepts_channel_method(monkeypatch):
+    session = _FakeNotificationSession()
+    monkeypatch.setattr("stackchan_mcp.stdio_server._active_session", session)
+    monkeypatch.setattr("stackchan_mcp.stdio_server._active_sessions", {})
+
+    params = {"content": "(head pat)", "meta": {"action": "head_pat"}}
+    await notify_stackchan_event(CHANNEL_NOTIFICATION_METHOD, params)
+
+    assert session.notifications == [
+        {"method": CHANNEL_NOTIFICATION_METHOD, "params": params}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notify_stackchan_event_rejects_unsupported_method(
+    monkeypatch,
+    caplog,
+):
+    session = _FakeNotificationSession()
+    monkeypatch.setattr("stackchan_mcp.stdio_server._active_session", session)
+    monkeypatch.setattr("stackchan_mcp.stdio_server._active_sessions", {})
+
+    with caplog.at_level("WARNING"):
+        await notify_stackchan_event("notifications/other", {"ok": True})
+
+    assert session.notifications == []
+    assert "Unsupported stackchan event notification method" in caplog.text
+
+
+def _notify_config(
+    *,
+    legacy: bool = False,
+    channels: bool = False,
+    jsonl: bool = False,
+) -> NotifyConfig:
+    return NotifyConfig(
+        legacy_event_enabled=legacy,
+        channels_enabled=channels,
+        jsonl_enabled=jsonl,
+        jsonl_path=Path("/tmp/stackchan-events-test.jsonl"),
+        messages=dict(DEFAULT_MESSAGE_TEMPLATES),
+    )
+
+
+class _FakeNotificationSession:
+    def __init__(self):
+        self.notifications = []
+
+    async def send_notification(self, notification):
+        self.notifications.append(
+            notification.model_dump(
+                by_alias=True,
+                mode="json",
+                exclude_none=True,
+            )
+        )

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -7,6 +7,7 @@ import pytest
 from mcp.types import CallToolRequest, ListToolsRequest
 
 from stackchan_mcp.notify_config import DEFAULT_MESSAGE_TEMPLATES, NotifyConfig
+import stackchan_mcp.stdio_server as stdio_server
 from stackchan_mcp.stdio_server import (
     CHANNEL_CAPABILITY,
     CHANNEL_NOTIFICATION_METHOD,
@@ -727,6 +728,36 @@ def test_stackchan_event_capabilities_and_instructions_follow_notify_config(
     assert options.capabilities.experimental == expected_capabilities
     assert _build_stackchan_event_instructions(config) == expected_instructions
     assert options.instructions == expected_instructions
+
+
+def test_create_initialization_options_requires_notify_config():
+    server = create_server(notify_config=_notify_config())
+
+    with pytest.raises(TypeError):
+        _create_initialization_options(server)
+
+
+def test_create_initialization_options_uses_explicit_notify_config(monkeypatch):
+    all_off_config = _notify_config(legacy=False, channels=False, jsonl=False)
+    channels_config = _notify_config(legacy=False, channels=True, jsonl=False)
+
+    load_calls = []
+
+    def load_all_off_config():
+        load_calls.append("load")
+        return all_off_config
+
+    monkeypatch.setattr(stdio_server, "load_notify_config", load_all_off_config)
+    server = create_server(notify_config=all_off_config)
+
+    all_off_options = _create_initialization_options(server, all_off_config)
+    channels_options = _create_initialization_options(server, channels_config)
+
+    assert load_calls == []
+    assert all_off_options.capabilities.experimental == {}
+    assert all_off_options.instructions is None
+    assert channels_options.capabilities.experimental == {CHANNEL_CAPABILITY: {}}
+    assert channels_options.instructions == STACKCHAN_CHANNEL_INSTRUCTIONS
 
 
 @pytest.mark.asyncio

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2025,6 +2025,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
@@ -2068,6 +2069,7 @@ requires-dist = [
     { name = "opuslib", marker = "extra == 'tts'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv" },
+    { name = "pyyaml", specifier = ">=6" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-faster-whisper'" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-openai'" },
     { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-voicevox'" },


### PR DESCRIPTION
## Summary

Refactor the gateway's Stack-chan event notification surface into three independent opt-in emission paths, all defaulting OFF, configured via a single user YAML file. Additionally, separate event payload semantics into a machine axis (sensor pattern) and a human axis (avatar action) via a new `action` field with a default mapping that is overridable in the same YAML.

- `legacy_event` — existing self-defined `stackchan/event` MCP notification (PR #262)
- `channels` — standard `notifications/claude/channel` (CC Channels mechanism + experimental `claude/channel` capability)
- `jsonl` — append-only event log for out-of-process host integration (PR #263)

All three default OFF. Users opt in via `~/.config/stackchan-mcp/notify.yml`.

Closes #265.

## Motivation

The public release shipped two emission paths both ON by default: the self-defined `stackchan/event` method (PR #262) and the JSONL append (PR #263). Neither rides Claude Code's first-class `notifications/claude/channel` mechanism that other Channels-aware plugins (telegram / discord / imessage) use, so a CC session cannot receive Stack-chan events natively. Always-on duplicate emission also conflicts with the "any MCP host can use this gateway" stance for hosts that have no in-process notification receiver.

This PR closes the structural gap to the Channels mechanism, makes every emission path opt-in, and keeps the JSONL tail pattern as a documented fallback for hosts without a native notification receiver.

## Changes (three commits)

### 1. `749a89b` — main implementation

- New module `gateway/stackchan_mcp/notify_config.py`: YAML loader with config search order (`STACKCHAN_NOTIFY_CONFIG` env → `$XDG_CONFIG_HOME/stackchan-mcp/notify.yml` → `~/.config/stackchan-mcp/notify.yml`), all-OFF default when no file is found, defensive fallback for malformed YAML, and a `MessageTemplate` map keyed by `(event_type, subtype)`.
- `gateway/stackchan_mcp/esp32_client.py`: three-way dispatch in `_emit_stackchan_event` after the existing per-field validation, with each branch independently gated on its config switch. The validation block (including the `isinstance(value, bool)` before `isinstance(value, int)` guard) is preserved.
- `gateway/stackchan_mcp/stdio_server.py`: `experimental_capabilities` and `instructions` are now assembled dynamically based on enabled paths. `notify_stackchan_event`'s method allowlist accepts both `"stackchan/event"` and `"notifications/claude/channel"`. The `StackChanServer(Server)` subclass and `_verify_mcp_sdk_compatibility` startup guard are preserved unchanged.
- `gateway/stackchan_mcp/cli.py`: `rotate_old_entries()` is now gated behind `jsonl.enabled` so an opt-out user does not see any persistent log file side effects.
- `gateway/stackchan_mcp/notify.example.yml`: shipped example documenting the schema.
- `README.md` + `README.ja.md`: opt-in walkthrough as a new optional quick-start subsection, EN/JP synced in the same commit.
- `CHANGELOG.md`: `[Unreleased]` Gateway entry covering the breaking change and the restore-previous-behavior recipe.
- Tests: `test_notify_config.py` (loader + override + malformed fallback + render_template), `test_event_dispatch.py` (eight on/off combinations + mapping override), extended `test_stdio_server.py` (per-mode capabilities + instructions + method allowlist), updates to `test_stackchan_event.py` / `test_event_log.py` / `test_cli.py` for the new all-OFF default.
- `gateway/pyproject.toml` + `gateway/uv.lock`: PyYAML dependency added.

### 2. `48fa2e1` — HTTP transport NotifyConfig stability + legacy params hygiene

Adversarial review of `749a89b` surfaced two issues:

- HTTP MCP sessions could advertise a different notify mode than the dispatcher used. The Streamable HTTP daemon (`stackchan-mcp serve --transport streamable-http`, landed in PR #264) calls `self.app.create_initialization_options()` per new session via `StreamableHTTPSessionManager`. If `_create_initialization_options` fell back to a fresh `load_notify_config()` on every call, a post-startup YAML edit could let HTTP clients see capabilities that disagreed with the cached dispatcher.
- The legacy `stackchan/event` params dict carried both `action` and `ts_unix`. PR #262 consumers were promised exactly one additive field (`action`); `ts_unix` was an undocumented second schema expansion in the backward-compat mode.

This commit:

- Threads the startup-loaded `NotifyConfig` through `build_app(..., notify_config=...)` → `create_server(notify_config=...)` → `StackChanServer.__init__` so HTTP sessions reuse the same config the dispatcher uses.
- Removes the implicit late `load_notify_config()` fallback from `_create_initialization_options`, which is now a positional-required argument. The single remaining explicit fallback lives at the top of `run_stdio_server` for callers that did not pre-resolve.
- Builds a separate legacy params dict containing exactly `{event_type, subtype, duration_ms, action, ts, session_id}` — no `ts_unix`. The full payload (including `ts_unix`) continues to ride the channels `meta` and the JSONL line.
- Regression tests: `test_create_initialization_options_requires_notify_config`, `test_http_session_uses_startup_notify_config`, `test_legacy_event_params_exclude_ts_unix`, `test_channels_meta_includes_ts_unix`, `test_jsonl_payload_includes_ts_unix`, `test_mixed_legacy_and_channels`.

### 3. `5c78bf2` — `render_template` defensive harden

Adversarial review of `48fa2e1` surfaced one remaining finding: a schema-valid-but-malformed channels message template (e.g. `{duration_ms.foo}`, `{x[bad]}`, `{unknown.foo}`) could raise `AttributeError` or `TypeError` from `str.format_map`. Round 1 only caught `IndexError / KeyError / ValueError`, so a bad user template would unwind the WebSocket handler on every physical event and disconnect the device until the config was fixed — violating the defensive malformed-config goal.

This commit catches `AttributeError` and `TypeError` as well and returns the original template string as a defensive fallback. New regression test `test_render_template_falls_back_on_malformed_format_strings` covers the three failure modes (attribute access on a non-attribute value, subscript on a non-subscriptable value, and unknown-key downstream attribute access).

## Verification

To run before merge (real-device steps gated behind the existing hardware sanity checklist and maintainer physical witness):

1. `cd gateway && ./.venv/bin/pytest tests/test_notify_config.py tests/test_event_dispatch.py tests/test_stackchan_event.py tests/test_event_log.py tests/test_stdio_server.py tests/test_cli.py -q` — local run: 185 passed, 1 skipped, 3 failed. The 3 failures are pre-existing socket-bind cases in `test_cli.py` tracked under #261 and unrelated to this PR.
2. `cd gateway && ./.venv/bin/ruff check .` — clean.
3. Manual: with `channels.enabled: true` in `~/.config/stackchan-mcp/notify.yml`, a real-device tap → CC session observes `<channel source="stackchan" action="head_pat" ...>` in context (confirms the Channels capability engages end-to-end). **Pending maintainer flash + physical verification.**
4. Manual: with `jsonl.enabled: true`, a real-device tap → JSONL append observed; existing host-side reader continues to function unchanged. **Pending.**
5. Manual: with all switches OFF (default), a real-device tap → no MCP notification emitted, no JSONL append, no `claude/channel` capability declared. **Pending.**

## Codex review history

| Round | Target | Verdict | Findings |
|---|---|---|---|
| Adv 1 | `749a89b` | needs-attention | 2 findings (HTTP `NotifyConfig` divergence [high], legacy params `ts_unix` leak [medium]) |
| Adv 2 | `48fa2e1` | needs-attention | 1 finding (`render_template` `AttributeError` / `TypeError` gap [medium]) |
| Adv 3 | `5c78bf2` | approve | No material findings |

All findings landed as the round-2 and round-3 commits in this PR.

## Compatibility

- Existing `stackchan/event` consumers (PR #262) continue to work when `legacy_event.enabled: true`. `action` is the only documented additive field; `ts_unix` no longer rides legacy_event params.
- Existing JSONL readers (PR #263) continue to work; the default JSONL path (`~/.claude/stackchan-events.jsonl`) and the `STACKCHAN_EVENTS_PATH` env override are preserved. The env var still wins over `jsonl.path` in the YAML.
- The `mcp` runtime pin (`>=1.27,<2.0`), the `_verify_mcp_sdk_compatibility` startup guard, and the `StackChanServer` subclass behavior are all preserved unchanged.

## BREAKING change

Default event emission changes from `legacy_event` ON + `jsonl` ON to all three switches default OFF. Existing users restore the previous behavior with a one-file `~/.config/stackchan-mcp/notify.yml`:

```yaml
legacy_event:
  enabled: true
jsonl:
  enabled: true
```

The `CHANGELOG.md` entry under `[Unreleased]` Gateway records this and links to the example YAML.

## Out of scope

- Host-side integration (CC hook scripts, launchd, tmux push, daemons) — owned by host integrators, outside this repo.
- Other host receivers (e.g. Hermes channel) — additive future PRs.
- Removal of the JSONL tail pattern — kept as a documented fallback for hosts without a native notification receiver.

## Refs

- Closes #265
- Refs #260 — original capability discussion
- Refs #262 — established `stackchan/event` self-defined method, retained as `legacy_event` mode
- Refs #263 — established the JSONL append helper, retained as `jsonl` mode with YAML-overridable path
- Refs #261 — unrelated pre-existing `test_cli.py` socket-bind failures observed in sandbox runs
