### PR TITLE
release: v0.9.1 — restore Windows wheel build (functional smoke test gate)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,15 @@ jobs:
   changelog-check:
     name: CHANGELOG check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Skip on `release:`-titled PRs: release-promotion PRs move
+    # entries from [Unreleased] into a new dated release section, so
+    # the [Unreleased] body is legitimately unchanged between base
+    # and head when the previous release had already drained it. The
+    # release-time gate in `firmware-release.yml` (and the
+    # `Verify CHANGELOG.md ...` step in `publish.yml`) is the
+    # authoritative check that the promoted section exists for the
+    # tag being pushed.
+    if: github.event_name == 'pull_request' && !startsWith(github.event.pull_request.title, 'release:')
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -274,25 +274,46 @@ jobs:
       - name: Build wheel (win_amd64)
         working-directory: gateway
         shell: pwsh
-        # `uv build --wheel` produces `*-py3-none-any.whl` by default;
-        # override the platform tag with cibuildwheel-style tag args via
-        # hatch's `--target-platform`-equivalent. Since hatchling does
-        # not have a CLI override for the wheel tag, rely on uv build's
-        # `--target` flag if available; otherwise fall back to renaming.
+        # `uv build --wheel` produces a `*-py3-none-any.whl` by
+        # default; rewrite the wheel's platform tag to `win_amd64` via
+        # the `wheel tags` CLI so both the filename and the internal
+        # `.dist-info/WHEEL` `Tag:` line say `win_amd64`. The earlier
+        # filename-only rename (introduced in PR #217) produced a
+        # wheel whose filename and internal metadata disagreed —
+        # wheel-validating tools would flag this as a malformed
+        # distribution. Codex review of v0.9.1 caught the
+        # inconsistency; this commit fixes it as part of the
+        # Windows wheel restore.
         run: |
-          # Use uv build to produce the wheel, then rename the
-          # platform tag from `any` to `win_amd64` so pip resolves it
-          # only on Windows x64 installs. hatchling does not auto-tag
-          # based on bundled binaries.
           uv build --wheel
+          # `wheel` is not a runtime dependency of stackchan-mcp; it
+          # is installed explicitly into the project env here so that
+          # `uv run python -m wheel tags ...` is available regardless
+          # of resolver caching behavior between runs.
+          uv pip install wheel
           $wheels = Get-ChildItem dist\*-py3-none-any.whl
           if ($wheels.Count -ne 1) {
             Write-Error "Expected exactly one py3-none-any wheel, found $($wheels.Count)"
             exit 1
           }
           $src = $wheels[0].FullName
-          $dst = $src -replace '-py3-none-any\.whl$', '-py3-none-win_amd64.whl'
-          Rename-Item -Path $src -NewName (Split-Path -Leaf $dst)
+          # Rewrite the wheel's platform tag in-place; `--remove`
+          # deletes the source `py3-none-any` wheel so only the
+          # `win_amd64` wheel remains in dist/.
+          uv run python -m wheel tags --platform-tag win_amd64 --remove $src
+          # Sanity check the produced wheel: exactly one win_amd64
+          # wheel and no leftover py3-none-any wheel should be in
+          # dist/ at this point.
+          $built = Get-ChildItem dist\*-win_amd64.whl
+          if ($built.Count -ne 1) {
+            Write-Error "Expected exactly one win_amd64 wheel after `wheel tags`, found $($built.Count)"
+            exit 1
+          }
+          $stale = Get-ChildItem dist\*-py3-none-any.whl -ErrorAction SilentlyContinue
+          if ($stale -ne $null -and $stale.Count -gt 0) {
+            Write-Error "Stale py3-none-any wheel still present after `wheel tags --remove`: $($stale -join ', ')"
+            exit 1
+          }
           Get-ChildItem dist\
 
       - name: Upload Windows wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,15 +122,28 @@ jobs:
         # equivalent gate in firmware-release.yml.
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
-          # Tag form is `vX.Y.Z`; the CHANGELOG heading form is
-          # `## [X.Y.Z] - YYYY-MM-DD`.
-          VERSION="${GITHUB_REF_NAME#v}"
-          if ! grep -qE "^## \[${VERSION}\] - " CHANGELOG.md; then
-            echo "::error title=Missing CHANGELOG section for ${GITHUB_REF_NAME}::CHANGELOG.md does not contain a dated section for this tag. Expected heading like: ## [${VERSION}] - YYYY-MM-DD"
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"   # e.g. v0.9.1
+          VERSION="${TAG#v}"          # e.g. 0.9.1
+          # Escape `.` for regex so a malformed heading like
+          # `## [0x9x1] - 2026-06-08` does not falsely match the
+          # dotted version on a naive grep.
+          VERSION_ESC=$(printf '%s' "$VERSION" | sed -E 's/\./\\./g')
+          # Match `## [<VERSION>] - YYYY-MM-DD` exactly (anchored line,
+          # no leading or trailing garbage). Require exactly one
+          # occurrence; zero is missing-section, more than one means
+          # a duplicate / botched promotion.
+          COUNT=$(grep -cE "^## \[${VERSION_ESC}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}\$" CHANGELOG.md || true)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error title=Missing CHANGELOG section for ${TAG}::CHANGELOG.md does not contain a dated section for this tag. Expected an exact heading like: ## [${VERSION}] - YYYY-MM-DD"
             echo "Add the section to CHANGELOG.md (promote the [Unreleased] entries into a new dated section) before pushing the tag."
             exit 1
           fi
