### PR TITLE
fix(publish): temporarily skip Windows wheel build for v0.9.0 — unblock PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,7 +309,17 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [build, build-windows-wheel]
+    # `build-windows-wheel` is temporarily removed from `needs` for
+    # v0.9.0 (paired with the `if: false` on that job above): when a
+    # job is `if: false`-skipped, GitHub Actions skip-propagates to
+    # downstream jobs that list it in `needs` unless we explicitly
+    # override with `always()` plus a per-need result check. Removing
+    # it from `needs` is the simpler revert path for v0.9.1 — just
+    # re-add `build-windows-wheel` to this list and drop the `if`
+    # disables above. The `Download Windows wheel (win_amd64)` step
+    # below is also disabled, so this publish job ships only the
+    # Linux sdist + py3-none-any wheel for v0.9.0.
+    needs: [build]
     # Only publish on tag pushes. workflow_dispatch invocations stop at
     # the build job above, so manual runs cannot release. The
     # `startsWith(github.ref, 'refs/tags/v')` guard makes the intent

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,6 +144,18 @@ jobs:
   build-windows-wheel:
     name: Build win_amd64 wheel
     needs: build
+    # Temporarily disabled for v0.9.0: the produced opus.dll is
+    # non-deterministic across runs on the current windows-latest
+    # runner-image (the SHA256 verify guard observes a different hash
+    # each build), so the pinned EXPECTED_OPUS_DLL_SHA256 cannot match.
+    # Restore in v0.9.1 once the SHA drift root cause is fixed (the
+    # likely path is replacing the byte-identical-binary guard with a
+    # functional smoke test, so each build's freshly produced opus.dll
+    # is verified by exercising the loader / encode round-trip instead
+    # of by hash comparison against a previously reviewed binary).
+    # Paired with the `Download Windows wheel (win_amd64)` step in the
+    # publish job below, which is also disabled.
+    if: false
     # The Windows wheel only differs from the Ubuntu build by the
     # bundled `opus.dll`, but it must be built on a Windows runner so
     # vcpkg can produce a binary that matches the runtime ABI users
@@ -324,7 +336,11 @@ jobs:
           name: python-package-distributions-linux
           path: dist/
 
+      # Temporarily disabled for v0.9.0 — paired with the
+      # `build-windows-wheel` job disable above. Restore in v0.9.1
+      # once the opus.dll SHA drift root cause is fixed.
       - name: Download Windows wheel (win_amd64)
+        if: false
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions-windows


### PR DESCRIPTION
## Summary

Hotfix for the v0.9.0 publish that failed at `Verify opus.dll SHA256`
in the `build-windows-wheel` job: the `windows-latest` runner image
now produces a non-deterministic `opus.dll` across builds (two
consecutive runs observed two different SHA256 values), so the
pinned `EXPECTED_OPUS_DLL_SHA256` cannot match.

This PR disables the Windows wheel build path for v0.9.0 only so
that the Linux sdist and the `py3-none-any` wheel can publish to
PyPI:

- `build-windows-wheel` job: `if: false` with a comment block pointing
  at v0.9.1 as the restore target.
- `Download Windows wheel (win_amd64)` step in the publish job:
  `if: false` paired with the job disable.
- `publish` job `needs`: removed `build-windows-wheel` so the
  `if: false`-skipped job does not skip-propagate to publish.

The Linux sdist and `py3-none-any` wheel are unchanged.

## Impact

- Linux / macOS users: unaffected, receive v0.9.0 with all features.
- Windows users on the base `stackchan-mcp` install: unaffected,
  receive v0.9.0.
- Windows users on `stackchan-mcp[tts]` / `[stt]` (bundled native
  `libopus`): stay on v0.8.0 until v0.9.1 ships. The `win_amd64`
  wheel for v0.9.0 does not exist, so `pip` will not auto-upgrade
  them to v0.9.0 against their `tts` / `stt` pin.

## v0.9.1 plan

A follow-up PR will replace the byte-identical SHA256 guard with a
functional smoke test: each build's freshly produced `opus.dll` is
verified by exercising the loader and an Opus encode round-trip, so
non-determinism in the produced binary stops being a release blocker
as long as the binary is functionally correct. Once that lands, the
`if: false` disables and the `needs` removal in this PR are reverted
in the same v0.9.1 commit.

A tracking issue for the SHA drift root cause and the v0.9.1 fix
will be opened after this PR lands.

## Test plan

### Code-level

- [ ] gateway: `uv run pytest`
- [ ] gateway: `uv run ruff check .`
- [x] Not applicable / not run: workflow file changes only; no Python
      or firmware sources touched.

Pre-PR validation:

- Pre-PR `codex review --base main` was run twice during preparation.
  Pass 1 flagged a P1 (the `publish` job's `needs` listed
  `build-windows-wheel` which would skip-propagate the publish job
  whenever the Windows wheel build is `if: false`-skipped); fixed in
  0045b40. Pass 2 returned no findings.

### Hardware

- [x] Not applicable / hardware not available: workflow-only change
      with no firmware effect.

## Breaking changes

None for non-Windows users. For Windows users on the `tts` or `stt`
extras, v0.9.0 will not produce a `win_amd64` wheel, so their
pinned install path stays on v0.8.0 until v0.9.1 ships. v0.9.1 is
the follow-up tracked as described above; it will not be
open-ended.

## Related issues

This PR unblocks the v0.9.0 release that was started by #273.
After this PR merges, the `v0.9.0` tag is re-pushed to point at this
PR's merge commit on `main`, which triggers the publish workflow
again.

## After merge

1. Force-update the `v0.9.0` tag to point at this PR's merge commit
   on `main`.
2. `publish.yml` runs Trusted Publishing to PyPI (sdist +
   `py3-none-any` wheel).
3. Create the v0.9.0 GitHub Release page with release notes that
   include the Windows wheel temporary-skip note and a pointer to
   the tracking issue.
4. Open the tracking issue for the SHA drift root cause and the
   v0.9.1 plan.
