### PR TITLE
docs(README): #268 restructure event notification section as a tri-channel guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ documented-only.
 
 ### Gateway
 
+- Changed: restructured the README EN/JP `Optional: enable event
+  notifications` section as a tri-channel guide. Each of `channels`,
+  `jsonl`, and `legacy_event` now has its own subsection with the
+  `notify.yml` enable block, a delivered payload example, and the
+  intended use case. The supported event subtypes are listed in a
+  structure that allows additional `touch` subtypes or new
+  top-level types to be appended without rewriting the section.
+  (#268)
+
 - Fixed: align the `stdio_server.py` `InitializationOptions.server_name`
   and `StackChanServer` constructor argument from the legacy
   `stackchan-mcp` string to the canonical `stackchanmcp` (no hyphen)

--- a/README.ja.md
+++ b/README.ja.md
@@ -596,16 +596,29 @@ jsonl:
 
 各イベントは、設定したパスに 1 行の JSON として追記されます。
 ファイルが存在しない場合は作成され、既存のエントリは保持されます。
-tap と stroke の配信例:
+1 行に含まれる field:
+
+- `event_type` — top-level event type（現状は `"touch"`）。
+- `subtype` — event type 内の subtype（現状は `"tap"` または
+  `"stroke"`）。
+- `duration_ms` — firmware が報告したイベントの継続時間（ミリ秒）。
+- `ts` — firmware uptime（ミリ秒、monotonic）。
+- `ts_unix` — gateway がイベントを記録した壁時計時刻。
+- `session_id` — gateway session 識別子。
+- `action`（任意） — `messages:` 設定で override したときのみ含まれる
+  avatar action。
+
+レンダリングされた文言（例: `head was tapped`）は `channels` channel
+が人間可読のメッセージとして配信するもので、JSONL レコード自体には
+保存されません。tap と stroke の配信例:
 
 ```json
-{"type": "touch", "subtype": "tap", "action": "head_pat", "message": "head was tapped"}
-{"type": "touch", "subtype": "stroke", "action": "head_stroke", "message": "head was stroked for 720ms", "duration_ms": 720}
+{"event_type": "touch", "subtype": "tap", "duration_ms": 0, "ts": 123456, "ts_unix": 1717862400.0, "session_id": "abc-123", "action": "head_pat"}
+{"event_type": "touch", "subtype": "stroke", "duration_ms": 720, "ts": 124000, "ts_unix": 1717862400.7, "session_id": "abc-123", "action": "head_stroke"}
 ```
 
-最上位の `type` / `subtype` は常に下記「Supported event subtypes」
-の行と対応します。`action` / `message` はデフォルト（または
-`messages:` で設定した override 内容）を反映します。
+最上位の `event_type` / `subtype` は下記「Supported event subtypes」
+の行と対応します。
 
 #### Channel: `legacy_event`（plugin 以前の backward compatibility）
 
@@ -621,11 +634,14 @@ legacy_event:
 ```
 
 gateway は独自定義の `stackchan/event` MCP notification method を
-送出します。notification params には `jsonl` の payload と同じ
-`type` / `subtype` / `action` / `message` の各 field が含まれます。
+送出します。notification params には `event_type` / `subtype` /
+`duration_ms` / `ts` / `session_id` の各 field が含まれます（上記
+JSONL レコードと同じ field 構成、ただし `ts_unix` は JSONL writer 側
+だけが付与するため legacy notification には含まれません）。`messages:`
+設定で override されている場合は任意の `action` field も含まれます。
 受信側の notification の扱いはホスト依存です: Claude Code の plugin
-以前経路では従来、メッセージが inline で表示されました。他ホストでは
-異なる扱いになる場合があります。
+以前経路では従来、レンダリング後のメッセージが inline で表示されま
+した。他ホストでは異なる扱いになる場合があります。
 
 #### Supported event subtypes
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -605,8 +605,10 @@ jsonl:
 - `ts` — firmware uptime（ミリ秒、monotonic）。
 - `ts_unix` — gateway がイベントを記録した壁時計時刻。
 - `session_id` — gateway session 識別子。
-- `action`（任意） — `messages:` 設定で override したときのみ含まれる
-  avatar action。
+- `action` — event subtype に対応する avatar action keyword（例:
+  `head_pat`, `head_stroke`）。組み込みの default template は常に
+  この値を埋めるほか、`messages:` override 側でも `action` の指定が
+  必須であるため、対応する全 subtype で必ず含まれます。
 
 レンダリングされた文言（例: `head was tapped`）は `channels` channel
 が人間可読のメッセージとして配信するもので、JSONL レコード自体には
@@ -634,14 +636,12 @@ legacy_event:
 ```
 
 gateway は独自定義の `stackchan/event` MCP notification method を
-送出します。notification params には `event_type` / `subtype` /
-`duration_ms` / `ts` / `session_id` の各 field が含まれます（上記
-JSONL レコードと同じ field 構成、ただし `ts_unix` は JSONL writer 側
-だけが付与するため legacy notification には含まれません）。`messages:`
-設定で override されている場合は任意の `action` field も含まれます。
-受信側の notification の扱いはホスト依存です: Claude Code の plugin
-以前経路では従来、レンダリング後のメッセージが inline で表示されま
-した。他ホストでは異なる扱いになる場合があります。
+送出します。notification params には上記 JSONL レコードと同じ field
+が含まれます（ただし `ts_unix` は JSONL writer 側だけが付与するため
+legacy notification には含まれません）。受信側の notification の
+扱いはホスト依存です: Claude Code の plugin 以前経路では従来、
+レンダリング後のメッセージが inline で表示されました。他ホストでは
+異なる扱いになる場合があります。
 
 #### Supported event subtypes
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -442,23 +442,53 @@ Vosk・whisper.cpp・他のクラウドサービス等を `listen` API を変え
 
 ### 6. オプション: イベント通知の有効化
 
-Stack-chan の物理イベント（touch tap / stroke）は、ホスト側の対応状況に
-合わせて複数の通知経路で届けられます。すべての経路はデフォルトで無効
-です。有効化するには `~/.config/stackchan-mcp/notify.yml` で opt-in
-してください。Channels 機構は実験的な MCP capability を使っており、
-今後変わる可能性があります。
+Stack-chan の物理イベント（現在対応: touch tap / stroke、構造上は
+将来の subtype 追加が可能）は、3 つの通知 channel で配信できます。
+すべての channel はデフォルトで無効です。
+`~/.config/stackchan-mcp/notify.yml` で opt-in してください。複数の
+channel を同時に有効化することもでき、その場合は有効化された各
+channel に同じイベントが配信されます。連携するホストに合わせて
+選んでください。
 
-Channels 通知を有効にするには:
+- `channels` — Claude Code plugin 経路。Claude Code の実験的な
+  Channels capability 経由で、`<channel ...>` ブロックとして
+  セッションに inject されます。Stack-chan を Claude Code plugin
+  として install し、イベントを会話の中に届けたい場合に使います。
+- `jsonl` — プロセス外ファイル連携。各イベントが 1 行の JSON として
+  指定したファイルに追記されます。Claude Code 以外のホストや独自
+  パイプラインが、ファイルを tail して非同期に取り込みたい場合に
+  使います。
+- `legacy_event` — plugin 以前の MCP notification。gateway が独自
+  定義の `stackchan/event` MCP notification method を送出します。
+  Channels capability 以前から存在する経路です。ホストが Claude Code
+  plugin 経路ではなく `~/.claude.json` `mcpServers` で gateway を
+  起動している場合の backward compatibility 用です。
 
-1. Gateway 側 — `~/.config/stackchan-mcp/notify.yml` で Channels を
-   有効化します。
+詳細な注釈付き設定リファレンスは `notify.example.yml` を参照して
+ください。
 
-   ```yaml
-   channels:
-     enabled: true
-   ```
+#### Channel: `channels`（Claude Code plugin 経路）
 
-2. Plugin install — `kisaragi-mochi-channels` marketplace から、本
+Stack-chan を Claude Code plugin として起動し、セッション内に channel
+ブロックとしてイベントを届けたい場合に使います。この channel は
+変化する可能性のある実験的な MCP capability を使います。
+
+`notify.yml` で有効化:
+
+```yaml
+channels:
+  enabled: true
+```
+
+Claude Code session に `<channel ...>` ブロックが inject されます:
+
+```
+<channel source="plugin:stackchanmcp:stackchanmcp" ...>head was tapped</channel>
+```
+
+セットアップ:
+
+1. Plugin install — `kisaragi-mochi-channels` marketplace から、本
    リポジトリを Claude Code plugin として install します。
 
    ```bash
@@ -470,7 +500,7 @@ Channels 通知を有効にするには:
    指してください。Claude Code は同梱の `.mcp.json` 経由で
    `${CLAUDE_PLUGIN_ROOT}/gateway` 配下の gateway を起動します。
 
-3. ホスト環境設定 — Channels 経路では、3 箇所のホスト側名前を
+2. ホスト環境設定 — Channels 経路では、3 箇所のホスト側名前を
    gateway の MCP server 名（`stackchanmcp`、ハイフン無し）と
    揃える必要があります。
 
@@ -492,7 +522,7 @@ Channels 通知を有効にするには:
      }
      ```
 
-4. 受け口側 — Channels フラグつきで Claude Code を起動します。
+3. 受け口側 — Channels フラグつきで Claude Code を起動します。
 
    ```bash
    claude --channels plugin:stackchanmcp@kisaragi-mochi-channels \
@@ -508,27 +538,26 @@ Channels 通知を有効にするには:
    検証されています。Channels capability が安定化したら、このフラグは
    optional になる予定です。
 
-   重要 — plugin 以前の起動経路では Channels が届きません: 以前
-   `~/.claude.json` の `mcpServers` 経由でこの gateway を起動して
-   いた場合、その旧経路では `<channel ...>` の inject は届きません。
-   Claude Code は plugin 経由で起動された MCP server のみに channel
-   source を付ける仕様です。plugin 経路に移行する前に、既存の gateway
-   プロセスを停止して ESP32 ownership lock を解放してください。そう
-   しないと plugin 経由で起動した gateway が lock 取得に失敗します。
-   `~/.claude.json` 経由のまま使いたい場合は、`channels` ではなく
-   `legacy_event` / `jsonl` を使ってください。どちらも plugin loading
-   なしで動作します。
+重要 — plugin 以前の起動経路では Channels が届きません: 以前
+`~/.claude.json` の `mcpServers` 経由でこの gateway を起動して
+いた場合、その旧経路では `<channel ...>` の inject は届きません。
+Claude Code は plugin 経由で起動された MCP server のみに channel
+source を付ける仕様です。plugin 経路に移行する前に、既存の gateway
+プロセスを停止して ESP32 ownership lock を解放してください。そう
+しないと plugin 経由で起動した gateway が lock 取得に失敗します。
+`~/.claude.json` 経路のまま使いたい場合は、下記の `legacy_event` /
+`jsonl` channel を使ってください。どちらも plugin loading なしで
+動作します。
 
-5. 他ホスト:
+他ホスト:
 
-   - **`claude/channel` 互換の受け口を持つ他ホスト**: 当該ホストの
-     ドキュメントに従って受け口を開いてください。Claude Code 以外の
-     ホストとの互換性は当リポジトリでは未検証です。
+- `claude/channel` 互換の受け口を持つ他ホスト: 当該ホストの
+  ドキュメントに従って受け口を開いてください。Claude Code 以外の
+  ホストとの互換性は当リポジトリでは未検証です。
+- Channels 受け口を持たないホスト: 下記の `jsonl` channel を
+  使ってください。
 
-   - **Channels 受け口を持たないホスト**: JSONL フォールバックを
-     使ってください（下記参照）。
-
-#### 旧 `stackchan-mcp`（ハイフン入り）form からの migration
+##### 旧 `stackchan-mcp`（ハイフン入り）form からの migration
 
 以前 `stackchan-mcp` server name form で Channels を有効化していた
 場合、ホスト MCP client と gateway を揃えるため、以下を現行の
@@ -551,25 +580,77 @@ Channels 通知を有効にするには:
 `Channel notifications skipped: server <name> not in --channels list
 for this session` を log し、notification が session に届きません。
 
-#### イベントメッセージ文言のカスタマイズ
+#### Channel: `jsonl`（プロセス外ファイル連携）
 
-届けられる各イベントには、テンプレートから生成される短いメッセージが
-付きます。組み込みのデフォルトは「機械的なイベント名」ではなく
-「デバイスが何を感じたか」を表す体験的な表現にしてあり、受信側の
-エージェントが一人称のナレーションとして読めるようになっています。
+Claude Code 以外のホストや独自パイプラインが、ファイルを tail して
+イベントを非同期に取り込みたい場合に使います。Claude Code 以外の
+任意の連携先に対して最も簡単に組み込める channel です。
 
-| イベント | デフォルト `action` | デフォルト `template` |
-| --- | --- | --- |
-| `touch` / `tap` | `head_pat` | `head was tapped` |
-| `touch` / `stroke` | `head_stroke` | `head was stroked for {duration_ms}ms` |
+`notify.yml` で有効化:
 
-`{duration_ms}` プレースホルダはイベントの payload から置換されます。
-未知のプレースホルダはそのまま保持されます。
+```yaml
+jsonl:
+  enabled: true
+  path: ~/.claude/stackchan-events.jsonl
+```
 
-文言を上書きするには、`~/.config/stackchan-mcp/notify.yml` に
-`messages:` ブロックを追加します。記載したイベント種別だけが上書き
-され、それ以外は上記のデフォルトのままです。たとえば、よりくだけた
-表現にする場合:
+各イベントは、設定したパスに 1 行の JSON として追記されます。
+ファイルが存在しない場合は作成され、既存のエントリは保持されます。
+tap と stroke の配信例:
+
+```json
+{"type": "touch", "subtype": "tap", "action": "head_pat", "message": "head was tapped"}
+{"type": "touch", "subtype": "stroke", "action": "head_stroke", "message": "head was stroked for 720ms", "duration_ms": 720}
+```
+
+最上位の `type` / `subtype` は常に下記「Supported event subtypes」
+の行と対応します。`action` / `message` はデフォルト（または
+`messages:` で設定した override 内容）を反映します。
+
+#### Channel: `legacy_event`（plugin 以前の backward compatibility）
+
+ホストが Claude Code plugin 経路ではなく `~/.claude.json` `mcpServers`
+で gateway を起動していて、ホストを plugin form に切り替えずに
+イベントを受け取りたい場合に使います。
+
+`notify.yml` で有効化:
+
+```yaml
+legacy_event:
+  enabled: true
+```
+
+gateway は独自定義の `stackchan/event` MCP notification method を
+送出します。notification params には `jsonl` の payload と同じ
+`type` / `subtype` / `action` / `message` の各 field が含まれます。
+受信側の notification の扱いはホスト依存です: Claude Code の plugin
+以前経路では従来、メッセージが inline で表示されました。他ホストでは
+異なる扱いになる場合があります。
+
+#### Supported event subtypes
+
+現在対応している物理イベントは下記の通りです。構造は意図的に拡張
+可能で、`touch` の subtype 追加や新しい top-level type（例:
+`motion`, `voice`）が後続の release で追加された場合も、本
+セクションの全面書き直しなしに追記できます。
+
+| Type | Subtype | デフォルト `action` | デフォルト `template` |
+| --- | --- | --- | --- |
+| `touch` | `tap` | `head_pat` | `head was tapped` |
+| `touch` | `stroke` | `head_stroke` | `head was stroked for {duration_ms}ms` |
+
+組み込みのデフォルトは「機械的なイベント名」ではなく「デバイスが
+何を感じたか」を表す体験的な表現にしてあり、受信側のエージェントが
+一人称のナレーションとして読めるようになっています。`{duration_ms}`
+プレースホルダは event payload から置換され、未知のプレースホルダは
+そのまま保持されます。
+
+##### 文言の上書き
+
+`~/.config/stackchan-mcp/notify.yml` に `messages:` block を追加
+すると、subtype ごとの `action` / `template` を上書きできます。
+記載した subtype だけが上書きされ、それ以外は上記のデフォルトの
+ままです。
 
 ```yaml
 # ~/.config/stackchan-mcp/notify.yml
@@ -585,19 +666,8 @@ messages:
 
 上書きする各 subtype には `action` と `template` の両方が必要です。
 `action` の値はイベントの metadata に転送されるため、下流の consumer
-がそれを key にしている場合は安定させておいてください。詳細な注釈付き
-リファレンスは `notify.example.yml` を参照してください。
-
-以前の常時有効だったイベント動作に戻す設定:
-
-```yaml
-# ~/.config/stackchan-mcp/notify.yml
-legacy_event:
-  enabled: true
-jsonl:
-  enabled: true
-  path: ~/.claude/stackchan-events.jsonl
-```
+がそれを key にしている場合は安定させておいてください。詳細な注釈
+付きリファレンスは `notify.example.yml` を参照してください。
 
 ## アバター画像について
 

--- a/README.md
+++ b/README.md
@@ -662,8 +662,11 @@ preserved. Each line carries:
 - `ts_unix` — wall-clock timestamp when the gateway recorded the
   event.
 - `session_id` — gateway session identifier.
-- `action` (optional) — avatar action keyed by the `messages:`
-  config; omitted when no override is configured.
+- `action` — avatar action keyword for the event subtype (e.g.
+  `head_pat`, `head_stroke`). The built-in default templates always
+  populate this, and `messages:` overrides are also required to
+  specify `action`, so this field is present for every supported
+  subtype.
 
 The rendered wording (e.g. `head was tapped`) is what the `channels`
 channel delivers as the human-readable message; it is not stored in
@@ -691,14 +694,12 @@ legacy_event:
 ```
 
 The gateway emits the self-defined `stackchan/event` MCP notification
-method. The notification params carry the `event_type` / `subtype` /
-`duration_ms` / `ts` / `session_id` fields (the same fields as the
-`jsonl` record above, minus `ts_unix`, which is added only by the
-JSONL writer). The optional `action` field is included when the
-`messages:` config provides an override. The host is responsible for
-surfacing the notification — Claude Code's pre-plugin path
-historically displayed the rendered template inline; other hosts may
-handle the notification differently.
+method. The notification params carry the same fields as the JSONL
+record above, except that `ts_unix` is not included (it is added only
+by the JSONL writer). The host is responsible for surfacing the
+notification — Claude Code's pre-plugin path historically displayed
+the rendered template inline; other hosts may handle the notification
+differently.
 
 #### Supported event subtypes
 

--- a/README.md
+++ b/README.md
@@ -494,22 +494,57 @@ the `listen` API.
 
 ### 6. Optional: enable event notifications
 
-Stack-chan physical events (touch tap / stroke) can be delivered through
-several notification paths, depending on host capabilities. All paths are
-disabled by default; opt in via `~/.config/stackchan-mcp/notify.yml`. The
-Channels mechanism uses an experimental MCP capability and may evolve.
+Stack-chan physical events (today: touch tap / stroke; the structure
+allows additional subtypes to be appended later) can be delivered
+through three notification channels. All channels are disabled by
+default; opt in via `~/.config/stackchan-mcp/notify.yml`. More than
+one channel can be enabled at the same time; each event is then
+delivered over every enabled channel. Pick whichever match the host
+you are integrating with:
 
-To enable Channels notifications:
+- `channels` — Claude Code plugin path. Notifications are injected
+  into the running session as `<channel ...>` blocks via Claude Code's
+  experimental Channels capability. Use this when Stack-chan is wired
+  into Claude Code as an installed plugin and you want events to reach
+  the conversation in-band.
+- `jsonl` — Out-of-process file integration. Each event is appended
+  as a single JSON line to a file you configure. Use this when an
+  external host (anything other than Claude Code, or your own
+  pipeline) needs to ingest events asynchronously by tailing a file.
+- `legacy_event` — Pre-plugin MCP notification. The gateway emits the
+  self-defined `stackchan/event` MCP notification method, which
+  existed before the Channels capability shipped. Use this for
+  backward compatibility when the host wires the gateway via
+  `~/.claude.json` `mcpServers` rather than the Claude Code plugin
+  path.
 
-1. Gateway side — turn Channels on in `~/.config/stackchan-mcp/notify.yml`:
+See `notify.example.yml` for the full annotated configuration
+reference.
 
-   ```yaml
-   channels:
-     enabled: true
-   ```
+#### Channel: `channels` (Claude Code plugin path)
 
-2. Plugin installation — install this repository as a Claude Code plugin
-   from the `kisaragi-mochi-channels` marketplace:
+Use when Stack-chan is loaded as a Claude Code plugin and you want
+events delivered as in-session channel blocks. This channel uses an
+experimental MCP capability that may evolve.
+
+Enable in `notify.yml`:
+
+```yaml
+channels:
+  enabled: true
+```
+
+Delivered as a `<channel ...>` block injected into the Claude Code
+session, for example:
+
+```
+<channel source="plugin:stackchanmcp:stackchanmcp" ...>head was tapped</channel>
+```
+
+Setup:
+
+1. Plugin installation — install this repository as a Claude Code
+   plugin from the `kisaragi-mochi-channels` marketplace:
 
    ```bash
    claude plugin install stackchanmcp@kisaragi-mochi-channels
@@ -520,7 +555,7 @@ To enable Channels notifications:
    marketplace; Claude Code starts the gateway under
    `${CLAUDE_PLUGIN_ROOT}/gateway` via the bundled `.mcp.json`.
 
-3. Host environment setup — the Channels delivery path requires three
+2. Host environment setup — the Channels delivery path requires three
    host-side names to be aligned with the gateway's MCP server name
    (`stackchanmcp`, no hyphen):
 
@@ -542,7 +577,7 @@ To enable Channels notifications:
      }
      ```
 
-4. Receiver side — launch Claude Code with the Channels flags:
+3. Receiver side — launch Claude Code with the Channels flags:
 
    ```bash
    claude --channels plugin:stackchanmcp@kisaragi-mochi-channels \
