### PR TITLE
feat(examples): add Cloudflare Workers WebSocket relay example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ documented-only.
 
 ## [Unreleased]
 
+### Examples
+
+- Added `examples/cloudflare-relay/` — optional Cloudflare Workers
+  relay example for reaching the gateway from outside the local LAN.
+  Includes a WebSocket proxy Worker with constant-time Bearer token
+  authentication, deployment instructions, and a shared-secret
+  rotation guide. The Worker uses only generally-available Cloudflare
+  primitives (Workers WS API, Cloudflare Tunnel public hostnames).
+
 ## [0.9.1] - 2026-06-08
 
 ### Gateway

--- a/README.ja.md
+++ b/README.ja.md
@@ -26,6 +26,7 @@
 | `firmware/` | [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) フォーク全体（git subtree）。StackChan 用カスタムボードは `firmware/main/boards/stackchan/` に配置 |
 | `gateway/` | Python MCP ゲートウェイ。stdio MCP サーバー (LLM側) + WebSocket MCP クライアント (ESP32側) + HTTP capture サーバー |
 | `docs/` | [`architecture.md`](docs/architecture.md): 全体構成図・ツール名マッピング・写真フロー・認証・Phase ロードマップ。[`firmware-sync.md`](docs/firmware-sync.md): upstream xiaozhi-esp32 同期手順。[`remote-access.md`](docs/remote-access.md): Tailscale Funnel による非LAN接続手順 |
+| `examples/` | オプションの非保守 example 群。[`cloudflare-relay/`](examples/cloudflare-relay/): LAN 外から gateway へ届くための Cloudflare Workers WebSocket リレー |
 
 ## 想定ハードウェア
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository is a monorepo.
 | `firmware/` | Full git subtree of [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32). The custom StackChan board lives at `firmware/main/boards/stackchan/`. |
 | `gateway/` | Python MCP gateway. stdio MCP server (LLM side) + WebSocket MCP client (ESP32 side) + HTTP capture server. |
 | `docs/` | [`architecture.md`](docs/architecture.md): full component diagram, tool name mapping, photo flow, auth, phase roadmap. [`firmware-sync.md`](docs/firmware-sync.md): upstream xiaozhi-esp32 sync playbook. [`remote-access.md`](docs/remote-access.md): Tailscale Funnel setup for non-LAN use. |
+| `examples/` | Optional, unmaintained examples. [`cloudflare-relay/`](examples/cloudflare-relay/): Cloudflare Workers WebSocket relay for reaching the gateway from outside the local LAN. |
 
 ## Target hardware
 

--- a/examples/cloudflare-relay/.gitignore
+++ b/examples/cloudflare-relay/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.wrangler/
+.dev.vars