-          echo "CHANGELOG.md contains a dated section for ${GITHUB_REF_NAME}."
+          if [ "$COUNT" -gt 1 ]; then
+            echo "::error title=Duplicate CHANGELOG section for ${TAG}::CHANGELOG.md has ${COUNT} dated sections for ${TAG}, expected exactly 1. Consolidate the duplicates before publishing."
+            exit 1
+          fi
+          echo "CHANGELOG entry for ${TAG} verified (exactly 1 dated section)."
 
       - name: Install gateway dependencies
         working-directory: gateway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,18 +144,18 @@ jobs:
   build-windows-wheel:
     name: Build win_amd64 wheel
     needs: build
-    # Temporarily disabled for v0.9.0: the produced opus.dll is
-    # non-deterministic across runs on the current windows-latest
-    # runner-image (the SHA256 verify guard observes a different hash
-    # each build), so the pinned EXPECTED_OPUS_DLL_SHA256 cannot match.
-    # Restore in v0.9.1 once the SHA drift root cause is fixed (the
-    # likely path is replacing the byte-identical-binary guard with a
-    # functional smoke test, so each build's freshly produced opus.dll
-    # is verified by exercising the loader / encode round-trip instead
-    # of by hash comparison against a previously reviewed binary).
-    # Paired with the `Download Windows wheel (win_amd64)` step in the
-    # publish job below, which is also disabled.
-    if: false
+    # Restored in v0.9.1 after the v0.9.0 hotfix (#274) temporarily
+    # disabled this job. The byte-identical SHA256 guard against a
+    # pinned EXPECTED_OPUS_DLL_SHA256 was retired here because the
+    # current windows-latest runner image produces non-deterministic
+    # opus.dll across builds (windows-latest → windows-2025-vs2026
+    # transition; MSVC under the new image embeds non-deterministic
+    # build info). The functional smoke test in the publish job below
+    # (`Smoke test bundled opus loader`, which loads opus.dll via
+    # opuslib and runs an Opus encode round-trip) is now the publish
+    # gate. The VCPKG_PIN below still locks the supply chain to a
+    # reviewed vcpkg release tag.
+    #
     # The Windows wheel only differs from the Ubuntu build by the
     # bundled `opus.dll`, but it must be built on a Windows runner so
     # vcpkg can produce a binary that matches the runtime ABI users
@@ -177,14 +177,15 @@ jobs:
       # https://github.com/microsoft/vcpkg/releases
       # Pinned to 2026.04.27 → Opus 1.5.2 port-version 1.
       VCPKG_PIN: "2026.04.27"
-      # Expected SHA256 of the produced opus.dll. Re-derived only when
-      # VCPKG_PIN or the windows-latest runner-image MSVC version
-      # changes. To rotate: run this workflow via `workflow_dispatch`
-      # (or watch the next tag run), copy the actual hash from the
-      # "Verify opus.dll SHA256" step below, and commit. An empty
-      # value intentionally fails the comparison so a missing pin
-      # cannot silently ship.
-      EXPECTED_OPUS_DLL_SHA256: "99cd252b09891398cefab997be8cdb1cebc9a40cafa1382c88ad32069560a864"
+      # NOTE: The previous EXPECTED_OPUS_DLL_SHA256 byte-identical
+      # guard was retired in v0.9.1 (see the job-level comment above).
+      # The functional smoke test in the publish job is now the
+      # publish gate; the freshly produced opus.dll must load via
+      # opuslib and pass an Opus encode round-trip on a real Windows
+      # runner before the wheel can ship. If deterministic builds
+      # are restored upstream (vcpkg + windows runner image), the
+      # SHA pin can be reintroduced as an additional reproducibility
+      # signal alongside the functional test, not as the sole gate.
 
     steps:
       - name: Checkout repository