@@ -559,27 +594,24 @@ To enable Channels notifications:
    versions. The flag is expected to become optional once the plugin's
    Channels capability stabilizes.
 
-   Important — pre-plugin wiring does not receive Channels: if you
-   previously wired this gateway via `~/.claude.json` `mcpServers`
-   (the pre-plugin path), that wiring does not receive `<channel ...>`
-   injections. Claude Code only attaches a channel source to
-   plugin-loaded MCP servers. Before switching to the plugin path,
-   stop any existing gateway process to release the ESP32 ownership
-   lock; the plugin-loaded gateway will otherwise fail to acquire it.
-   If you prefer to keep the `~/.claude.json` wiring, use
-   `legacy_event` and `jsonl` instead of `channels` — both work
-   without plugin loading.
+Important — pre-plugin wiring does not receive Channels: if you
+previously wired this gateway via `~/.claude.json` `mcpServers` (the
+pre-plugin path), that wiring does not receive `<channel ...>`
+injections. Claude Code only attaches a channel source to
+plugin-loaded MCP servers. Before switching to the plugin path, stop
+any existing gateway process to release the ESP32 ownership lock; the
+plugin-loaded gateway will otherwise fail to acquire it. If you prefer
+to keep the `~/.claude.json` wiring, use the `legacy_event` or `jsonl`
+channel below — both work without plugin loading.
 
