### PR TITLE
fix(stdio) + docs(README): align Channels delivery path to stackchanmcp form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,30 @@ documented-only.
 
 ### Gateway
 
+- Fixed: align the `stdio_server.py` `InitializationOptions.server_name`
+  and `StackChanServer` constructor argument from the legacy
+  `stackchan-mcp` string to the canonical `stackchanmcp` (no hyphen)
+  introduced in PR #266 (#265). Without this rename the host MCP
+  client logs `Channel notifications skipped: server stackchan-mcp
+  not in --channels list for this session` and the Channels delivery
+  path is blocked end-to-end. The `STACKCHAN_CHANNEL_INSTRUCTIONS`
+  prompt example tag is also synced to the on-the-wire form
+  `<channel source="plugin:stackchanmcp:stackchanmcp" ...>`, and the
+  README EN/JP `Optional: enable event notifications` section is
+  rewritten to match the post-PR-#266 reality:
+  `plugin:stackchanmcp@kisaragi-mochi-channels` as the canonical
+  `--channels` form, a Plugin installation step using
+  `claude plugin install`, a Host environment setup step covering
+  `.mcp.json` `mcpServers` key alignment, `settings.local.json`
+  `enabledMcpjsonServers` whitelist, and the system-wide
+  `/Library/Application Support/ClaudeCode/managed-settings.json`
+  `allowedChannelPlugins` entry, the
+  `--dangerously-load-development-channels` requirement noted as
+  currently required (approved-allowlist-only without this flag has
+  been verified not to deliver notifications), and a Migration
+  section listing the rename targets for users on the older
+  `stackchan-mcp` (hyphenated) server-name form. (#271)
+
 - Changed: rephrased the default notification message templates from
   mechanical event-name labels (`(head pat)` / `(head stroke,
   {duration_ms}ms)`) to experiential English (`head was tapped` / `head

--- a/README.ja.md
+++ b/README.ja.md
@@ -458,42 +458,68 @@ Channels 通知を有効にするには:
      enabled: true
    ```
 
-2. 受け口側 — ホストごとに開き方が異なります。
+2. Plugin install — `kisaragi-mochi-channels` marketplace から、本
+   リポジトリを Claude Code plugin として install します。
 
-   - **Claude Code**: 本リポジトリを CC plugin として読み込み、
-     かつ この plugin の MCP server を Channels source として登録する
-     ことで、gateway が宣言する `claude/channel` capability を
-     Claude Code が購読するようにします。
+   ```bash
+   claude plugin install stackchanmcp@kisaragi-mochi-channels
+   ```
 
-     ```bash
-     claude --plugin-dir /path/to/stackchan-mcp --channels server:stackchan-mcp --agent <your-agent>
+   ローカル開発で作業コピーを使う場合は、marketplace install の
+   代わりに `--plugin-dir /path/to/stackchan-mcp` で本リポジトリを
+   指してください。Claude Code は同梱の `.mcp.json` 経由で
+   `${CLAUDE_PLUGIN_ROOT}/gateway` 配下の gateway を起動します。
+
+3. ホスト環境設定 — Channels 経路では、3 箇所のホスト側名前を
+   gateway の MCP server 名（`stackchanmcp`、ハイフン無し）と
+   揃える必要があります。
+
+   - Plugin の `.mcp.json` `mcpServers` key を `stackchanmcp` にする。
+     以前別の key で gateway を wire していた場合は rename して
+     ください。
+   - Claude Code の `settings.local.json` の `enabledMcpjsonServers`
+     whitelist に `stackchanmcp` を含める。
+   - Channels allowlist は system-wide 承認が必要です。Claude Code は
+     user-level（`~/.claude/settings.json` 等）の設定は Channels
+     allowlist として有効になりません。macOS では
+     `/Library/Application Support/ClaudeCode/managed-settings.json` を
+     作成または編集してください（`sudo` 必要）。
+
+     ```json
+     {
+       "channelsEnabled": true,
+       "allowedChannelPlugins": ["stackchanmcp@kisaragi-mochi-channels"]
+     }
      ```
 
-     1 セッション限定のローカル開発では `--plugin-dir` に本リポジトリの
-     作業コピーを指定してください。Claude Code は同梱の `.mcp.json`
-     経由で `${CLAUDE_PLUGIN_ROOT}/gateway` 配下の gateway を起動します。
-     `--channels server:stackchan-mcp` 引数を付けることで Claude Code がこの
-     server を channel source として attach し、session に
-     `<channel source="stackchan-mcp" ...>` blocks を inject します。
-     付けないと plugin は読み込まれますが、channels の notification は
-     受信側で silent に drop されます。allowlist 制限により開発用 server
-     が登録できない場合は、代わりに
-     `--dangerously-load-development-channels server:stackchan-mcp` を使って
-     ください。Marketplace 公開
-     (`--channels plugin:stackchan-mcp@<marketplace>`) は follow-up
-     として追跡し、manifest を marketplace へ提出したタイミングで
-     利用可能になります。
+4. 受け口側 — Channels フラグつきで Claude Code を起動します。
 
-     重要 — plugin 以前の起動経路では Channels が届きません: 以前
-     `~/.claude.json` の `mcpServers` 経由でこの gateway を起動して
-     いた場合、その旧経路では `<channel ...>` の inject は届きません。
-     Claude Code は plugin 経由で起動された MCP server のみに channel
-     source を付ける仕様です。plugin 経路に移行する前に、既存の
-     stackchan-mcp gateway プロセスを停止して ESP32 ownership lock
-     を解放してください。そうしないと plugin 経由で起動した gateway
-     が lock 取得に失敗します。`~/.claude.json` 経由のまま使いたい
-     場合は、`channels` ではなく `legacy_event` / `jsonl` を使って
-     ください。どちらも plugin loading なしで動作します。
+   ```bash
+   claude --channels plugin:stackchanmcp@kisaragi-mochi-channels \
+          --dangerously-load-development-channels plugin:stackchanmcp@kisaragi-mochi-channels
+   ```
+
+   `--channels` フラグは channel source を gateway に attach し、
+   session に `<channel source="plugin:stackchanmcp:stackchanmcp" ...>`
+   blocks を inject します。`--dangerously-load-development-channels`
+   フラグは現状 `--channels` と併用が必要です。plugin の Channels
+   capability が実験的で、approved-allowlist のみ経路（このフラグ
+   なし）では現行 Claude Code 版で notification が届かないことが
+   検証されています。Channels capability が安定化したら、このフラグは
+   optional になる予定です。
+
+   重要 — plugin 以前の起動経路では Channels が届きません: 以前
+   `~/.claude.json` の `mcpServers` 経由でこの gateway を起動して
+   いた場合、その旧経路では `<channel ...>` の inject は届きません。
+   Claude Code は plugin 経由で起動された MCP server のみに channel
+   source を付ける仕様です。plugin 経路に移行する前に、既存の gateway
+   プロセスを停止して ESP32 ownership lock を解放してください。そう
+   しないと plugin 経由で起動した gateway が lock 取得に失敗します。
+   `~/.claude.json` 経由のまま使いたい場合は、`channels` ではなく
+   `legacy_event` / `jsonl` を使ってください。どちらも plugin loading
+   なしで動作します。
+
+5. 他ホスト:
 
    - **`claude/channel` 互換の受け口を持つ他ホスト**: 当該ホストの
      ドキュメントに従って受け口を開いてください。Claude Code 以外の
@@ -501,6 +527,29 @@ Channels 通知を有効にするには:
 
    - **Channels 受け口を持たないホスト**: JSONL フォールバックを
      使ってください（下記参照）。
+
+#### 旧 `stackchan-mcp`（ハイフン入り）form からの migration
+
+以前 `stackchan-mcp` server name form で Channels を有効化していた
+場合、ホスト MCP client と gateway を揃えるため、以下を現行の
+`stackchanmcp` form（ハイフン無し）に rename してください。
+
+- Plugin / server 名: ホストの `.mcp.json` `mcpServers` key、
+  `settings.local.json` `enabledMcpjsonServers` whitelist、および
+  `--channels` / `--dangerously-load-development-channels` フラグの
+  引数。`stackchan-mcp`（ハイフン入り）を `stackchanmcp` に変更。
+- Channels フラグ form: `--channels server:stackchan-mcp` を
+  `--channels plugin:stackchanmcp@kisaragi-mochi-channels` に変更。
+  marketplace manifest が公開済のため、plugin form が現行の正式 form
+  です。
+- system-wide allowlist:
+  `/Library/Application Support/ClaudeCode/managed-settings.json` の
+  `allowedChannelPlugins` に `stackchanmcp@kisaragi-mochi-channels`
+  （旧 `stackchan-mcp` form ではない）を列挙してください。
+
+これらすべての rename がなければ、ホスト MCP client は
+`Channel notifications skipped: server <name> not in --channels list
+for this session` を log し、notification が session に届きません。
 
 #### イベントメッセージ文言のカスタマイズ
 

--- a/README.md
+++ b/README.md
@@ -508,49 +508,100 @@ To enable Channels notifications:
      enabled: true
    ```
 
-2. Receiver side — open a receiver on your host:
+2. Plugin installation — install this repository as a Claude Code plugin
+   from the `kisaragi-mochi-channels` marketplace:
 
-   - **Claude Code**: load this repository as a CC plugin AND register
-     this plugin's MCP server as a Channels source so Claude Code
-     subscribes to the `claude/channel` capability advertised by this
-     gateway.
+   ```bash
+   claude plugin install stackchanmcp@kisaragi-mochi-channels
+   ```
 
-     ```bash
-     claude --plugin-dir /path/to/stackchan-mcp --channels server:stackchan-mcp --agent <your-agent>
+   For local development against your working copy, pass
+   `--plugin-dir /path/to/stackchan-mcp` instead of installing from the
+   marketplace; Claude Code starts the gateway under
+   `${CLAUDE_PLUGIN_ROOT}/gateway` via the bundled `.mcp.json`.
+
+3. Host environment setup — the Channels delivery path requires three
+   host-side names to be aligned with the gateway's MCP server name
+   (`stackchanmcp`, no hyphen):
+
+   - The plugin's `.mcp.json` `mcpServers` key for this gateway must be
+     `stackchanmcp`. If you previously wired the gateway under a
+     different key, rename it.
+   - Claude Code's `settings.local.json` `enabledMcpjsonServers`
+     whitelist must include `stackchanmcp`.
+   - The Channels allowlist requires a system-wide approval — Claude
+     Code does not honor user-level (e.g. `~/.claude/settings.json`)
+     settings for the Channels allowlist. On macOS, create or edit
+     `/Library/Application Support/ClaudeCode/managed-settings.json`
+     (requires `sudo`):
+
+     ```json
+     {
+       "channelsEnabled": true,
+       "allowedChannelPlugins": ["stackchanmcp@kisaragi-mochi-channels"]
+     }
      ```
 
-     For one-session local development, point `--plugin-dir` at your
-     working copy of this repository; Claude Code starts the gateway
-     under `${CLAUDE_PLUGIN_ROOT}/gateway` via the bundled `.mcp.json`.
-     The `--channels server:stackchan-mcp` argument is what makes Claude Code
-     attach the channel source to this server and inject
-     `<channel source="stackchan-mcp" ...>` blocks into the session;
-     without it the plugin loads but channels notifications are
-     silently dropped on the receiving side. If allowlist restrictions
-     block a development server from being added, use
-     `--dangerously-load-development-channels server:stackchan-mcp` instead.
-     Marketplace publication (`--channels plugin:stackchan-mcp@<marketplace>`)
-     is tracked as a follow-up and will land once the manifest is
-     submitted to a marketplace.
+4. Receiver side — launch Claude Code with the Channels flags:
 
-     Important — pre-plugin wiring does not receive Channels: if you
-     previously wired this gateway via `~/.claude.json` `mcpServers`
-     (the pre-plugin path), that wiring does not receive `<channel ...>`
-     injections. Claude Code only attaches a channel source to
-     plugin-loaded MCP servers. Before switching to the plugin path,
-     stop any existing stackchan-mcp gateway process to release the
-     ESP32 ownership lock; the plugin-loaded gateway will otherwise
-     fail to acquire it. If you prefer to keep the `~/.claude.json`
-     wiring, use `legacy_event` and `jsonl` instead of `channels` —
-     both work without plugin loading.
+   ```bash
+   claude --channels plugin:stackchanmcp@kisaragi-mochi-channels \
+          --dangerously-load-development-channels plugin:stackchanmcp@kisaragi-mochi-channels
+   ```
 
-   - **Other hosts with a `claude/channel`-compatible receiver**: open
-     that receiver per the host's documentation. Compatibility with
-     hosts other than Claude Code has not been verified in this
-     repository.
+   The `--channels` flag attaches the channel source to the gateway and
+   injects `<channel source="plugin:stackchanmcp:stackchanmcp" ...>`
+   blocks into the session. The
+   `--dangerously-load-development-channels` flag is currently required
+   alongside `--channels` because the plugin's Channels capability is
+   experimental; the approved-allowlist-only path without this flag has
+   been verified not to deliver notifications in current Claude Code
+   versions. The flag is expected to become optional once the plugin's
+   Channels capability stabilizes.
+
+   Important — pre-plugin wiring does not receive Channels: if you
+   previously wired this gateway via `~/.claude.json` `mcpServers`
+   (the pre-plugin path), that wiring does not receive `<channel ...>`
+   injections. Claude Code only attaches a channel source to
+   plugin-loaded MCP servers. Before switching to the plugin path,
+   stop any existing gateway process to release the ESP32 ownership
+   lock; the plugin-loaded gateway will otherwise fail to acquire it.
+   If you prefer to keep the `~/.claude.json` wiring, use
+   `legacy_event` and `jsonl` instead of `channels` — both work
+   without plugin loading.
+
+5. Other hosts:
+
+   - **Hosts with a `claude/channel`-compatible receiver**: open that
+     receiver per the host's documentation. Compatibility with hosts
+     other than Claude Code has not been verified in this repository.
 
    - **Hosts without a Channels receiver**: use the JSONL fallback (see
      below).
+
+#### Migration from the previous `stackchan-mcp` (hyphenated) form
+
+If you enabled Channels using the older `stackchan-mcp` server-name
+form, rename to the current `stackchanmcp` form (no hyphen) in all four
+places to keep the host MCP client and the gateway aligned:
+
+- Plugin / server name: change `stackchan-mcp` to `stackchanmcp` in
+  your host's `.mcp.json` `mcpServers` key, in `settings.local.json`
+  `enabledMcpjsonServers` whitelist, and in the `--channels` /
+  `--dangerously-load-development-channels` flag arguments.
+- Channels flag form: change from `--channels server:stackchan-mcp` to
+  `--channels plugin:stackchanmcp@kisaragi-mochi-channels`. The
+  plugin form is the supported form now that the marketplace manifest
+  is published.
+- system-wide allowlist: ensure
+  `/Library/Application Support/ClaudeCode/managed-settings.json` has
+  `allowedChannelPlugins` listing
+  `stackchanmcp@kisaragi-mochi-channels` (not the old `stackchan-mcp`
+  form).
+
+Without all four renames the host MCP client logs
+`Channel notifications skipped: server <name> not in --channels list
+for this session` and the notifications never reach the session.
 
 #### Customizing event message wording
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -236,7 +236,7 @@ def _create_initialization_options(
     notify_config: NotifyConfig,
 ) -> InitializationOptions:
     return InitializationOptions(
-        server_name="stackchan-mcp",
+        server_name="stackchanmcp",
         server_version=__version__,
         capabilities=server.get_capabilities(
             notification_options=NotificationOptions(),
@@ -594,7 +594,7 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
     _verify_mcp_sdk_compatibility()
     if notify_config is None:
         notify_config = load_notify_config()
-    server = StackChanServer("stackchan-mcp", notify_config=notify_config)
+    server = StackChanServer("stackchanmcp", notify_config=notify_config)
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -42,9 +42,9 @@ STACKCHAN_EVENT_INSTRUCTIONS = (
 )
 STACKCHAN_CHANNEL_INSTRUCTIONS = (
     'Stack-chan physical events arrive as Channels notifications under '
-    '<channel source="stackchan-mcp" action="..." subtype="..." '
-    'duration_ms="...">. React naturally using existing tools '
-    '(set_avatar, say, set_mouth, set_leds, move_head).'
+    '<channel source="plugin:stackchanmcp:stackchanmcp" action="..." '
+    'subtype="..." duration_ms="...">. React naturally using existing '
+    'tools (set_avatar, say, set_mouth, set_leds, move_head).'
 )
 STACKCHAN_JSONL_INSTRUCTIONS = (
     "Stack-chan physical events are persisted to the JSONL log; host "

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -30,7 +30,7 @@ def test_create_server():
     """Server creation succeeds with correct name."""
     server = create_server()
     assert server is not None
-    assert server.name == "stackchan-mcp"
+    assert server.name == "stackchanmcp"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #266 introduced the `stackchanmcp` (no hyphen) canonical
plugin/server name, but two call sites in
`gateway/stackchan_mcp/stdio_server.py` still passed the legacy
`stackchan-mcp` string when constructing
`InitializationOptions.server_name` and the `StackChanServer`
constructor. The host MCP client logs
`Channel notifications skipped: server stackchan-mcp not in
--channels list for this session` even when
`--channels plugin:stackchanmcp@kisaragi-mochi-channels` is specified
and the system-wide `managed-settings.json` allowlist includes the
same plugin, blocking the Channels delivery path end-to-end.

This PR lands the missing `stackchan-mcp` -> `stackchanmcp` rename in
`stdio_server.py`, updates the test expectation and the
`STACKCHAN_CHANNEL_INSTRUCTIONS` prompt example to the on-the-wire
`source="plugin:stackchanmcp:stackchanmcp"` form, and rewrites the
README Channels section to match the post-PR-#266 reality.

## Changes

- `gateway/stackchan_mcp/stdio_server.py`:
  - Rename `server_name="stackchan-mcp"` and
    `StackChanServer("stackchan-mcp", ...)` to `stackchanmcp` so the
    runtime-announced server name matches the canonical plugin name.
  - Update `STACKCHAN_CHANNEL_INSTRUCTIONS` example tag from
    `source="stackchan-mcp"` to
    `source="plugin:stackchanmcp:stackchanmcp"` to match the
    on-the-wire shape the host actually injects.

- `gateway/tests/test_stdio_server.py` — update
  `test_create_server`'s expected `server.name` to `stackchanmcp`.
  All 62 tests in this file pass after the change.

- `README.md` / `README.ja.md` — rewrite the
  `### 6. Optional: enable event notifications` section:
  - Use `plugin:stackchanmcp@kisaragi-mochi-channels` as the
    `--channels` form (the marketplace manifest is published; the
    plugin form is now the supported form).
  - Add a Plugin installation step using
    `claude plugin install stackchanmcp@kisaragi-mochi-channels`.
  - Add a Host environment setup step documenting the three
    host-side names that must align with the gateway's MCP server
    name: `.mcp.json` `mcpServers` key, `settings.local.json`
    `enabledMcpjsonServers` whitelist, and the system-wide
    `/Library/Application Support/ClaudeCode/managed-settings.json`
    `allowedChannelPlugins` entry.
  - Document `--dangerously-load-development-channels` as currently
    required alongside `--channels` (the approved-allowlist-only
    path without this flag has been verified not to deliver
    notifications in current Claude Code versions; the flag is
    expected to become optional once the Channels capability
    stabilizes).
  - Add a Migration section listing the rename targets for users
    who enabled Channels via the older `stackchan-mcp` (hyphenated)
    server-name form, with the host MCP client log message that
    signals an incomplete migration.

## Verification

Verified end-to-end with the patched `stdio_server.py` plus the
host-side name alignment (the steps the README now documents):

1. Approved-allowlist + `--channels plugin:stackchanmcp@...` +
   `--dangerously-load-development-channels plugin:stackchanmcp@...`
   produced `Channel notifications registered` in the host MCP log
   (previously: `Channel notifications skipped: server
   stackchan-mcp not in --channels list for this session`).
2. A `notifications/claude/channel` injection from both a fake-event
   WS frame and a physical ESP32 touch event produced the expected
   `<channel source="plugin:stackchanmcp:stackchanmcp"
   event_type="touch" subtype="..." duration_ms="..." action="..."
   ...>` block in the receiving session.
3. `uv run pytest tests/test_stdio_server.py -q` — 62 passed.

## Test plan

- [ ] Check out `fix/stdio-server-name-align`, install the plugin
      with `claude plugin install stackchanmcp@kisaragi-mochi-channels`
      against this branch, follow the rewritten README Channels
      section, and confirm a touch event injects a
      `<channel source="plugin:stackchanmcp:stackchanmcp" ...>` block.
- [ ] Confirm the legacy `--channels server:stackchan-mcp` form still
      logs the documented skip message so the Migration section's
      diagnostic remains accurate.