@@ -224,30 +225,24 @@ jobs:
           New-Item -ItemType Directory -Force -Path $dest_dir | Out-Null
           Copy-Item -Force $dll "$dest_dir\opus.dll"
 
-      # Block the wheel build on opus.dll SHA256 drift. Without this
-      # gate, a tag rerun (or a runner-image refresh that changes
-      # MSVC build behaviour) could silently ship a different native
-      # binary than the one reviewed for the release, defeating the
-      # vcpkg pin above.
-      - name: Verify opus.dll SHA256
+      # Confirm vcpkg actually produced opus.dll and capture its
+      # SHA256 for informational logging. Functional verification
+      # (load opus.dll via opuslib and run an Opus encode round-trip)
+      # happens in the publish job below — see `Smoke test bundled
+      # opus loader`. The byte-identical SHA256 guard was retired in
+      # v0.9.1; see the job-level comment above for the rationale.
+      - name: Confirm opus.dll was produced
         shell: pwsh
         run: |
           $dll = "$env:GITHUB_WORKSPACE\gateway\stackchan_mcp\_libs\opus.dll"
+          if (-not (Test-Path $dll)) {
+            Write-Output "::error::opus.dll was not produced by vcpkg install. Expected at $dll."
+            exit 1
+          }
           $actual = (Get-FileHash $dll -Algorithm SHA256).Hash.ToLower()
-          $expected = $env:EXPECTED_OPUS_DLL_SHA256.ToLower()
-          Write-Output "opus.dll SHA256 (actual):   $actual"
-          Write-Output "opus.dll SHA256 (expected): $expected"
-          if ([string]::IsNullOrWhiteSpace($expected)) {
-            Write-Output "::error::EXPECTED_OPUS_DLL_SHA256 is unset. Run this workflow via workflow_dispatch, then copy the actual hash above into the EXPECTED_OPUS_DLL_SHA256 env in .github/workflows/publish.yml and commit before tagging a release."
-            exit 1
-          }
-          if ($actual -ne $expected) {
-            Write-Output "::error::opus.dll SHA256 mismatch — vcpkg-side or runner-image drift detected. Refusing to publish a different binary than the one reviewed for this VCPKG_PIN."
-            exit 1
-          }
-          Write-Output "opus.dll SHA256: verified against EXPECTED_OPUS_DLL_SHA256."
+          Write-Output "opus.dll SHA256 (informational, not used as publish gate): $actual"
           # Expose for any downstream step (e.g. release notes) that
-          # may want to surface the verified hash.
+          # may want to surface the captured hash.
           "OPUS_DLL_SHA256=$actual" | Out-File -Append -FilePath $env:GITHUB_ENV
 
       - name: Set up uv
@@ -309,17 +304,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    # `build-windows-wheel` is temporarily removed from `needs` for
-    # v0.9.0 (paired with the `if: false` on that job above): when a
-    # job is `if: false`-skipped, GitHub Actions skip-propagates to
-    # downstream jobs that list it in `needs` unless we explicitly
-    # override with `always()` plus a per-need result check. Removing
-    # it from `needs` is the simpler revert path for v0.9.1 — just
-    # re-add `build-windows-wheel` to this list and drop the `if`
-    # disables above. The `Download Windows wheel (win_amd64)` step
-    # below is also disabled, so this publish job ships only the
-    # Linux sdist + py3-none-any wheel for v0.9.0.
-    needs: [build]
+    needs: [build, build-windows-wheel]
     # Only publish on tag pushes. workflow_dispatch invocations stop at
     # the build job above, so manual runs cannot release. The
     # `startsWith(github.ref, 'refs/tags/v')` guard makes the intent
@@ -346,11 +331,7 @@ jobs:
           name: python-package-distributions-linux
           path: dist/
 
-      # Temporarily disabled for v0.9.0 — paired with the
-      # `build-windows-wheel` job disable above. Restore in v0.9.1
-      # once the opus.dll SHA drift root cause is fixed.
       - name: Download Windows wheel (win_amd64)
-        if: false
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions-windows

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,29 @@ jobs:
         working-directory: gateway
         run: uv lock --check
 