-5. Other hosts:
+Other hosts:
 
-   - **Hosts with a `claude/channel`-compatible receiver**: open that
-     receiver per the host's documentation. Compatibility with hosts
-     other than Claude Code has not been verified in this repository.
+- Hosts with a `claude/channel`-compatible receiver: open that
+  receiver per the host's documentation. Compatibility with hosts
+  other than Claude Code has not been verified in this repository.
+- Hosts without a Channels receiver: use the `jsonl` channel below.
 
-   - **Hosts without a Channels receiver**: use the JSONL fallback (see
-     below).
-
-#### Migration from the previous `stackchan-mcp` (hyphenated) form
+##### Migration from the previous `stackchan-mcp` (hyphenated) form
 
 If you enabled Channels using the older `stackchan-mcp` server-name
 form, rename to the current `stackchanmcp` form (no hyphen) in all four
@@ -603,25 +635,76 @@ Without all four renames the host MCP client logs
 `Channel notifications skipped: server <name> not in --channels list
 for this session` and the notifications never reach the session.
 
-#### Customizing event message wording
+#### Channel: `jsonl` (out-of-process file integration)
 
-Each delivered event carries a short message rendered from a template.
+Use when an external host or your own pipeline needs to ingest events
+asynchronously by tailing a file. This is the simplest channel to wire
+into anything that is not Claude Code.
+
+Enable in `notify.yml`:
+
+```yaml
+jsonl:
+  enabled: true
+  path: ~/.claude/stackchan-events.jsonl
+```
+
+Each event is appended as one JSON line to the configured path. The
+file is created if it does not exist, and existing entries are
+preserved. A delivered tap and stroke pair looks like:
+
+```json
+{"type": "touch", "subtype": "tap", "action": "head_pat", "message": "head was tapped"}
+{"type": "touch", "subtype": "stroke", "action": "head_stroke", "message": "head was stroked for 720ms", "duration_ms": 720}
+```
+
+The top-level `type` and `subtype` always correspond to the rows in
+"Supported event subtypes" below; `action` and `message` reflect the
+defaults, or the override you configured under `messages:`.
+
+#### Channel: `legacy_event` (pre-plugin backward compatibility)
+
+Use when the gateway is wired into the host via `~/.claude.json`
+`mcpServers` (the pre-plugin path) and you want events without
+switching the host over to the plugin form.
+
+Enable in `notify.yml`:
+
+```yaml
+legacy_event:
+  enabled: true
+```
+
+The gateway emits the self-defined `stackchan/event` MCP notification
+method. The notification params carry the same `type` / `subtype` /
+`action` / `message` fields as the `jsonl` payload above. The host is
+responsible for surfacing the notification — Claude Code's pre-plugin
+path historically displayed the message inline; other hosts may
+handle the notification differently.
+
+#### Supported event subtypes
+
+The currently supported physical events are listed below. The structure
+is intentionally extensible: additional `touch` subtypes or new
+top-level types (e.g. `motion`, `voice`) can be appended in future
+releases without rewriting this section.
+
+| Type | Subtype | Default `action` | Default `template` |
+| --- | --- | --- | --- |
+| `touch` | `tap` | `head_pat` | `head was tapped` |
+| `touch` | `stroke` | `head_stroke` | `head was stroked for {duration_ms}ms` |
+
 The built-in defaults are phrased experientially — describing what the
 device felt rather than naming a mechanical event — so the consuming
