### PR TITLE
fix(gateway): drop interface network address from mDNS advertise list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ documented-only.
 
 - docs(gateway): daemon setup and Phase B migration notes. (#178)
 
+- Fixed: mDNS advertise list now drops interface IPs that equal their
+  subnet's network address. Previously such an address slipped past the
+  existing network/broadcast filter when it appeared in the prefix-less
+  socket source, causing zeroconf to crash with `EADDRNOTAVAIL` and
+  hang gateway startup in `async_wait_for_start`. The IPv4 enumerator
+  now adopts the ifaddr prefix for matching socket-source addresses,
+  and `AsyncZeroconf` is constrained to the advertised IPv4 set via
+  `interfaces=`. (#267)
+
 - Fixed: #178 Phase B stage 3 HTTP daemon — cancel-safe queue dispatch
   drops items for cancelled HTTP requests before ESP32 dispatch and
   drains pending items on lifespan shutdown with a JSON-RPC

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -195,8 +195,29 @@ def _iter_socket_ipv4_addresses() -> list[tuple[str, int | None]]:
 
 
 def _enumerate_usable_ipv4_addresses() -> list[str]:
+    ifaddr_entries = _iter_ifaddr_ipv4_addresses()
+    socket_entries = _iter_socket_ipv4_addresses()
+
+    # The socket-based source carries no subnet prefix, so on its own it cannot
+    # exclude network/broadcast addresses. When the same address also appears
+    # in the ifaddr source (which does carry a prefix), adopt that prefix so
+    # ``_is_network_or_broadcast_address`` can recognise and drop the entry.
+    # Without this, a host whose ``getaddrinfo``-resolved set includes an
+    # interface's subnet network base (which can happen when an interface ends
+    # up with its own subnet's network address as its host IP) would be
+    # advertised and then crash the zeroconf socket with ``EADDRNOTAVAIL``.
+    prefix_by_address = {
+        address: prefix
+        for address, prefix in ifaddr_entries
+        if prefix is not None
+    }
+    enriched_socket_entries = [
+        (address, prefix_by_address.get(address, prefix))
+        for address, prefix in socket_entries
+    ]
+
     return _select_advertised_addresses(
-        [*_iter_ifaddr_ipv4_addresses(), *_iter_socket_ipv4_addresses()]
+        [*ifaddr_entries, *enriched_socket_entries]
     )
 
 
@@ -269,7 +290,15 @@ class MdnsAdvertiser:
             return
 
         AsyncZeroconf, ServiceInfo = _load_zeroconf_classes()
-        zeroconf = AsyncZeroconf()
+        # Constrain zeroconf to the IPv4 interfaces we actually advertise on.
+        # The default ``InterfaceChoice.All`` makes zeroconf bind a socket on
+        # every host IPv4 address it can find, which on a host with several
+        # interfaces can include addresses the kernel refuses ``sendto`` on
+        # (the engine then never finishes starting, and the gateway hangs in
+        # ``async_wait_for_start``). Passing the same set of addresses we put
+        # into the SRV record keeps zeroconf in sync with our advertisement
+        # and skips the unusable interfaces entirely.
+        zeroconf = AsyncZeroconf(interfaces=advertisement.parsed_addresses)
         info = ServiceInfo(
             advertisement.service_type,
             advertisement.service_name,

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -154,6 +154,37 @@ def test_addresses_without_prefix_are_not_excluded(
     assert advertisement.parsed_addresses == ["192.168.0.0", "192.168.0.10"]
 
 
+def test_socket_source_inherits_ifaddr_prefix_for_network_address_filtering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression: an interface can end up holding its subnet's network address
+    # (e.g. ``192.168.1.0/24`` with both subnet and ifaddr-reported IP equal to
+    # ``192.168.1.0``) under unusual host routing or bridge configurations.
+    # The ifaddr source reports it with the correct prefix; the socket source
+    # (via ``getaddrinfo``) returns the same address with no prefix. Without
+    # bridging the two, the socket entry would slip past
+    # ``_is_network_or_broadcast_address`` and zeroconf would later crash with
+    # ``EADDRNOTAVAIL`` trying to ``sendto`` that address. The enumerator must
+    # adopt the ifaddr prefix for matching socket addresses so the existing
+    # network/broadcast filter applies uniformly.
+    monkeypatch.setattr(
+        mdns,
+        "_iter_ifaddr_ipv4_addresses",
+        lambda: [("192.168.1.42", 24), ("192.168.1.0", 24)],
+    )
+    monkeypatch.setattr(
+        mdns,
+        "_iter_socket_ipv4_addresses",
+        lambda: [("192.168.1.0", None), ("192.168.1.42", None)],
+    )
+
+    advertisement = build_advertisement(host="0.0.0.0", port=8765)
+
+    assert advertisement is not None
+    assert "192.168.1.0" not in advertisement.parsed_addresses
+    assert "192.168.1.42" in advertisement.parsed_addresses
+
+
 def test_mixed_tier_ordering_preserves_within_tier_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -204,7 +235,8 @@ async def test_advertiser_registers_service(monkeypatch: pytest.MonkeyPatch) -> 
             self.kwargs = kwargs
 
     class FakeAsyncZeroconf:
-        def __init__(self) -> None:
+        def __init__(self, *, interfaces=None) -> None:
+            self.interfaces = interfaces
             self.registered = []
             self.unregistered = []
             self.closed = False
@@ -259,7 +291,8 @@ async def test_advertiser_warns_when_service_name_changes(
             self.kwargs = kwargs
 
     class RenamingAsyncZeroconf:
-        def __init__(self) -> None:
+        def __init__(self, *, interfaces=None) -> None:
+            self.interfaces = interfaces
             self.registered = []
             self.unregistered = []
             self.closed = False
@@ -318,7 +351,8 @@ async def test_advertiser_closes_zeroconf_when_registration_fails(
             self.kwargs = kwargs
 
     class FailingAsyncZeroconf:
-        def __init__(self) -> None:
+        def __init__(self, *, interfaces=None) -> None:
+            self.interfaces = interfaces
             self.closed = False
             instances.append(self)
 


### PR DESCRIPTION
## Summary
- An interface whose reported IP equals its subnet's network address could end up in `getaddrinfo`'s socket-source output without a prefix, slipping past `_is_network_or_broadcast_address` and crashing zeroconf with `EADDRNOTAVAIL` during gateway startup (the engine then hangs in `async_wait_for_start`).
- The IPv4 enumerator now adopts ifaddr's prefix for any socket-source address that also appears in the ifaddr source, so the existing network/broadcast filter applies uniformly.
- `MdnsAdvertiser.start` constrains `AsyncZeroconf` to the advertised IPv4 set via `interfaces=`, preventing the default `InterfaceChoice.All` from binding sockets on host addresses unrelated to the advertised set.

## Test plan
- [x] `pytest gateway/tests/test_mdns_advertiser.py` — 19/19 pass, includes a new regression test that pins the socket-source / ifaddr-prefix bridge.
- [x] Manual gateway startup on a host where one interface's IP equals its subnet's network address — mDNS advertisement now completes cleanly (no `EADDRNOTAVAIL`), gateway proceeds to stdio MCP server start without hanging in `async_wait_for_start`.

## Compatibility
- Behaviour is unchanged on hosts without the affected interface configuration: the ifaddr source still drives prefix-based filtering, and the `interfaces=` set still covers the full advertised IPv4 list.