+      - name: Verify CHANGELOG.md has dated section for this tag
+        # Mirrors the firmware-release.yml CHANGELOG gate: refuse to
+        # publish a release tag that does not have a matching dated
+        # `## [X.Y.Z] - YYYY-MM-DD` section in CHANGELOG.md, so the
+        # promotion of `[Unreleased]` entries into a dated section is
+        # enforced rather than documented-only. The `changelog-check`
+        # gate in build.yml skips on `release:`-titled PRs (release
+        # promotion intentionally leaves [Unreleased] body unchanged
+        # between base and head); this tag-time gate is the
+        # authoritative floor for gateway releases, paired with the
+        # equivalent gate in firmware-release.yml.
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          # Tag form is `vX.Y.Z`; the CHANGELOG heading form is
+          # `## [X.Y.Z] - YYYY-MM-DD`.
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! grep -qE "^## \[${VERSION}\] - " CHANGELOG.md; then
+            echo "::error title=Missing CHANGELOG section for ${GITHUB_REF_NAME}::CHANGELOG.md does not contain a dated section for this tag. Expected heading like: ## [${VERSION}] - YYYY-MM-DD"
+            echo "Add the section to CHANGELOG.md (promote the [Unreleased] entries into a new dated section) before pushing the tag."
+            exit 1
+          fi
+          echo "CHANGELOG.md contains a dated section for ${GITHUB_REF_NAME}."
+
       - name: Install gateway dependencies
         working-directory: gateway
         run: uv sync --frozen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-08