-agent reads them as first-person narration:
+agent reads them as first-person narration. The `{duration_ms}`
+placeholder is substituted from the event payload; unknown
+placeholders are preserved verbatim.
 
-| Event | Default `action` | Default `template` |
-| --- | --- | --- |
-| `touch` / `tap` | `head_pat` | `head was tapped` |
-| `touch` / `stroke` | `head_stroke` | `head was stroked for {duration_ms}ms` |
+##### Overriding the wording
 
-The `{duration_ms}` placeholder is substituted from the event payload;
-unknown placeholders are preserved verbatim.
-
-To override the wording, add a `messages:` block to
-`~/.config/stackchan-mcp/notify.yml`. Only the event types you list are
-overridden; everything else keeps the defaults above. For example, to
-use a more casual phrasing:
+Add a `messages:` block to `~/.config/stackchan-mcp/notify.yml` to
+override the per-subtype `action` and `template`. Only the subtypes
+you list are overridden; everything else keeps the defaults above.
 
 ```yaml
 # ~/.config/stackchan-mcp/notify.yml
@@ -636,20 +719,9 @@ messages:
 ```
 
 Both `action` and `template` are required for each overridden subtype.
-The `action` value is forwarded in the event metadata, so keep it stable
-if a downstream consumer keys off it. See `notify.example.yml` for the
-full annotated reference.
-
-To restore the previous always-on event behavior:
-
-```yaml
-# ~/.config/stackchan-mcp/notify.yml
-legacy_event:
-  enabled: true
-jsonl:
-  enabled: true
-  path: ~/.claude/stackchan-events.jsonl
-```
+The `action` value is forwarded in the event metadata, so keep it
+stable if a downstream consumer keys off it. See `notify.example.yml`
+for the full annotated reference.
 
 ## About the avatar images
 

