### PR TITLE
feat(gateway): #269 experiential default notification templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ documented-only.
 
 ### Gateway
 
+- Changed: rephrased the default notification message templates from
+  mechanical event-name labels (`(head pat)` / `(head stroke,
+  {duration_ms}ms)`) to experiential English (`head was tapped` / `head
+  was stroked for {duration_ms}ms`) so the receiving LLM agent reads
+  them as first-person narration. `notify.example.yml` now demonstrates
+  the override surface with a casual-tone example instead of mirroring
+  the defaults, and both README.md and README.ja.md gain a "Customizing
+  event message wording" subsection documenting the experiential framing
+  intent, the override mechanism, and a worked example. Existing
+  `action` values (`head_pat` / `head_stroke`) are kept stable for
+  downstream consumers. `test_event_dispatch.py` content expectations
+  now reference `DEFAULT_MESSAGE_TEMPLATES[("touch", "tap")].template`
+  directly, decoupling dispatch-path tests from future wording edits.
+  (#270)
+
 - BREAKING: gateway event emission paths now default to all OFF instead of
   legacy `stackchan/event` notifications plus JSONL logging. Added three
   independent opt-in switches (`legacy_event`, `channels`, `jsonl`) via

--- a/README.ja.md
+++ b/README.ja.md
@@ -502,6 +502,43 @@ Channels 通知を有効にするには:
    - **Channels 受け口を持たないホスト**: JSONL フォールバックを
      使ってください（下記参照）。
 
+#### イベントメッセージ文言のカスタマイズ
+
+届けられる各イベントには、テンプレートから生成される短いメッセージが
+付きます。組み込みのデフォルトは「機械的なイベント名」ではなく
+「デバイスが何を感じたか」を表す体験的な表現にしてあり、受信側の
+エージェントが一人称のナレーションとして読めるようになっています。
+
+| イベント | デフォルト `action` | デフォルト `template` |
+| --- | --- | --- |
+| `touch` / `tap` | `head_pat` | `head was tapped` |
+| `touch` / `stroke` | `head_stroke` | `head was stroked for {duration_ms}ms` |
+
+`{duration_ms}` プレースホルダはイベントの payload から置換されます。
+未知のプレースホルダはそのまま保持されます。
+
+文言を上書きするには、`~/.config/stackchan-mcp/notify.yml` に
+`messages:` ブロックを追加します。記載したイベント種別だけが上書き
+され、それ以外は上記のデフォルトのままです。たとえば、よりくだけた
+表現にする場合:
+
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+messages:
+  touch:
+    tap:
+      action: head_pat
+      template: "got a head pat"
+    stroke:
+      action: head_stroke
+      template: "head being stroked for {duration_ms}ms"
+```
+
+上書きする各 subtype には `action` と `template` の両方が必要です。
+`action` の値はイベントの metadata に転送されるため、下流の consumer
+がそれを key にしている場合は安定させておいてください。詳細な注釈付き
+リファレンスは `notify.example.yml` を参照してください。
+
 以前の常時有効だったイベント動作に戻す設定:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -552,6 +552,43 @@ To enable Channels notifications:
    - **Hosts without a Channels receiver**: use the JSONL fallback (see
      below).
 
+#### Customizing event message wording
+
+Each delivered event carries a short message rendered from a template.
+The built-in defaults are phrased experientially — describing what the
+device felt rather than naming a mechanical event — so the consuming
+agent reads them as first-person narration:
+
+| Event | Default `action` | Default `template` |
+| --- | --- | --- |
+| `touch` / `tap` | `head_pat` | `head was tapped` |
+| `touch` / `stroke` | `head_stroke` | `head was stroked for {duration_ms}ms` |
+
+The `{duration_ms}` placeholder is substituted from the event payload;
+unknown placeholders are preserved verbatim.
+
+To override the wording, add a `messages:` block to
+`~/.config/stackchan-mcp/notify.yml`. Only the event types you list are
+overridden; everything else keeps the defaults above. For example, to
+use a more casual phrasing:
+
+```yaml
+# ~/.config/stackchan-mcp/notify.yml
+messages:
+  touch:
+    tap:
+      action: head_pat
+      template: "got a head pat"
+    stroke:
+      action: head_stroke
+      template: "head being stroked for {duration_ms}ms"
+```
+
+Both `action` and `template` are required for each overridden subtype.
+The `action` value is forwarded in the event metadata, so keep it stable
+if a downstream consumer keys off it. See `notify.example.yml` for the
+full annotated reference.
+
 To restore the previous always-on event behavior:
 
 ```yaml

--- a/gateway/stackchan_mcp/notify.example.yml
+++ b/gateway/stackchan_mcp/notify.example.yml
@@ -6,11 +6,16 @@ channels:
 jsonl:
   enabled: false          # JSONL append for out-of-process host integration
   path: ~/.claude/stackchan-events.jsonl
+# messages: override the wording delivered for each physical event.
+# Omit this block entirely to keep the built-in experiential defaults
+# ("head was tapped" / "head was stroked for {duration_ms}ms").
+# The examples below customize the phrasing per event type; {duration_ms}
+# is substituted from the event payload.
 messages:
   touch:
     tap:
       action: head_pat
-      template: "(head pat)"
+      template: "got a head pat"
     stroke:
       action: head_stroke
-      template: "(head stroke, {duration_ms}ms)"
+      template: "head being stroked for {duration_ms}ms"

--- a/gateway/stackchan_mcp/notify_config.py
+++ b/gateway/stackchan_mcp/notify_config.py
@@ -36,11 +36,11 @@ class NotifyConfig:
 DEFAULT_MESSAGE_TEMPLATES: Final[dict[tuple[str, str], MessageTemplate]] = {
     ("touch", "tap"): MessageTemplate(
         action="head_pat",
-        template="(head pat)",
+        template="head was tapped",
     ),
     ("touch", "stroke"): MessageTemplate(
         action="head_stroke",
-        template="(head stroke, {duration_ms}ms)",
+        template="head was stroked for {duration_ms}ms",
     ),
 }
 

--- a/gateway/tests/test_event_dispatch.py
+++ b/gateway/tests/test_event_dispatch.py
@@ -78,7 +78,7 @@ async def test_emit_stackchan_event_dispatches_selected_paths(
         channel_index = expected_notify_methods.index(stdio_server.CHANNEL_NOTIFICATION_METHOD)
         channel_params = notify_calls[channel_index][1]
         assert channel_params == {
-            "content": "(head pat)",
+            "content": DEFAULT_MESSAGE_TEMPLATES[("touch", "tap")].template,
             "meta": _expected_meta(),
         }
         assert channel_params["meta"]["action"] == "head_pat"
@@ -175,7 +175,10 @@ async def test_channels_meta_includes_ts_unix(monkeypatch):
     assert notify_calls == [
         (
             stdio_server.CHANNEL_NOTIFICATION_METHOD,
-            {"content": "(head pat)", "meta": _expected_meta()},
+            {
+                "content": DEFAULT_MESSAGE_TEMPLATES[("touch", "tap")].template,
+                "meta": _expected_meta(),
+            },
         )
     ]
     assert notify_calls[0][1]["meta"]["ts_unix"] == "1717000000.25"
@@ -204,7 +207,10 @@ async def test_mixed_legacy_and_channels(monkeypatch):
         (stdio_server.STACKCHAN_EVENT_METHOD, _expected_legacy_params()),
         (
             stdio_server.CHANNEL_NOTIFICATION_METHOD,
-            {"content": "(head pat)", "meta": _expected_meta()},
+            {
+                "content": DEFAULT_MESSAGE_TEMPLATES[("touch", "tap")].template,
+                "meta": _expected_meta(),
+            },
         ),
     ]
     legacy_params = notify_calls[0][1]

--- a/gateway/tests/test_notify_config.py
+++ b/gateway/tests/test_notify_config.py
@@ -43,11 +43,11 @@ def test_default_no_env_no_file_returns_all_off(monkeypatch, tmp_path):
     assert config.jsonl_path == DEFAULT_LOG_PATH
     assert config.messages[("touch", "tap")] == MessageTemplate(
         action="head_pat",
-        template="(head pat)",
+        template="head was tapped",
     )
     assert config.messages[("touch", "stroke")] == MessageTemplate(
         action="head_stroke",
-        template="(head stroke, {duration_ms}ms)",
+        template="head was stroked for {duration_ms}ms",
     )
 
 


### PR DESCRIPTION
## Summary
Rephrase the default Stack-chan notification templates from mechanical
event-name labels (`(head pat)` / `(head stroke, {duration_ms}ms)`) to
experiential English (`head was tapped` / `head was stroked for
{duration_ms}ms`), aligning the wording with how a receiving LLM agent
would naturally narrate the event in first person. The `action` values
(`head_pat` / `head_stroke`) are kept stable for any downstream consumer
that keys off them.

Also:

- `notify.example.yml` `messages:` block is converted from a default-mirror
  into a usable override example (`got a head pat` / `head being stroked
  for {duration_ms}ms`) with an inline comment clarifying that omitting
  the block keeps the built-in defaults.
- A new "Customizing event message wording" subsection lands in both
  `README.md` and `README.ja.md` (under the event-notification section),
  documenting the experiential framing intent, the override mechanism,
  and a worked example that matches `notify.example.yml`.
- `test_notify_config.py` expectations follow the new defaults.
- `test_event_dispatch.py` literal `"(head pat)"` content expectations
  are replaced with `DEFAULT_MESSAGE_TEMPLATES[("touch", "tap")].template`
  references, matching the import-driven pattern already used at L117 /
  L264 of the same file. This removes the brittle coupling between default
  wording and dispatch-path test fixtures, so future wording changes do
  not require touching dispatch tests.

## Test plan

- [x] `cd gateway && uv run pytest` → 459 passed, 1 skipped
- [x] `cd gateway && uv run ruff check .` → All checks passed
- [x] `git diff main..HEAD --stat` → 6 files, +94 / -9 (no personal
      config, no Tailscale host, no absolute home paths leaked)
- [x] EN / JP README subsections kept structurally and semantically in
      sync (same default table, same worked example, same override
      mechanism description)
- [x] Pre-PR `codex review --base main` → 0 findings (template wording +
      docs + tests only, no dispatch-path regression)

Closes #269