--- a/examples/cloudflare-relay/README.md
+++ b/examples/cloudflare-relay/README.md
@@ -1,0 +1,77 @@
+# Cloudflare Workers Relay (optional example)
+
+This directory contains a self-contained example for relaying WebSocket
+connections from a Stack-chan device to a self-hosted `stackchan-mcp`
+gateway through Cloudflare Workers, enabling the device to reach the
+gateway from outside the local LAN.
+
+This example is provided as-is and is not part of the maintained
+`stackchan-mcp` dependency surface. It is intended as a reference for
+operators who want to make their gateway reachable over the public
+internet via Cloudflare, while keeping the gateway machine itself
+behind NAT.
+
+## Overview
+
+    Stack-chan (ESP32 firmware)
+      └── WSS (Authorization: Bearer <shared-secret>)
+            │
+            ▼
+      Cloudflare Workers (this example)
+       ─ verifies Bearer token (constant-time compare)
+       ─ proxies the WebSocket bidirectionally
+            │
+            ▼ fetch (WS upgrade)
+      Cloudflare Tunnel hostname (cloudflared on the gateway host)
+            │
+            ▼
+      stackchan-mcp gateway (ws://localhost:8765)
+
+The Stack-chan firmware tries mDNS auto-discovery first (LAN case), and
+falls back to the configured `websocket.fallback_url` (this Worker's
+URL) when mDNS does not resolve. No firmware changes are required.
+
+## When to use this
+
+Use this example if all of the following apply:
+
+- You want a Stack-chan device to reach the gateway when it is not on
+  the same LAN as the gateway machine.
+- The gateway machine is reachable 24/7 and can run `cloudflared` as a
+  background service.
+- You are comfortable maintaining a personal Cloudflare account and a
+  Workers Paid plan (around 5 USD per month).
+
+If you only operate Stack-chan on a single LAN, this example is not
+needed — the default mDNS auto-discovery flow handles that case
+without any external dependency.
+
+## Components
+
+| File                             | Purpose                                          |
+| -------------------------------- | ------------------------------------------------ |
+| `src/index.ts`                   | The Worker: Bearer auth + bidirectional WS proxy |
+| `wrangler.toml`                  | Cloudflare Workers deployment configuration      |
+| `package.json` / `tsconfig.json` | TypeScript build setup                           |
+| `docs/setup.md`                  | Step-by-step setup (Tunnel, deploy, NVS config)  |
+| `docs/secret-rotation.md`        | How to rotate the shared Bearer secret           |
+
+## Trade-offs
+
+- First outbound connection takes about 15 seconds because the
+  firmware first attempts mDNS (5s timeout) and then falls back to the
+  Cloudflare endpoint (10s server-hello window). Subsequent reconnects
+  use exponential backoff.
+- Traffic is proxied through Cloudflare edge, adding small latency on
+  top of the direct Tunnel-to-gateway hop.
+- This example uses a single shared Bearer token for authentication.
+  Treat it as you would any production secret; see
+  `docs/secret-rotation.md` for rotation guidance.
+- This example deliberately avoids beta Cloudflare features (e.g.,
+  Workers VPC bindings). It uses only generally-available primitives
+  (Workers WS API, Cloudflare Tunnel public hostnames).
+
+## License
+
+MIT — same as the rest of this repository. See the top-level `LICENSE`
+file.

--- a/examples/cloudflare-relay/README.md
+++ b/examples/cloudflare-relay/README.md
@@ -18,17 +18,18 @@ behind NAT.
             │
             ▼
       Cloudflare Workers (this example)
-       ─ verifies device Bearer token (constant-time compare)
+       ─ verifies Bearer token (constant-time compare)
        ─ proxies the WebSocket bidirectionally
-       ─ attaches its own Authorization: Bearer <UPSTREAM_TOKEN>
-         when set (otherwise the upstream is unauthenticated)
+       ─ forwards the same Authorization header upstream
             │
             ▼ fetch (WS upgrade, https://)
       Cloudflare Tunnel hostname (cloudflared on the gateway host)
             │
             ▼
       stackchan-mcp gateway (ws://localhost:8765,
-        started with --token <UPSTREAM_TOKEN> for defence-in-depth)
+        started with STACKCHAN_TOKEN=<SHARED_SECRET> so it
+        authenticates both mDNS-direct and relayed connections
+        with the same Bearer)
 
 The Stack-chan firmware tries mDNS auto-discovery first (LAN case), and
 falls back to the configured `websocket.fallback_url` (this Worker's
@@ -67,14 +68,15 @@ without any external dependency.
   use exponential backoff.
 - Traffic is proxied through Cloudflare edge, adding small latency on
   top of the direct Tunnel-to-gateway hop.
-- This example uses two layered Bearer tokens for authentication:
-  `SHARED_SECRET` between the device and the Worker, and an optional
-  `UPSTREAM_TOKEN` between the Worker and the gateway (active when
-  the gateway is started with `--token <upstream-secret>`). Without
-  `UPSTREAM_TOKEN`, the tunnel hostname is effectively
-  unauthenticated; with it, both boundaries require a valid Bearer.
-  Treat both as you would any production secret; see
-  `docs/secret-rotation.md` for rotation guidance.
+- This example uses a single shared Bearer token (`SHARED_SECRET`)
+  end-to-end. The firmware sends it on every WebSocket connection
+  (both mDNS-direct on-LAN and Worker-relayed off-LAN); the Worker
+  verifies it and forwards the same `Authorization` header upstream;
+  the gateway re-verifies it when started with
+  `STACKCHAN_TOKEN=<SHARED_SECRET>`. A single shared secret matches
+  the firmware's behaviour of sending the same NVS `websocket.token`
+  on every candidate. Treat it as you would any production secret;
+  see `docs/secret-rotation.md` for rotation guidance.
 - This example deliberately avoids beta Cloudflare features (e.g.,
   Workers VPC bindings). It uses only generally-available primitives
   (Workers WS API, Cloudflare Tunnel public hostnames).

--- a/examples/cloudflare-relay/README.md
+++ b/examples/cloudflare-relay/README.md
@@ -14,18 +14,21 @@ behind NAT.
 ## Overview
 
     Stack-chan (ESP32 firmware)
-      └── WSS (Authorization: Bearer <shared-secret>)
+      └── WSS (Authorization: Bearer <SHARED_SECRET>)
             │
             ▼
       Cloudflare Workers (this example)
-       ─ verifies Bearer token (constant-time compare)
+       ─ verifies device Bearer token (constant-time compare)
        ─ proxies the WebSocket bidirectionally
+       ─ attaches its own Authorization: Bearer <UPSTREAM_TOKEN>
+         when set (otherwise the upstream is unauthenticated)
             │
-            ▼ fetch (WS upgrade)
+            ▼ fetch (WS upgrade, https://)
       Cloudflare Tunnel hostname (cloudflared on the gateway host)
             │
             ▼
-      stackchan-mcp gateway (ws://localhost:8765)
+      stackchan-mcp gateway (ws://localhost:8765,
+        started with --token <UPSTREAM_TOKEN> for defence-in-depth)
 
 The Stack-chan firmware tries mDNS auto-discovery first (LAN case), and
 falls back to the configured `websocket.fallback_url` (this Worker's
@@ -64,8 +67,13 @@ without any external dependency.
   use exponential backoff.
 - Traffic is proxied through Cloudflare edge, adding small latency on
   top of the direct Tunnel-to-gateway hop.
-- This example uses a single shared Bearer token for authentication.
-  Treat it as you would any production secret; see
+- This example uses two layered Bearer tokens for authentication:
+  `SHARED_SECRET` between the device and the Worker, and an optional
+  `UPSTREAM_TOKEN` between the Worker and the gateway (active when
+  the gateway is started with `--token <upstream-secret>`). Without
+  `UPSTREAM_TOKEN`, the tunnel hostname is effectively
+  unauthenticated; with it, both boundaries require a valid Bearer.
+  Treat both as you would any production secret; see
   `docs/secret-rotation.md` for rotation guidance.
 - This example deliberately avoids beta Cloudflare features (e.g.,
   Workers VPC bindings). It uses only generally-available primitives

--- a/examples/cloudflare-relay/docs/secret-rotation.md
+++ b/examples/cloudflare-relay/docs/secret-rotation.md
@@ -1,20 +1,23 @@
-# Rotating the Shared Bearer Secret
+# Rotating the Shared Bearer Secrets
 
-The Bearer token shared between the Worker and the Stack-chan device
-should be rotated if it is suspected to be leaked, or periodically as
-part of routine credential hygiene. This document describes the
-manual rotation procedure.
+The relay uses two separate Bearer tokens — `SHARED_SECRET` for the
+device-to-Worker boundary and `UPSTREAM_TOKEN` for the Worker-to-gateway
+boundary — and each should be rotated if it is suspected to be leaked,
+or periodically as part of routine credential hygiene. This document
+describes the manual rotation procedure.
 
-## Procedure
+Rotate the two secrets independently. The procedure below applies to
+each one separately; complete it for `SHARED_SECRET` first, then for
+`UPSTREAM_TOKEN` (or only the one you need to rotate).
+
+## Rotating `SHARED_SECRET` (device <-> Worker)
 
 ### 1. Generate a new secret
 
-On your deployment workstation:
-
     openssl rand -hex 32
 
-Keep the output handy — you will set it in both the Worker and the
-device's NVS in the next steps.
+Keep the output handy — you will set it on the Worker and on the
+device in the next steps.
 
 ### 2. Update the Worker
 
@@ -23,30 +26,56 @@ From `examples/cloudflare-relay/`:
     npx wrangler secret put SHARED_SECRET
     # paste the new secret when prompted
 
-This overwrites the existing secret. The Worker will reject the device
-on its next connection attempt because the device is still presenting
-the old token.
+This overwrites the existing secret. The Worker will reject the
+device on its next connection attempt because the device is still
+presenting the old token.
 
 ### 3. Update the Stack-chan device
 
 Boot the device into WiFi configuration mode and update
 `websocket.token` in the web UI to the new secret. Save and reboot.
 
-### 4. Verify reconnection
+### 4. Verify
 
 Take the device off-LAN and confirm it reconnects via the Worker.
 Check the Worker logs (`npx wrangler tail`) for a successful Bearer
 verification.
 
-If the device cannot reconnect, double-check that the device's
-`websocket.token` matches the value you pasted into
-`wrangler secret put`.
+## Rotating `UPSTREAM_TOKEN` (Worker <-> gateway)
+
+If you are running the gateway without `--token`, you do not have
+this secret to rotate; you can skip this section.
+
+### 1. Generate a new secret
+
+    openssl rand -hex 32
+
+### 2. Update the Worker
+
+From `examples/cloudflare-relay/`:
+
+    npx wrangler secret put UPSTREAM_TOKEN
+    # paste the new secret when prompted
+
+### 3. Update the gateway
+
+Restart the gateway with the new `--token <new-value>`. There is
+typically a brief window where the Worker presents the new token but
+the old gateway process is still running; minimize this by restarting
+the gateway immediately after Step 2.
+
+### 4. Verify
+
+Take the device off-LAN and confirm the relay path still works (the
+device-side connection is unaffected by `UPSTREAM_TOKEN` rotation;
+all the work happens between the Worker and the gateway).
 
 ## Notes
 
-- This procedure causes a brief window (between Step 2 and Step 3)
-  where the device cannot reach the Worker. On-LAN traffic is
-  unaffected because it uses mDNS directly.
+- Each rotation causes a brief window (between Worker secret update
+  and the corresponding device or gateway update) where that side of
+  the relay cannot reach the other. On-LAN traffic is unaffected
+  because it uses mDNS directly between the device and the gateway.
 - There is no automatic rotation mechanism in this example. For
   production use, consider implementing token rotation through a
   Workers KV / Durable Objects-backed scheme.

--- a/examples/cloudflare-relay/docs/secret-rotation.md
+++ b/examples/cloudflare-relay/docs/secret-rotation.md
@@ -1,23 +1,27 @@
-# Rotating the Shared Bearer Secrets
+# Rotating the Shared Bearer Secret
 
-The relay uses two separate Bearer tokens — `SHARED_SECRET` for the
-device-to-Worker boundary and `UPSTREAM_TOKEN` for the Worker-to-gateway
-boundary — and each should be rotated if it is suspected to be leaked,
-or periodically as part of routine credential hygiene. This document
-describes the manual rotation procedure.
+The relay uses a single shared Bearer token (`SHARED_SECRET`)
+end-to-end. The Stack-chan device sends it in the `Authorization`
+header on every connection, the Worker verifies it, and the gateway
+re-verifies the forwarded header (when started with
+`STACKCHAN_TOKEN=<SHARED_SECRET>`). The secret should be rotated if
+it is suspected to be leaked, or periodically as part of routine
+credential hygiene.
 
-Rotate the two secrets independently. The procedure below applies to
-each one separately; complete it for `SHARED_SECRET` first, then for
-`UPSTREAM_TOKEN` (or only the one you need to rotate).
+Rotating it requires updating the value in three places: the
+Worker's `SHARED_SECRET` secret, the device's `websocket.token` NVS
+field, and the gateway's `STACKCHAN_TOKEN` environment variable. The
+order below minimizes the window where any one of them is out of
+sync.
 
-## Rotating `SHARED_SECRET` (device <-> Worker)
+## Procedure
 
 ### 1. Generate a new secret
 
     openssl rand -hex 32
 
-Keep the output handy — you will set it on the Worker and on the
-device in the next steps.
+Keep the output handy — you will set it on the Worker, the device,
+and the gateway in the next steps.
 
 ### 2. Update the Worker
 
@@ -26,56 +30,43 @@ From `examples/cloudflare-relay/`:
     npx wrangler secret put SHARED_SECRET
     # paste the new secret when prompted
 
-This overwrites the existing secret. The Worker will reject the
-device on its next connection attempt because the device is still
-presenting the old token.
+The Worker now expects the new value. The device still presents the
+old one, so off-LAN connections will start receiving 401s from the
+Worker until Step 3 lands.
 
 ### 3. Update the Stack-chan device
 
 Boot the device into WiFi configuration mode and update
 `websocket.token` in the web UI to the new secret. Save and reboot.
 
-### 4. Verify
+The device now presents the new value. The gateway still expects the
+old one via `STACKCHAN_TOKEN`, so LAN-direct connections and the
+gateway side of relayed connections will see 401 until Step 4 lands.
 
-Take the device off-LAN and confirm it reconnects via the Worker.
-Check the Worker logs (`npx wrangler tail`) for a successful Bearer
-verification.
+### 4. Update the gateway
 
-## Rotating `UPSTREAM_TOKEN` (Worker <-> gateway)
+Restart the gateway process with the new value in
+`STACKCHAN_TOKEN`:
 
-If you are running the gateway without `--token`, you do not have
-this secret to rotate; you can skip this section.
+    STACKCHAN_TOKEN=<new value> uv run stackchan-mcp
 
-### 1. Generate a new secret
+The gateway now accepts the new token from both LAN-direct and
+relayed connections.
 
-    openssl rand -hex 32
+### 5. Verify
 
-### 2. Update the Worker
-
-From `examples/cloudflare-relay/`:
-
-    npx wrangler secret put UPSTREAM_TOKEN
-    # paste the new secret when prompted
-
-### 3. Update the gateway
-
-Restart the gateway with the new `--token <new-value>`. There is
-typically a brief window where the Worker presents the new token but
-the old gateway process is still running; minimize this by restarting
-the gateway immediately after Step 2.
-
-### 4. Verify
-
-Take the device off-LAN and confirm the relay path still works (the
-device-side connection is unaffected by `UPSTREAM_TOKEN` rotation;
-all the work happens between the Worker and the gateway).
+Confirm that on-LAN (mDNS-direct) and off-LAN (Worker-relayed)
+connections both succeed under the new secret. Check the Worker logs
+(`npx wrangler tail`) for a successful Bearer verification on the
+off-LAN path, and the gateway logs for a successful authentication on
+the on-LAN path.
 
 ## Notes
 
-- Each rotation causes a brief window (between Worker secret update
-  and the corresponding device or gateway update) where that side of
-  the relay cannot reach the other. On-LAN traffic is unaffected
-  because it uses mDNS directly between the device and the gateway.
+- The rotation causes a brief window (between Step 2 and Step 4)
+  where the device is out of sync with one or both of the Worker /
+  gateway. Plan the rotation when a short disconnect is acceptable,
+  or co-ordinate Step 3 and Step 4 closely.
 - There is no automatic rotation mechanism in this example. For
   production use, consider implementing token rotation through a
   Workers KV / Durable Objects-backed scheme.

--- a/examples/cloudflare-relay/docs/secret-rotation.md
+++ b/examples/cloudflare-relay/docs/secret-rotation.md
@@ -1,0 +1,52 @@
+# Rotating the Shared Bearer Secret
+
+The Bearer token shared between the Worker and the Stack-chan device
+should be rotated if it is suspected to be leaked, or periodically as
+part of routine credential hygiene. This document describes the
+manual rotation procedure.
+
+## Procedure
+
+### 1. Generate a new secret
+
+On your deployment workstation:
+
+    openssl rand -hex 32
+
+Keep the output handy — you will set it in both the Worker and the
+device's NVS in the next steps.
+
+### 2. Update the Worker
+
+From `examples/cloudflare-relay/`:
+
+    npx wrangler secret put SHARED_SECRET
+    # paste the new secret when prompted
+
+This overwrites the existing secret. The Worker will reject the device
+on its next connection attempt because the device is still presenting
+the old token.
+
+### 3. Update the Stack-chan device
+
+Boot the device into WiFi configuration mode and update
+`websocket.token` in the web UI to the new secret. Save and reboot.
+
+### 4. Verify reconnection
+
+Take the device off-LAN and confirm it reconnects via the Worker.
+Check the Worker logs (`npx wrangler tail`) for a successful Bearer
+verification.
+
+If the device cannot reconnect, double-check that the device's
+`websocket.token` matches the value you pasted into
+`wrangler secret put`.
+
+## Notes
+
+- This procedure causes a brief window (between Step 2 and Step 3)
+  where the device cannot reach the Worker. On-LAN traffic is
+  unaffected because it uses mDNS directly.
+- There is no automatic rotation mechanism in this example. For
+  production use, consider implementing token rotation through a
+  Workers KV / Durable Objects-backed scheme.

--- a/examples/cloudflare-relay/docs/setup.md
+++ b/examples/cloudflare-relay/docs/setup.md
@@ -8,6 +8,11 @@ relay.
 ## Prerequisites
 
 - A Cloudflare account.
+- A domain registered with Cloudflare (so you can add DNS records).
+  This example currently requires a custom domain because named
+  tunnels do not auto-publish hostnames under `*.cfargotunnel.com`,
+  and setting up a custom hostname via `cloudflared tunnel route dns`
+  requires control of the DNS zone.
 - Node.js (>= 18) and npm installed on your workstation.
 - A machine that hosts the `stackchan-mcp` gateway and is reachable
   24/7 (this guide assumes macOS; Linux / Windows users should adapt
@@ -38,7 +43,8 @@ ingress config below.
 ## Step 2: Configure Tunnel ingress
 
 Create `~/.cloudflared/config.yml` with the following content,
-substituting the tunnel UUID and your chosen hostname:
+substituting the tunnel UUID and your chosen hostname (must be under
+a Cloudflare-managed domain you own):
 
     tunnel: <tunnel-uuid>
     credentials-file: /Users/<you>/.cloudflared/<tunnel-uuid>.json
@@ -47,10 +53,6 @@ substituting the tunnel UUID and your chosen hostname:
       - hostname: stackchan-relay-backend.<your-domain>
         service: ws://localhost:8765
       - service: http_status:404
-
-If you do not own a domain on Cloudflare, you can use the
-`<tunnel-name>.cfargotunnel.com` hostname that the tunnel exposes by
-default; replace the `hostname:` value accordingly.
 
 Then route the chosen hostname to the tunnel:
 
@@ -67,14 +69,25 @@ Verify it is running:
 
     cloudflared tunnel info stackchan-relay-backend
 
-## Step 4: Generate a shared secret
+## Step 4: Generate the shared secrets
+
+This example uses two separate Bearer tokens — one for the
+device-to-Worker boundary, one for the Worker-to-gateway boundary —
+so each segment can be rotated independently.
 
 On your deployment workstation:
 
-    openssl rand -hex 32
+    openssl rand -hex 32   # SHARED_SECRET (device <-> Worker)
+    openssl rand -hex 32   # UPSTREAM_TOKEN (Worker <-> gateway)
 
-Save the output — you will set it on the Worker and on the Stack-chan
-device.
+Save both outputs. You will set them on the Worker, on the
+Stack-chan device, and on the gateway in the next steps.
+
+If you intend to run the gateway without authentication (i.e., not
+passing `--token` to the gateway), you can skip generating
+`UPSTREAM_TOKEN`. Be aware that the tunnel hostname then becomes an
+unauthenticated endpoint — anyone who learns the hostname can reach
+the gateway directly without going through the Worker.
 
 ## Step 5: Deploy the Worker
 
@@ -83,15 +96,22 @@ From `examples/cloudflare-relay/`:
     npx wrangler login
 
 Edit `wrangler.toml` and set `UPSTREAM_URL` to the tunnel hostname
-configured in Step 2, prefixed with `wss://`. For example:
+configured in Step 2, prefixed with `https://` (not `wss://` — the
+Worker performs the WebSocket upgrade by issuing `fetch()` with
+`Upgrade: websocket`, which requires an http/https URL). For example:
 
     [vars]
-    UPSTREAM_URL = "wss://stackchan-relay-backend.<your-domain>"
+    UPSTREAM_URL = "https://stackchan-relay-backend.<your-domain>"
 
-Register the shared secret (do not commit it):
+Register the device-to-Worker shared secret (do not commit it):
 
     npx wrangler secret put SHARED_SECRET
-    # paste the secret from Step 4 when prompted
+    # paste the SHARED_SECRET value from Step 4 when prompted
+
+If you generated `UPSTREAM_TOKEN` in Step 4, register it too:
+
+    npx wrangler secret put UPSTREAM_TOKEN
+    # paste the UPSTREAM_TOKEN value from Step 4 when prompted
 
 Deploy:
 
@@ -100,9 +120,20 @@ Deploy:
 Wrangler will print the Worker URL (for example,
 `https://stackchan-relay.<your-subdomain>.workers.dev`). Convert this
 to a `wss://` URL — that becomes the value you set on the Stack-chan
-device in Step 6.
+device in Step 7.
 
-## Step 6: Configure the Stack-chan device
+## Step 6: Configure the gateway
+
+If you want the gateway to require an upstream Bearer token (matching
+the `UPSTREAM_TOKEN` registered with the Worker), start the gateway
+with `--token`. For example:
+
+    uv run stackchan-mcp --token <UPSTREAM_TOKEN value>
+
+If you skip this and start the gateway without `--token`, the tunnel
+hostname becomes an unauthenticated endpoint (see Step 4 trade-off).
+
+## Step 7: Configure the Stack-chan device
 
 Boot the device into its WiFi configuration access point (refer to the
 main `stackchan-mcp` README for how to enter config mode). In the web
@@ -111,7 +142,7 @@ UI, set:
 - `websocket.url` → leave empty (the firmware uses mDNS auto-discovery
   for the LAN case).
 - `websocket.fallback_url` → the Worker URL from Step 5, as `wss://`.
-- `websocket.token` → the shared secret from Step 4.
+- `websocket.token` → the `SHARED_SECRET` value from Step 4.
 
 Save and reboot the device. The firmware will:
 
@@ -120,7 +151,7 @@ Save and reboot the device. The firmware will:
 3. Send the Bearer token in the `Authorization` header for the Worker
    to verify.
 
-## Step 7: Verify
+## Step 8: Verify
 
 With the device on the same LAN as the gateway, it should connect
 directly via mDNS (no relay traffic). Confirm by checking the gateway
@@ -137,10 +168,16 @@ the Bearer token verified.
 - `unauthorized` (HTTP 401) from the Worker: the Bearer token on the
   device does not match the Worker's `SHARED_SECRET`. Re-check both,
   and rotate the secret if leaked (see `secret-rotation.md`).
-- `upstream unreachable` (HTTP 502) from the Worker: `cloudflared` is
-  not connected, the tunnel ingress is misconfigured, or the gateway
-  is not running on `localhost:8765`. Check `cloudflared tunnel info`
-  on the gateway host.
+- `upstream unreachable` (HTTP 502) from the Worker: usually one of:
+  - `cloudflared` is not connected on the gateway host (check
+    `cloudflared tunnel info` there).
+  - The tunnel ingress is misconfigured.
+  - The gateway is not running on `localhost:8765`.
+  - The gateway is started with `--token <upstream-secret>` but the
+    Worker does not have `UPSTREAM_TOKEN` set (the gateway returns
+    401 and the Worker surfaces 502). Register `UPSTREAM_TOKEN` via
+    `wrangler secret put` (see Step 5) so it matches the gateway's
+    `--token` value.
 - The device never falls back to the Worker URL on-LAN: this is
   expected. mDNS auto-discovery wins on-LAN; the Worker URL is only
   used when mDNS fails to resolve a candidate.

--- a/examples/cloudflare-relay/docs/setup.md
+++ b/examples/cloudflare-relay/docs/setup.md
@@ -69,25 +69,21 @@ Verify it is running:
 
     cloudflared tunnel info stackchan-relay-backend
 
-## Step 4: Generate the shared secrets
+## Step 4: Generate the shared secret
 
-This example uses two separate Bearer tokens — one for the
-device-to-Worker boundary, one for the Worker-to-gateway boundary —
-so each segment can be rotated independently.
+This example uses a single shared Bearer token end-to-end. The
+firmware sends it on every connection (on-LAN mDNS-direct and
+off-LAN relayed); the Worker verifies it and forwards the same header
+to the gateway; the gateway (when started with `STACKCHAN_TOKEN`)
+re-verifies it. Using a single token keeps both the LAN and relay
+paths working with the same NVS configuration on the device.
 
 On your deployment workstation:
 
-    openssl rand -hex 32   # SHARED_SECRET (device <-> Worker)
-    openssl rand -hex 32   # UPSTREAM_TOKEN (Worker <-> gateway)
+    openssl rand -hex 32
 
-Save both outputs. You will set them on the Worker, on the
-Stack-chan device, and on the gateway in the next steps.
-
-If you intend to run the gateway without authentication (i.e., not
-passing `--token` to the gateway), you can skip generating
-`UPSTREAM_TOKEN`. Be aware that the tunnel hostname then becomes an
-unauthenticated endpoint — anyone who learns the hostname can reach
-the gateway directly without going through the Worker.
+Save the output. You will set it on the Worker, on the Stack-chan
+device, and on the gateway.
 
 ## Step 5: Deploy the Worker
 
@@ -103,15 +99,10 @@ Worker performs the WebSocket upgrade by issuing `fetch()` with
     [vars]
     UPSTREAM_URL = "https://stackchan-relay-backend.<your-domain>"
 
-Register the device-to-Worker shared secret (do not commit it):
+Register the shared secret (do not commit it):
 
     npx wrangler secret put SHARED_SECRET
-    # paste the SHARED_SECRET value from Step 4 when prompted
-
-If you generated `UPSTREAM_TOKEN` in Step 4, register it too:
-
-    npx wrangler secret put UPSTREAM_TOKEN
-    # paste the UPSTREAM_TOKEN value from Step 4 when prompted
+    # paste the secret from Step 4 when prompted
 
 Deploy:
 
@@ -124,14 +115,17 @@ device in Step 7.
 
 ## Step 6: Configure the gateway
 
-If you want the gateway to require an upstream Bearer token (matching
-the `UPSTREAM_TOKEN` registered with the Worker), start the gateway
-with `--token`. For example:
+Restart the gateway with the shared secret in the `STACKCHAN_TOKEN`
+environment variable. The gateway authenticates incoming WebSocket
+connections (both LAN-direct from the device and relayed from the
+Worker) against this value:
 
-    uv run stackchan-mcp --token <UPSTREAM_TOKEN value>
+    STACKCHAN_TOKEN=<shared-secret value> uv run stackchan-mcp
 
-If you skip this and start the gateway without `--token`, the tunnel
-hostname becomes an unauthenticated endpoint (see Step 4 trade-off).
+If you skip setting `STACKCHAN_TOKEN`, the gateway accepts connections
+without authentication. The tunnel hostname then becomes an
+unauthenticated endpoint — anyone who learns the hostname can reach
+the gateway without going through the Worker.
 
 ## Step 7: Configure the Stack-chan device
 
@@ -142,14 +136,15 @@ UI, set:
 - `websocket.url` → leave empty (the firmware uses mDNS auto-discovery
   for the LAN case).
 - `websocket.fallback_url` → the Worker URL from Step 5, as `wss://`.
-- `websocket.token` → the `SHARED_SECRET` value from Step 4.
+- `websocket.token` → the shared secret from Step 4.
 
 Save and reboot the device. The firmware will:
 
 1. Attempt mDNS discovery first (LAN case, about 5s timeout).
 2. If mDNS yields no candidates, fall back to the Worker URL.
-3. Send the Bearer token in the `Authorization` header for the Worker
-   to verify.
+3. Send the Bearer token in the `Authorization` header on every
+   candidate (so the gateway authenticates both LAN-direct and
+   relayed connections with the same value).
 
 ## Step 8: Verify
 
@@ -168,16 +163,18 @@ the Bearer token verified.
 - `unauthorized` (HTTP 401) from the Worker: the Bearer token on the
   device does not match the Worker's `SHARED_SECRET`. Re-check both,
   and rotate the secret if leaked (see `secret-rotation.md`).
+- `relay misconfigured: SHARED_SECRET unset` (HTTP 500) from the
+  Worker: the `SHARED_SECRET` Wrangler secret is not registered.
+  Run `npx wrangler secret put SHARED_SECRET` (see Step 5).
 - `upstream unreachable` (HTTP 502) from the Worker: usually one of:
   - `cloudflared` is not connected on the gateway host (check
     `cloudflared tunnel info` there).
   - The tunnel ingress is misconfigured.
   - The gateway is not running on `localhost:8765`.
-  - The gateway is started with `--token <upstream-secret>` but the
-    Worker does not have `UPSTREAM_TOKEN` set (the gateway returns
-    401 and the Worker surfaces 502). Register `UPSTREAM_TOKEN` via
-    `wrangler secret put` (see Step 5) so it matches the gateway's
-    `--token` value.
+  - The gateway is started with `STACKCHAN_TOKEN=<value>` but the
+    Worker has a different `SHARED_SECRET`. The gateway then
+    returns 401 and the Worker surfaces 502. Make sure the two
+    values are identical.
 - The device never falls back to the Worker URL on-LAN: this is
   expected. mDNS auto-discovery wins on-LAN; the Worker URL is only
   used when mDNS fails to resolve a candidate.

--- a/examples/cloudflare-relay/docs/setup.md
+++ b/examples/cloudflare-relay/docs/setup.md
@@ -51,7 +51,7 @@ a Cloudflare-managed domain you own):
 
     ingress:
       - hostname: stackchan-relay-backend.<your-domain>
-        service: ws://localhost:8765
+        service: http://localhost:8765
       - service: http_status:404
 
 Then route the chosen hostname to the tunnel:

--- a/examples/cloudflare-relay/docs/setup.md
+++ b/examples/cloudflare-relay/docs/setup.md
@@ -1,0 +1,146 @@
+# Setup Guide
+
+This document walks through deploying the Cloudflare Workers relay
+example end-to-end: setting up a Cloudflare Tunnel on the gateway host,
+deploying the Worker, and pointing the Stack-chan firmware at the
+relay.
+
+## Prerequisites
+
+- A Cloudflare account.
+- Node.js (>= 18) and npm installed on your workstation.
+- A machine that hosts the `stackchan-mcp` gateway and is reachable
+  24/7 (this guide assumes macOS; Linux / Windows users should adapt
+  the install steps for `cloudflared`).
+- The `stackchan-mcp` gateway already running and listening on
+  `ws://localhost:8765` on the gateway host.
+
+Install the per-host tools:
+
+    # On the gateway host (where stackchan-mcp gateway runs)
+    brew install cloudflared
+
+    # On your deployment workstation (can be the same machine)
+    cd examples/cloudflare-relay
+    npm install
+
+## Step 1: Create the Cloudflare Tunnel
+
+On the gateway host, log in to Cloudflare and create a tunnel:
+
+    cloudflared tunnel login
+    cloudflared tunnel create stackchan-relay-backend
+
+The `create` command prints a UUID and writes a credentials file under
+`~/.cloudflared/`. Note both — you will reference the UUID in the
+ingress config below.
+
+## Step 2: Configure Tunnel ingress
+
+Create `~/.cloudflared/config.yml` with the following content,
+substituting the tunnel UUID and your chosen hostname:
+
+    tunnel: <tunnel-uuid>
+    credentials-file: /Users/<you>/.cloudflared/<tunnel-uuid>.json
+
+    ingress:
+      - hostname: stackchan-relay-backend.<your-domain>
+        service: ws://localhost:8765
+      - service: http_status:404
+
+If you do not own a domain on Cloudflare, you can use the
+`<tunnel-name>.cfargotunnel.com` hostname that the tunnel exposes by
+default; replace the `hostname:` value accordingly.
+
+Then route the chosen hostname to the tunnel:
+
+    cloudflared tunnel route dns stackchan-relay-backend \
+      stackchan-relay-backend.<your-domain>
+
+## Step 3: Run cloudflared as a service
+
+Install `cloudflared` as a launchd service so it survives reboots:
+
+    sudo cloudflared service install
+
+Verify it is running:
+
+    cloudflared tunnel info stackchan-relay-backend
+
+## Step 4: Generate a shared secret
+
+On your deployment workstation:
+
+    openssl rand -hex 32
+
+Save the output — you will set it on the Worker and on the Stack-chan
+device.
+
+## Step 5: Deploy the Worker
+
+From `examples/cloudflare-relay/`:
+
+    npx wrangler login
+
+Edit `wrangler.toml` and set `UPSTREAM_URL` to the tunnel hostname
+configured in Step 2, prefixed with `wss://`. For example:
+
+    [vars]
+    UPSTREAM_URL = "wss://stackchan-relay-backend.<your-domain>"
+
+Register the shared secret (do not commit it):
+
+    npx wrangler secret put SHARED_SECRET
+    # paste the secret from Step 4 when prompted
+
+Deploy:
+
+    npx wrangler deploy
+
+Wrangler will print the Worker URL (for example,
+`https://stackchan-relay.<your-subdomain>.workers.dev`). Convert this
+to a `wss://` URL — that becomes the value you set on the Stack-chan
+device in Step 6.
+
+## Step 6: Configure the Stack-chan device
+
+Boot the device into its WiFi configuration access point (refer to the
+main `stackchan-mcp` README for how to enter config mode). In the web
+UI, set:
+
+- `websocket.url` → leave empty (the firmware uses mDNS auto-discovery
+  for the LAN case).
+- `websocket.fallback_url` → the Worker URL from Step 5, as `wss://`.
+- `websocket.token` → the shared secret from Step 4.
+
+Save and reboot the device. The firmware will:
+
+1. Attempt mDNS discovery first (LAN case, about 5s timeout).
+2. If mDNS yields no candidates, fall back to the Worker URL.
+3. Send the Bearer token in the `Authorization` header for the Worker
+   to verify.
+
+## Step 7: Verify
+
+With the device on the same LAN as the gateway, it should connect
+directly via mDNS (no relay traffic). Confirm by checking the gateway
+logs for an incoming WebSocket connection from the device's LAN IP.
+
+Then take the device off-LAN (e.g., tether to a mobile hotspot). The
+device should connect within roughly 15 seconds: ~5s mDNS timeout +
+~10s server-hello window on the Worker candidate. Confirm by checking
+the Worker logs (`npx wrangler tail`) for a connection accepted with
+the Bearer token verified.
+
+## Troubleshooting
+
+- `unauthorized` (HTTP 401) from the Worker: the Bearer token on the
+  device does not match the Worker's `SHARED_SECRET`. Re-check both,
+  and rotate the secret if leaked (see `secret-rotation.md`).
+- `upstream unreachable` (HTTP 502) from the Worker: `cloudflared` is
+  not connected, the tunnel ingress is misconfigured, or the gateway
+  is not running on `localhost:8765`. Check `cloudflared tunnel info`
+  on the gateway host.
+- The device never falls back to the Worker URL on-LAN: this is
+  expected. mDNS auto-discovery wins on-LAN; the Worker URL is only
+  used when mDNS fails to resolve a candidate.

--- a/examples/cloudflare-relay/package.json
+++ b/examples/cloudflare-relay/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "stackchan-relay",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Optional Cloudflare Workers relay example for stackchan-mcp",
+  "main": "src/index.ts",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260601.0",
+    "typescript": "^5.5.0",
+    "wrangler": "^3.80.0"
+  }
+}

--- a/examples/cloudflare-relay/src/index.ts
+++ b/examples/cloudflare-relay/src/index.ts
@@ -3,13 +3,6 @@
 interface Env {
   SHARED_SECRET: string;
   UPSTREAM_URL: string;
-  // Optional Bearer token presented to the upstream gateway. Set this
-  // via `wrangler secret put UPSTREAM_TOKEN` only when the gateway is
-  // started with `--token <upstream-secret>`. When unset, the Worker
-  // does not send an Authorization header upstream — meaning the
-  // tunnel hostname is effectively unauthenticated. See README for
-  // the security trade-off.
-  UPSTREAM_TOKEN?: string;
 }
 
 export default {
@@ -21,6 +14,16 @@ export default {
     }
 
     // 2. Verify the Authorization Bearer token using constant-time comparison.
+    //    Fail closed if SHARED_SECRET is unset — without this guard, a
+    //    misconfigured deployment would compare against the literal
+    //    string "Bearer undefined" and authenticate any client that
+    //    presented that value.
+    if (!env.SHARED_SECRET) {
+      return new Response(
+        "relay misconfigured: SHARED_SECRET unset",
+        { status: 500 },
+      );
+    }
     const auth = req.headers.get("Authorization") ?? "";
     const expected = "Bearer " + env.SHARED_SECRET;
     if (!constantTimeEqual(auth, expected)) {
@@ -28,21 +31,20 @@ export default {
     }
 
     // 3. Open the upstream WebSocket through the configured Cloudflare Tunnel.
-    //    Forward the firmware's identity headers. The device-side
-    //    Authorization header is terminated at this Worker; if the
-    //    gateway requires its own Bearer token, attach it from
-    //    UPSTREAM_TOKEN here.
-    const upstreamHeaders: Record<string, string> = {
-      Upgrade: "websocket",
-      "Protocol-Version": req.headers.get("Protocol-Version") ?? "",
-      "Device-Id": req.headers.get("Device-Id") ?? "",
-      "Client-Id": req.headers.get("Client-Id") ?? "",
-    };
-    if (env.UPSTREAM_TOKEN) {
-      upstreamHeaders["Authorization"] = "Bearer " + env.UPSTREAM_TOKEN;
-    }
+    //    Forward the device's Authorization header to the gateway so
+    //    a gateway started with STACKCHAN_TOKEN=<SHARED_SECRET> can
+    //    re-verify the same Bearer. The firmware sends the same NVS
+    //    `websocket.token` on every candidate, so on-LAN mDNS-direct
+    //    and off-LAN relayed connections present the same value to
+    //    the gateway.
     const upstreamReq = new Request(env.UPSTREAM_URL, {
-      headers: upstreamHeaders,
+      headers: {
+        Upgrade: "websocket",
+        Authorization: auth,
+        "Protocol-Version": req.headers.get("Protocol-Version") ?? "",
+        "Device-Id": req.headers.get("Device-Id") ?? "",
+        "Client-Id": req.headers.get("Client-Id") ?? "",
+      },
     });
     const upstreamRes = await fetch(upstreamReq);
     if (upstreamRes.status !== 101 || !upstreamRes.webSocket) {

--- a/examples/cloudflare-relay/src/index.ts
+++ b/examples/cloudflare-relay/src/index.ts
@@ -1,0 +1,72 @@
+/// <reference types="@cloudflare/workers-types" />
+
+interface Env {
+  SHARED_SECRET: string;
+  UPSTREAM_URL: string;
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    // 1. Verify this is a WebSocket upgrade request.
+    const upgrade = req.headers.get("Upgrade");
+    if (upgrade !== "websocket") {
+      return new Response("expected websocket", { status: 426 });
+    }
+
+    // 2. Verify the Authorization Bearer token using constant-time comparison.
+    const auth = req.headers.get("Authorization") ?? "";
+    const expected = "Bearer " + env.SHARED_SECRET;
+    if (!constantTimeEqual(auth, expected)) {
+      return new Response("unauthorized", { status: 401 });
+    }
+
+    // 3. Open the upstream WebSocket through the configured Cloudflare Tunnel.
+    //    Forward the firmware's identity headers (but not Authorization).
+    const upstreamReq = new Request(env.UPSTREAM_URL, {
+      headers: {
+        Upgrade: "websocket",
+        "Protocol-Version": req.headers.get("Protocol-Version") ?? "",
+        "Device-Id": req.headers.get("Device-Id") ?? "",
+        "Client-Id": req.headers.get("Client-Id") ?? "",
+      },
+    });
+    const upstreamRes = await fetch(upstreamReq);
+    if (upstreamRes.status !== 101 || !upstreamRes.webSocket) {
+      return new Response("upstream unreachable", { status: 502 });
+    }
+    const upstreamWS = upstreamRes.webSocket;
+    upstreamWS.accept();
+
+    // 4. Create a WebSocketPair to return to the client.
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    server.accept();
+
+    // 5. Pipe messages bidirectionally. Text and binary frames are both
+    //    delivered through event.data without further inspection.
+    server.addEventListener("message", (e) => upstreamWS.send(e.data));
+    upstreamWS.addEventListener("message", (e) => server.send(e.data));
+
+    // 6. Propagate close and error events in both directions so neither
+    //    side is left holding a half-open connection.
+    server.addEventListener("close", () => upstreamWS.close());
+    upstreamWS.addEventListener("close", () => server.close());
+    server.addEventListener("error", () => upstreamWS.close());
+    upstreamWS.addEventListener("error", () => server.close());
+
+    // 7. Return the client side of the WebSocketPair as the response.
+    return new Response(null, { status: 101, webSocket: client });
+  },
+};
+
+// Constant-time string comparison to mitigate timing attacks on the
+// Bearer secret. The length-mismatch fast path is not secret-derived
+// in this code path (the expected length is fixed by SHARED_SECRET).
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/examples/cloudflare-relay/src/index.ts
+++ b/examples/cloudflare-relay/src/index.ts
@@ -3,6 +3,13 @@
 interface Env {
   SHARED_SECRET: string;
   UPSTREAM_URL: string;
+  // Optional Bearer token presented to the upstream gateway. Set this
+  // via `wrangler secret put UPSTREAM_TOKEN` only when the gateway is
+  // started with `--token <upstream-secret>`. When unset, the Worker
+  // does not send an Authorization header upstream — meaning the
+  // tunnel hostname is effectively unauthenticated. See README for
+  // the security trade-off.
+  UPSTREAM_TOKEN?: string;
 }
 
 export default {
@@ -21,14 +28,21 @@ export default {
     }
 
     // 3. Open the upstream WebSocket through the configured Cloudflare Tunnel.
-    //    Forward the firmware's identity headers (but not Authorization).
+    //    Forward the firmware's identity headers. The device-side
+    //    Authorization header is terminated at this Worker; if the
+    //    gateway requires its own Bearer token, attach it from
+    //    UPSTREAM_TOKEN here.
+    const upstreamHeaders: Record<string, string> = {
+      Upgrade: "websocket",
+      "Protocol-Version": req.headers.get("Protocol-Version") ?? "",
+      "Device-Id": req.headers.get("Device-Id") ?? "",
+      "Client-Id": req.headers.get("Client-Id") ?? "",
+    };
+    if (env.UPSTREAM_TOKEN) {
+      upstreamHeaders["Authorization"] = "Bearer " + env.UPSTREAM_TOKEN;
+    }
     const upstreamReq = new Request(env.UPSTREAM_URL, {
-      headers: {
-        Upgrade: "websocket",
-        "Protocol-Version": req.headers.get("Protocol-Version") ?? "",
-        "Device-Id": req.headers.get("Device-Id") ?? "",
-        "Client-Id": req.headers.get("Client-Id") ?? "",
-      },
+      headers: upstreamHeaders,
     });
     const upstreamRes = await fetch(upstreamReq);
     if (upstreamRes.status !== 101 || !upstreamRes.webSocket) {

--- a/examples/cloudflare-relay/tsconfig.json
+++ b/examples/cloudflare-relay/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/cloudflare-relay/wrangler.toml
+++ b/examples/cloudflare-relay/wrangler.toml
@@ -3,11 +3,18 @@
 #
 # Before deploying:
 #   1. Copy this file as-is (or edit `name` to match your own deployment).
-#   2. Set UPSTREAM_URL to your Cloudflare Tunnel hostname (wss://...).
-#   3. Register the shared Bearer token as a secret:
+#   2. Set UPSTREAM_URL to your Cloudflare Tunnel hostname using the
+#      `https://` form (the Worker performs the WebSocket upgrade by
+#      issuing fetch() with `Upgrade: websocket`, which requires an
+#      http/https URL).
+#   3. Register the device-to-Worker shared Bearer token:
 #        wrangler secret put SHARED_SECRET
-#      (this is NOT stored in wrangler.toml or committed)
-#   4. Deploy:
+#   4. If the gateway is started with `--token <upstream-secret>`,
+#      register the Worker-to-gateway Bearer token as well:
+#        wrangler secret put UPSTREAM_TOKEN
+#      (omit this step if the gateway has no token; see README for the
+#      security trade-off.)
+#   5. Deploy:
 #        wrangler deploy
 
 name = "stackchan-relay"
@@ -16,6 +23,6 @@ compatibility_date = "2026-06-01"
 
 # UPSTREAM_URL points to the Cloudflare Tunnel that exposes the
 # stackchan-mcp gateway's localhost:8765 WebSocket endpoint.
-# Format: wss://<your-tunnel-hostname>
+# Format: https://<your-tunnel-hostname>
 [vars]
-UPSTREAM_URL = "wss://<your-tunnel-hostname>"
+UPSTREAM_URL = "https://<your-tunnel-hostname>"

--- a/examples/cloudflare-relay/wrangler.toml
+++ b/examples/cloudflare-relay/wrangler.toml
@@ -1,0 +1,21 @@
+# wrangler.toml — Cloudflare Workers deployment configuration for
+# the stackchan-mcp relay example.
+#
+# Before deploying:
+#   1. Copy this file as-is (or edit `name` to match your own deployment).
+#   2. Set UPSTREAM_URL to your Cloudflare Tunnel hostname (wss://...).
+#   3. Register the shared Bearer token as a secret:
+#        wrangler secret put SHARED_SECRET
+#      (this is NOT stored in wrangler.toml or committed)
+#   4. Deploy:
+#        wrangler deploy
+
+name = "stackchan-relay"
+main = "src/index.ts"
+compatibility_date = "2026-06-01"
+
+# UPSTREAM_URL points to the Cloudflare Tunnel that exposes the
+# stackchan-mcp gateway's localhost:8765 WebSocket endpoint.
+# Format: wss://<your-tunnel-hostname>
+[vars]
+UPSTREAM_URL = "wss://<your-tunnel-hostname>"

--- a/examples/cloudflare-relay/wrangler.toml
+++ b/examples/cloudflare-relay/wrangler.toml
@@ -7,14 +7,12 @@
 #      `https://` form (the Worker performs the WebSocket upgrade by
 #      issuing fetch() with `Upgrade: websocket`, which requires an
 #      http/https URL).
-#   3. Register the device-to-Worker shared Bearer token:
+#   3. Register the shared Bearer secret used end-to-end (device <->
+#      Worker <-> gateway). The Worker verifies it against the
+#      incoming Authorization header and forwards the same header to
+#      the upstream gateway:
 #        wrangler secret put SHARED_SECRET
-#   4. If the gateway is started with `--token <upstream-secret>`,
-#      register the Worker-to-gateway Bearer token as well:
-#        wrangler secret put UPSTREAM_TOKEN
-#      (omit this step if the gateway has no token; see README for the
-#      security trade-off.)
-#   5. Deploy:
+#   4. Deploy:
 #        wrangler deploy
 
 name = "stackchan-relay"


### PR DESCRIPTION
## Summary

Add `examples/cloudflare-relay/` as a self-contained, unmaintained
optional example for reaching the `stackchan-mcp` gateway from outside
the local LAN.

The example consists of a small Cloudflare Worker that:

- Verifies an `Authorization: Bearer <shared-secret>` header from the
  device using constant-time comparison (fails closed if the secret
  is not configured).
- Forwards the same `Authorization` header upstream so a gateway
  started with `STACKCHAN_TOKEN=<shared-secret>` can re-verify the
  Bearer for both LAN-direct and relayed connections.
- Proxies the WebSocket bidirectionally to the gateway through a
  Cloudflare Tunnel (`cloudflared`) running on the gateway host.

No firmware changes are required: the existing `websocket.fallback_url`
and `websocket.token` NVS fields cover the device-side configuration.
The firmware's mDNS auto-discovery flow continues to win on-LAN; the
Worker URL is only used when mDNS yields no candidates (typically when
the device is off-LAN).

## Why a new `examples/` directory

This is the first entry under a new top-level `examples/` directory,
intended for optional end-user-configurable reference deployments
(not maintained code paths that the gateway or firmware depend on).
Each example carries its own README, docs, and license notice. The
example is provided as-is and breakage is best-effort to address.

## Design choices

- Single shared Bearer token end-to-end (`SHARED_SECRET` on the
  Worker, `websocket.token` on the device, `STACKCHAN_TOKEN` on the
  gateway). The firmware sends the same NVS `websocket.token` on
  every candidate, so any scheme where the gateway expects a
  different value for direct vs relayed connections breaks the LAN
  path.
- Constant-time Bearer comparison with a fail-closed guard against
  unset `SHARED_SECRET`.
- Generally-available Cloudflare primitives only — deliberately
  avoids beta features such as Workers VPC bindings, whose
  WebSocket support is not yet documented and whose API may change
  before GA.
- The Worker forwards `Protocol-Version` / `Device-Id` / `Client-Id`
  headers to upstream verbatim, along with the device's
  `Authorization` header. The WebSocket upgrade fetch uses the
  `https://` scheme because the Workers runtime performs the upgrade
  over an http/https origin (the same applies to the `cloudflared`
  ingress `service` value on the gateway host).
- `cloudflared` runs on the gateway host (24/7 reachable) and the
  Worker reaches it via the tunnel's public hostname under a
  Cloudflare-managed domain (named tunnels do not auto-publish
  under `*.cfargotunnel.com`, so a custom hostname is required).

## Top-level docs touched

- `README.md` / `README.ja.md`: a new `examples/` row in the
  Repository layout table.
- `CHANGELOG.md`: a new `Examples` subsection under `## [Unreleased]`.

## Pre-PR review status

This branch went through four rounds of `codex review`. Findings from
each round were addressed in follow-up commits, and round 4 returned
clean (no blocking issues).

The branch was then merged with `main` to pick up the mDNS recovery
fix (#280) so that real-device verification reflects the latest
gateway and firmware behavior.

## Test plan

- [x] `npm install` succeeds in `examples/cloudflare-relay/`.
- [x] `npx tsc --noEmit` passes (TypeScript type-check).
- [x] `wrangler dev` boots the Worker locally with a dummy
      `UPSTREAM_URL`.
- [x] On-LAN device test: with mDNS reachable, the device connects
      directly via mDNS without traffic to the Worker (regression
      check that the fallback ordering is unchanged).
- [x] Off-LAN device test: with mDNS unreachable and the Worker
      deployed, the device falls back to the Worker URL within ~15s
      and connects (Bearer accepted by both Worker and gateway).

### Real-device verification result

Verified end-to-end with `cloudflared` and the Worker live at the
same time, so the on-LAN and off-LAN paths were exercised against
the same backend configuration:

- On-LAN: the device discovers the gateway over mDNS within ~12s
  after boot (a `_stackchan-mcp._tcp.local.` instance is accepted
  with multiple addresses considered), selects the LAN candidate,
  and establishes the WebSocket in under 100 ms. No traffic is
  observed at the Worker / Cloudflare Tunnel side; the relay log
  shows zero ingress requests during this window. The pre-existing
  ordering (mDNS first, then `websocket.fallback_url`) is preserved.
- Off-LAN: with the device on a network where mDNS is not delivered
  (NAT-isolated tethering), the firmware exhausts three mDNS query
  attempts (~11s combined), then falls back to the configured
  `websocket.fallback_url`. The WebSocket upgrade through the Worker
  and the Cloudflare Tunnel reaches the gateway in ~1s, well under
  the ~15s plan target. The Bearer token is accepted at both the
  Worker and the gateway; the device transitions to its idle state
  with all MCP tools available.

## Out of scope

- The existing `docs/remote-access.md` (Tailscale Funnel guide) is
  left untouched in this PR. Consolidating the off-LAN access guides
  is a follow-up doc PR if desired.
- No CI job is introduced for the Worker build/test; examples are
  best-effort by design.