--- a/README.md
+++ b/README.md
@@ -651,16 +651,31 @@ jsonl:
 
 Each event is appended as one JSON line to the configured path. The
 file is created if it does not exist, and existing entries are
-preserved. A delivered tap and stroke pair looks like:
+preserved. Each line carries:
+
+- `event_type` — top-level event type (currently `"touch"`).
+- `subtype` — subtype within the event type (currently `"tap"` or
+  `"stroke"`).
+- `duration_ms` — firmware-reported duration of the event in
+  milliseconds.
+- `ts` — firmware uptime in milliseconds (monotonic).
+- `ts_unix` — wall-clock timestamp when the gateway recorded the
+  event.
+- `session_id` — gateway session identifier.
+- `action` (optional) — avatar action keyed by the `messages:`
+  config; omitted when no override is configured.
+
+The rendered wording (e.g. `head was tapped`) is what the `channels`
+channel delivers as the human-readable message; it is not stored in
+the JSONL record itself. A delivered tap-and-stroke pair looks like:
 
 ```json
-{"type": "touch", "subtype": "tap", "action": "head_pat", "message": "head was tapped"}
-{"type": "touch", "subtype": "stroke", "action": "head_stroke", "message": "head was stroked for 720ms", "duration_ms": 720}
+{"event_type": "touch", "subtype": "tap", "duration_ms": 0, "ts": 123456, "ts_unix": 1717862400.0, "session_id": "abc-123", "action": "head_pat"}
+{"event_type": "touch", "subtype": "stroke", "duration_ms": 720, "ts": 124000, "ts_unix": 1717862400.7, "session_id": "abc-123", "action": "head_stroke"}
 ```
 