+
+### Gateway
+
+- Restored: Windows `win_amd64` wheel build (bundled native
+  `libopus`) by retiring the byte-identical SHA256 guard against the
+  pinned `EXPECTED_OPUS_DLL_SHA256` (which had become non-matchable
+  under the `windows-latest` → `windows-2025-vs2026` runner-image
+  transition — MSVC under the new image embeds non-deterministic
+  build info, so the produced `opus.dll` differs across runs). The
+  publish gate is now the functional smoke test in the publish job
+  (load `opus.dll` via `opuslib` and run an Opus encode round-trip
+  on a real Windows runner). The `VCPKG_PIN` (the reviewed vcpkg
+  release tag) still locks the supply chain to a known port. Pairs
+  with reverting the v0.9.0 hotfix
+  ([PR #274](https://github.com/kisaragi-mochi/stackchan-mcp/pull/274))
+  that temporarily disabled the `build-windows-wheel` job and
+  removed it from the publish job's `needs`.
+
 ## [firmware-v1.9.0] - 2026-06-08
 
 ### Firmware
@@ -1522,7 +1541,8 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.8.0...v0.9.0
 [firmware-v1.9.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.8.0...firmware-v1.9.0
 [firmware-v1.8.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.7.0...firmware-v1.8.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2018,7 +2018,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Restore the `build-windows-wheel` job that v0.9.0's hotfix
([PR #274](https://github.com/kisaragi-mochi/stackchan-mcp/pull/274))
temporarily disabled, and retire the byte-identical SHA256 guard
that caused the v0.9.0 publish to fail. The publish gate is now
the functional smoke test that already lived in the publish job
(load `opus.dll` via `opuslib` and run an Opus encode round-trip on
a real Windows runner), which is what users actually hit at
install time.

This is the "next" half of the v0.9.0 + v0.9.1 split that
[PR #274](https://github.com/kisaragi-mochi/stackchan-mcp/pull/274)
committed to.

## What changed

### Windows wheel restore + structural fix

- `build-windows-wheel` job: `if: false` removed, job runs again on
  tag-push events.
- `Download Windows wheel (win_amd64)` step in the publish job:
  `if: false` removed.
- `publish` job `needs`: restored to `[build, build-windows-wheel]`.
- `EXPECTED_OPUS_DLL_SHA256` env removed. The byte-identical hash
  comparison is replaced by a presence check plus an informational
  SHA log in the build job; functional verification of the freshly
  produced `opus.dll` happens in the publish job's existing
  `Smoke test bundled opus loader` step.
- `VCPKG_PIN` is retained: the reviewed vcpkg release tag remains
  the supply-chain anchor for which Opus port and source tarball
  gets built.

### Wheel-internal Tag fix (was a latent issue from PR #217)

The `Build wheel (win_amd64)` step previously renamed the produced
wheel from `*-py3-none-any.whl` to `*-py3-none-win_amd64.whl` but
left the internal `.dist-info/WHEEL` `Tag:` line at `py3-none-any`.
This produced a wheel whose filename and internal metadata
disagreed — pip happily installed it but strict wheel-validating
tools would flag it. The step now uses `wheel tags --platform-tag
win_amd64 --remove` to rewrite both filename and internal metadata
in one go, plus two sanity checks (exactly one `*-win_amd64.whl`,
no leftover `*-py3-none-any.whl`) to fail loudly if the rewrite
silently breaks.

### CI gate adjustments

- `build.yml` `changelog-check`: skip on PRs whose title starts with
  `release:`. Release-promotion PRs move entries from `[Unreleased]`
  into a new dated section, so the `[Unreleased]` body is
  legitimately unchanged between base and head when the previous
  release already drained it. This gate's intent (catch forgotten
  CHANGELOG entries on feature PRs) is preserved for non-release
  PRs; release PRs are exempt by title prefix.
- `publish.yml` build job: a new `Verify CHANGELOG.md has dated
  section for this tag` step is inserted right after the uv.lock
  sync step, mirroring the strict regex used by
  `firmware-release.yml`. It anchors `^## \[<VERSION>\] - YYYY-MM-DD$`,
  escapes `.` in the version, and requires exactly one matching
  section. This restores the floor that the build-time skip
  removed, but at the tag-push boundary where it is authoritative
  for releases.

### Version bump and CHANGELOG promotion

- `gateway/pyproject.toml` 0.9.0 → 0.9.1
- `gateway/uv.lock` synced via `uv lock`
- `CHANGELOG.md` `[0.9.1] - 2026-06-08` section added, with the
  comparison-link footer updated.

## Background

The v0.9.0 publish failed at the `Verify opus.dll SHA256` step
because the `windows-latest` runner image (transitioning to
`windows-2025-vs2026` per GitHub's notice for 2026-06-15) produces
a non-deterministic `opus.dll` across builds — two consecutive
`workflow_dispatch` dry-runs during release prep observed two
different SHA256 values (`0f775c...` and `155229...`), so the
pinned `EXPECTED_OPUS_DLL_SHA256` could not match either run.
PR #274 shipped v0.9.0 without the `win_amd64` wheel as a
short-lived hotfix; this PR ships the structural fix as v0.9.1.

If deterministic builds are restored upstream (vcpkg + windows
runner image stabilization), the SHA pin can be reintroduced as an
additional reproducibility signal alongside the functional test,
not as the sole publish gate.

## Test plan

### Code-level

- [ ] gateway: `uv run pytest`
- [ ] gateway: `uv run ruff check .`
- [x] Not applicable / not run: workflow file changes + version bump
      + CHANGELOG promotion only; no Python or firmware sources
      touched.

Pre-PR validation:

- Pre-PR `codex review --base main` was run five times during
  preparation, addressing each finding:
  - Pass 1: P2 — `Build wheel (win_amd64)` step left the internal
    `.dist-info/WHEEL` `Tag:` line at `py3-none-any` after the
    filename rename. Fixed in `5679d36` with `wheel tags
    --platform-tag win_amd64 --remove`.
  - Pass 2: P1 — `build.yml` `changelog-check` rejects
    release-promotion PRs because `[Unreleased]` body is unchanged
    between base and head. Fixed in `e837ace` by skipping the
    check on `release:`-titled PRs.
  - Pass 3: P2 — skipping the build-time check removed the only
    CHANGELOG gate for gateway releases. Fixed in `a1e2364` by
    adding a tag-push-time gate in `publish.yml`.
  - Pass 4: P2 — the new tag-time gate used a naive grep that
    would falsely match malformed headings (e.g. `## [0.9.1] -
    TODO` or `## [0x9x1] - ...`). Fixed in `ca3fd9f` by anchoring
    the regex to `YYYY-MM-DD$`, escaping `.` in the version, and
    requiring exactly one matching section.
  - Pass 5: clean, no findings.

### Hardware

- [x] Not applicable / hardware not available: workflow + version
      changes only.

## Breaking changes

None for users. Internal CI behavior changes:

- `EXPECTED_OPUS_DLL_SHA256` env is removed from `publish.yml` —
  no longer maintained.
- `build.yml` `changelog-check` skips on `release:`-titled PRs.
- `publish.yml` build job adds a tag-push-time CHANGELOG section
  check, paired with the equivalent gate in
  `firmware-release.yml`.

## Related

- [PR #274](https://github.com/kisaragi-mochi/stackchan-mcp/pull/274)
  — the v0.9.0 hotfix this PR completes the follow-up for.
- v0.8.0 → v0.9.0 release path
  ([PR #273](https://github.com/kisaragi-mochi/stackchan-mcp/pull/273))
  — the pair release whose Windows-wheel side this PR restores.

## After merge

1. Tag `v0.9.1` on the merge commit and push to trigger
   `publish.yml` — both Linux and Windows wheels build, the
   functional smoke test gates the publish, and Trusted Publishing
   uploads sdist + `py3-none-any` wheel + `win_amd64` wheel to PyPI.
2. Create the v0.9.1 GitHub Release page with notes pointing back
   at this PR and the v0.9.0 release.
3. Edit the v0.9.0 GitHub Release page's "Windows-only wheel
   temporarily skipped" section to link forward to v0.9.1.