-The top-level `type` and `subtype` always correspond to the rows in
-"Supported event subtypes" below; `action` and `message` reflect the
-defaults, or the override you configured under `messages:`.
+The top-level `event_type` and `subtype` correspond to the rows in
+"Supported event subtypes" below.
 
 #### Channel: `legacy_event` (pre-plugin backward compatibility)
 
@@ -676,10 +691,13 @@ legacy_event:
 ```
 
 The gateway emits the self-defined `stackchan/event` MCP notification
-method. The notification params carry the same `type` / `subtype` /
-`action` / `message` fields as the `jsonl` payload above. The host is
-responsible for surfacing the notification — Claude Code's pre-plugin
-path historically displayed the message inline; other hosts may
+method. The notification params carry the `event_type` / `subtype` /
+`duration_ms` / `ts` / `session_id` fields (the same fields as the
+`jsonl` record above, minus `ts_unix`, which is added only by the
+JSONL writer). The optional `action` field is included when the
+`messages:` config provides an override. The host is responsible for
+surfacing the notification — Claude Code's pre-plugin path
+historically displayed the rendered template inline; other hosts may
 handle the notification differently.
 
 #### Supported event subtypes


### PR DESCRIPTION
## Summary

Restructure the README EN/JP "Optional: enable event notifications"
section as a tri-channel guide so that each of `channels`, `jsonl`,
and `legacy_event` is documented as a first-class delivery option
rather than a variation on the `channels` path.

Each channel now has its own subsection containing the `notify.yml`
enable block, a delivered payload example (rendered `<channel>` block,
JSONL line, or `stackchan/event` MCP notification params), and the
intended use case. An opening paragraph summarizes the three channels
side by side. Supported event subtypes are listed in a dedicated
subsection that allows additional `touch` subtypes or new top-level
types to be appended in future releases without rewriting the
section, and the message-template override guidance is grouped next
to the subtype table.

PR #271 already landed the `channels`-path setup details (plugin
install, host environment alignment, migration from the
`stackchan-mcp` hyphenated form); this PR completes the remaining
scope listed in the Issue #268 tracking comment.

## Test plan

### Code-level

- [ ] gateway: `uv run pytest`
- [ ] gateway: `uv run ruff check .`
- [ ] firmware: `python ./scripts/release.py stackchan`
- [x] Not applicable / not run: documentation-only change, no Python
      or firmware sources touched.

Documentation accuracy was verified against the implementation:

- The JSONL field list (`event_type` / `subtype` / `duration_ms` /
  `ts` / `ts_unix` / `session_id` / `action`) matches
  `gateway/stackchan_mcp/event_log.py:log_event`.
- The `action` field being present for default events too was
  confirmed against the `DEFAULT_MESSAGE_TEMPLATES` resolution path
  in `gateway/stackchan_mcp/esp32_client.py:846-852`.
- Pre-PR `codex review --base main` was run three times during
  preparation: pass 1 flagged a payload-schema mismatch (`type` /
  `message` vs. `event_type` / no `message`), fixed in e5ed2f1; pass
  2 flagged the `action` field being incorrectly marked optional,
  fixed in 16f17e1; pass 3 returned no findings.

### Hardware

- [x] Not applicable / hardware not available: documentation-only
      change with no firmware effect.

## Breaking changes

None. Documentation-only rewrite of the README notification section;
no behavior or API changes.

## Related issues

Closes #268.
