### PR TITLE
fix(mdns): refresh gateway IP and browse all firmware candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Add periodic IP-change detection to the mDNS advertiser; the gateway now
+  re-registers its mDNS service automatically when the host's primary IPv4
+  changes (DHCP lease renewal, Wi-Fi switch, sleep/wake, dock/undock).
+  Recovery latency is bounded by `refresh_interval` (default 30 s).
+  Pair with Firmware vX.Y.Z+ for automatic device-side recovery — earlier
+  firmware versions may still get stuck on the stale mDNS instance until
+  manual reboot. (#277)
+
+### Firmware
+
+- mDNS gateway discovery now considers all supported `_stackchan-mcp._tcp.local.`
+  service instances in one browse, not only the first. Combined with Gateway
+  vA.B.C+ mDNS IP refresh, the device recovers automatically from a gateway
+  host-IP change even while a stale mDNS instance is still in the cache. The
+  existing `websocket_protocol.cc` per-candidate fallback (5→30 s reconnect
+  backoff) handles the additional candidates. (#277)
+
 ## [0.9.1] - 2026-06-08
 
 ### Gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ documented-only.
 - Add periodic IP-change detection to the mDNS advertiser; the gateway now
   re-registers its mDNS service automatically when the host's primary IPv4
   changes (DHCP lease renewal, Wi-Fi switch, sleep/wake, dock/undock).
-  Recovery latency is bounded by `refresh_interval` (default 30 s).
+  Recovery latency is bounded by approximately `2 × refresh_interval` (one
+  polling interval to observe the address change, plus one debounce-confirm
+  interval before re-registering; default 30 s → worst case ~60 s).
   Pair with Firmware vX.Y.Z+ for automatic device-side recovery — earlier
   firmware versions may still get stuck on the stale mDNS instance until
   manual reboot. (#277)

--- a/README.ja.md
+++ b/README.ja.md
@@ -155,10 +155,16 @@ path の後で引き続き試行されます。`CONFIG_FORCE_DEFAULT_WEBSOCKET_U
 compile out するには `CONFIG_STACKCHAN_MDNS_DISCOVERY=n` を設定します。
 discovery にはローカル LAN 上の UDP multicast が必要で、router や VLAN
 によっては遮断されます。複数のゲートウェイが見える場合、ファームウェア
-は最初の supported gateway service を選び、その service の usable IPv4
-address をそれぞれ試し、選択した instance / host / address list / port を
-log に出します。mDNS が見つけるのは URL だけで、認証は引き続き
+は 1 回の browse で見つかったすべての supported gateway service について
+usable IPv4 address をそれぞれ試し、accepted instance 数と candidate
+address list を log に出します。mDNS が見つけるのは URL だけで、認証は引き続き
 `websocket.token` / `CONFIG_DEFAULT_WEBSOCKET_TOKEN` が制御します。
+
+gateway host IPv4 が変わった後の自動復旧には、paired mDNS fix の両側が必要です:
+Gateway vA.B.C+ は host address 変更時に advertised service を更新し、
+Firmware vX.Y.Z+ は 1 回の browse で見つかったすべての supported mDNS service
+instance を試します。それより古い firmware は、再起動するまで stale cache 上の
+instance を試し続ける場合があります。
 
 ファームウェアはゲートウェイ接続のために以下の NVS キーを参照します:
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,17 @@ The gateway advertises mDNS by default; run `stackchan-mcp --no-mdns` to
 disable advertisement. To compile out firmware discovery, set
 `CONFIG_STACKCHAN_MDNS_DISCOVERY=n`. Discovery requires UDP multicast on the
 local LAN, and some routers or VLANs block it. When multiple gateways are
-visible, the firmware picks the first supported gateway service, tries each
-usable IPv4 address from that service, and logs the selected instance, host,
-address list, and port. mDNS only discovers the URL;
+visible, the firmware tries each usable IPv4 address from every supported
+gateway service discovered in one browse, and logs the accepted instance count
+and candidate address list. mDNS only discovers the URL;
 `websocket.token` / `CONFIG_DEFAULT_WEBSOCKET_TOKEN` still control
 authentication.
+
+Automatic recovery after a gateway host IPv4 change requires both sides of the
+paired mDNS fix: Gateway vA.B.C+ refreshes the advertised service when the host
+address changes, and Firmware vX.Y.Z+ tries all supported mDNS service
+instances from a browse. Earlier firmware may keep trying a stale cached
+instance until reboot.
 
 The firmware reads these NVS keys for the gateway connection:
 

--- a/firmware/main/protocols/mdns_gateway_discovery.cc
+++ b/firmware/main/protocols/mdns_gateway_discovery.cc
@@ -260,11 +260,15 @@ std::optional<std::vector<MdnsGatewayCandidate>> DiscoverStackchanGateway(uint32
 
     if (all_candidates.has_value()) {
         std::string addresses = JoinCandidateAddresses(*all_candidates);
+        // Cast size_t to unsigned int and use %u to stay nano-printf-safe
+        // (newlib-nano in ESP-IDF does not handle %zu; the misaligned arg
+        // would then read the size_t as a string pointer and crash). Same
+        // pattern as firmware/main/boards/stackchan/avatar_set_fetcher.cc.
         ESP_LOGI(TAG,
-                 "mDNS gateway browse complete: raw_results=%d accepted_instances=%d candidates=%zu addresses=%s",
+                 "mDNS gateway browse complete: raw_results=%d accepted_instances=%d candidates=%u addresses=%s",
                  result_count,
                  extracted.accepted_instances,
-                 all_candidates->size(),
+                 static_cast<unsigned int>(all_candidates->size()),
                  addresses.c_str());
     } else if (result_count == 0) {
         ESP_LOGI(TAG, "No mDNS stackchan gateway services discovered");

--- a/firmware/main/protocols/mdns_gateway_discovery.cc
+++ b/firmware/main/protocols/mdns_gateway_discovery.cc
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <utility>
 #include <vector>
 
 #if CONFIG_STACKCHAN_MDNS_DISCOVERY
@@ -114,8 +115,75 @@ std::string JoinCandidateAddresses(const std::vector<MdnsGatewayCandidate>& cand
     return joined;
 }
 
+std::string JoinAddresses(const std::vector<std::string>& addresses) {
+    if (addresses.empty()) {
+        return std::string();
+    }
+    std::string joined = addresses.front();
+    for (size_t i = 1; i < addresses.size(); ++i) {
+        joined += ",";
+        joined += addresses[i];
+    }
+    return joined;
+}
+
 std::string BuildWebSocketUrl(const std::string& address, uint16_t port, const std::string& path) {
     return "ws://" + address + ":" + std::to_string(port) + path;
+}
+
+struct ExtractedGatewayCandidates {
+    int accepted_instances = 0;
+    std::vector<MdnsGatewayCandidate> candidates;
+};
+
+ExtractedGatewayCandidates ExtractGatewayCandidatesFromMdnsResults(const mdns_result_t* results,
+                                                                   int result_count) {
+    ExtractedGatewayCandidates extracted;
+    for (const mdns_result_t* result = results; result != nullptr; result = result->next) {
+        std::string instance_name = SafeString(result->instance_name);
+        std::string hostname = SafeString(result->hostname);
+
+        auto version = TxtValue(result, "version");
+        if (version.has_value() && *version != "1") {
+            ESP_LOGI(TAG,
+                     "Skipping mDNS gateway instance=\"%s\" host=\"%s\": unsupported TXT version=\"%s\"",
+                     instance_name.c_str(), hostname.c_str(), version->c_str());
+            continue;
+        }
+
+        if (result->port == 0) {
+            ESP_LOGW(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": zero port",
+                     instance_name.c_str(), hostname.c_str());
+            continue;
+        }
+
+        auto addresses = UsableIpv4Addresses(result);
+        if (addresses.empty()) {
+            ESP_LOGI(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": no usable IPv4 address",
+                     instance_name.c_str(), hostname.c_str());
+            continue;
+        }
+
+        std::string path = NormalizePath(TxtValue(result, "path"));
+        ESP_LOGI(TAG,
+                 "Accepting mDNS gateway instance=\"%s\" host=\"%s\" port=%u path=\"%s\" addresses=%s",
+                 instance_name.c_str(), hostname.c_str(),
+                 static_cast<unsigned>(result->port), path.c_str(),
+                 JoinAddresses(addresses).c_str());
+        ++extracted.accepted_instances;
+        for (const auto& address : addresses) {
+            MdnsGatewayCandidate candidate;
+            candidate.url = BuildWebSocketUrl(address, result->port, path);
+            candidate.instance_name = instance_name;
+            candidate.hostname = hostname;
+            candidate.address = address;
+            candidate.port = result->port;
+            candidate.path = path;
+            candidate.result_count = result_count;
+            extracted.candidates.push_back(candidate);
+        }
+    }
+    return extracted;
 }
 
 #endif  // CONFIG_STACKCHAN_MDNS_DISCOVERY
@@ -182,66 +250,27 @@ std::optional<std::vector<MdnsGatewayCandidate>> DiscoverStackchanGateway(uint32
     }
 
     int result_count = CountResults(results);
-    std::optional<std::vector<MdnsGatewayCandidate>> selected;
-
-    for (mdns_result_t* result = results; result != nullptr; result = result->next) {
-        std::string instance_name = SafeString(result->instance_name);
-        std::string hostname = SafeString(result->hostname);
-
-        auto version = TxtValue(result, "version");
-        if (version.has_value() && *version != "1") {
-            ESP_LOGI(TAG,
-                     "Skipping mDNS gateway instance=\"%s\" host=\"%s\": unsupported TXT version=\"%s\"",
-                     instance_name.c_str(), hostname.c_str(), version->c_str());
-            continue;
-        }
-
-        if (result->port == 0) {
-            ESP_LOGW(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": zero port",
-                     instance_name.c_str(), hostname.c_str());
-            continue;
-        }
-
-        auto addresses = UsableIpv4Addresses(result);
-        if (addresses.empty()) {
-            ESP_LOGI(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": no usable IPv4 address",
-                     instance_name.c_str(), hostname.c_str());
-            continue;
-        }
-
-        std::string path = NormalizePath(TxtValue(result, "path"));
-        std::vector<MdnsGatewayCandidate> candidates;
-        candidates.reserve(addresses.size());
-        for (const auto& address : addresses) {
-            MdnsGatewayCandidate candidate;
-            candidate.url = BuildWebSocketUrl(address, result->port, path);
-            candidate.instance_name = instance_name;
-            candidate.hostname = hostname;
-            candidate.address = address;
-            candidate.port = result->port;
-            candidate.path = path;
-            candidate.result_count = result_count;
-            candidates.push_back(candidate);
-        }
-        selected = candidates;
-        break;
+    // Keep the count next to the extracted candidates so summary logs stay
+    // accurate without a mutable out-parameter.
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(results, result_count);
+    std::optional<std::vector<MdnsGatewayCandidate>> all_candidates;
+    if (!extracted.candidates.empty()) {
+        all_candidates = std::move(extracted.candidates);
     }
 
-    if (selected.has_value()) {
-        const auto& first = selected->front();
-        std::string addresses = JoinCandidateAddresses(*selected);
+    if (all_candidates.has_value()) {
+        std::string addresses = JoinCandidateAddresses(*all_candidates);
         ESP_LOGI(TAG,
-                 "mDNS discovered %d stackchan gateway service(s); selected instance=\"%s\" host=\"%s\" addresses=%s port=%u path=\"%s\"",
-                 first.result_count,
-                 first.instance_name.c_str(),
-                 first.hostname.c_str(),
-                 addresses.c_str(),
-                 first.port,
-                 first.path.c_str());
+                 "mDNS gateway browse complete: raw_results=%d accepted_instances=%d candidates=%zu addresses=%s",
+                 result_count,
+                 extracted.accepted_instances,
+                 all_candidates->size(),
+                 addresses.c_str());
     } else if (result_count == 0) {
         ESP_LOGI(TAG, "No mDNS stackchan gateway services discovered");
     } else {
-        ESP_LOGI(TAG, "No supported mDNS stackchan gateway service found among %d result(s)", result_count);
+        ESP_LOGW(TAG, "mDNS gateway browse found %d result(s), but no supported gateway candidates",
+                 result_count);
     }
 
     if (results != nullptr) {
@@ -249,7 +278,7 @@ std::optional<std::vector<MdnsGatewayCandidate>> DiscoverStackchanGateway(uint32
     }
     restore_wifi_power_save();
     mdns_free();
-    return selected;
+    return all_candidates;
 #else
     (void)timeout_ms;
     return std::nullopt;

--- a/firmware/main/protocols/mdns_gateway_discovery.h
+++ b/firmware/main/protocols/mdns_gateway_discovery.h
@@ -16,8 +16,9 @@ struct MdnsGatewayCandidate {
     int result_count = 0;
 };
 
-// Returns one candidate per usable IPv4 address for the first supported
-// gateway service. std::nullopt means no supported gateway was discovered.
+// Returns one candidate per usable IPv4 address for all supported gateway
+// services discovered in one mDNS browse. std::nullopt means no supported
+// gateway was discovered.
 std::optional<std::vector<MdnsGatewayCandidate>> DiscoverStackchanGateway(uint32_t timeout_ms);
 
 #endif  // _MDNS_GATEWAY_DISCOVERY_H_

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -239,6 +239,26 @@ def _resolve_concrete_host_ipv4_addresses(host: str) -> list[str]:
     return _select_advertised_addresses([(address, None) for address in addresses])
 
 
+def _resolve_addresses_for_host(host: str) -> list[str]:
+    """Resolve advertised addresses for ``host`` using the same logic as
+    :func:`build_advertisement`.
+
+    Wildcard hosts (``0.0.0.0`` / ``*`` / ``""``) enumerate every usable
+    non-loopback IPv4 address on the machine; concrete hosts only resolve
+    addresses for that specific host. The refresh loop calls this helper so
+    its comparison set matches what a fresh ``build_advertisement(...)``
+    would actually register — without this, a host started with a concrete
+    HOST in a multi-NIC / Tailscale environment would see every poll as an
+    "address change" against an unrelated extra interface and churn the
+    registration on every refresh interval.
+    """
+    return (
+        _enumerate_usable_ipv4_addresses()
+        if _is_wildcard_host(host)
+        else _resolve_concrete_host_ipv4_addresses(host)
+    )
+
+
 def build_advertisement(
     *,
     host: str,
@@ -254,11 +274,7 @@ def build_advertisement(
         return None
 
     normalized_path = path if path.startswith("/") else f"/{path}"
-    addresses = (
-        _enumerate_usable_ipv4_addresses()
-        if _is_wildcard_host(host)
-        else _resolve_concrete_host_ipv4_addresses(host)
-    )
+    addresses = _resolve_addresses_for_host(host)
     if not addresses:
         logger.warning(
             "mDNS advertisement skipped: no usable non-loopback IPv4 address "
@@ -420,6 +436,16 @@ class MdnsAdvertiser:
                 return
 
             await self._close_zeroconf_locked()
+            # Clear the cached advertised set immediately after closing the old
+            # zeroconf instance. If the subsequent re-registration raises (or
+            # the host IP later reverts to ``old_addresses``), the refresh
+            # loop's ``current != _last_advertised_addresses`` check would
+            # otherwise compare against the stale value and stay quiet — the
+            # advertisement would remain dead until a manual restart. Setting
+            # this to ``None`` here guarantees the next refresh tick observes
+            # a divergence and retries registration regardless of which
+            # address state the host happens to be in.
+            self._last_advertised_addresses = None
             await self._register_advertisement_locked(advertisement)
             new_addresses = tuple(advertisement.parsed_addresses)
             self._last_advertised_addresses = new_addresses
@@ -440,7 +466,11 @@ class MdnsAdvertiser:
         while True:
             try:
                 await asyncio.sleep(self._refresh_interval)
-                current_addresses = tuple(_enumerate_usable_ipv4_addresses())
+                start_args = self._start_args
+                if start_args is None:
+                    continue
+                host = start_args["host"]
+                current_addresses = tuple(_resolve_addresses_for_host(host))
                 old_addresses = self._last_advertised_addresses
                 if current_addresses == old_addresses:
                     continue
@@ -452,7 +482,11 @@ class MdnsAdvertiser:
                     current_addresses,
                 )
                 await asyncio.sleep(self._refresh_interval)
-                confirmed_addresses = tuple(_enumerate_usable_ipv4_addresses())
+                start_args = self._start_args
+                if start_args is None:
+                    continue
+                host = start_args["host"]
+                confirmed_addresses = tuple(_resolve_addresses_for_host(host))
                 if confirmed_addresses != current_addresses:
                     logger.info(
                         "mDNS refresh dropped transient address change: "

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import logging
 import socket
@@ -280,15 +281,57 @@ def build_advertisement(
 class MdnsAdvertiser:
     """Registers the gateway's WebSocket endpoint via mDNS/DNS-SD."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, refresh_interval: float = 30.0) -> None:
+        if refresh_interval < 10.0 or refresh_interval > 300.0:
+            raise ValueError("refresh_interval must be between 10.0 and 300.0 seconds")
+        self._lock: asyncio.Lock = asyncio.Lock()
         self._zeroconf: Any | None = None
         self._service_info: Any | None = None
+        self._refresh_task: asyncio.Task | None = None
+        self._last_advertised_addresses: tuple[str, ...] | None = None
+        self._refresh_interval: float = refresh_interval
+        self._start_args: dict[str, Any] | None = None
 
     async def start(self, *, host: str, port: int, path: str = "/") -> None:
+        task = self._refresh_task
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=1.0)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
+
+        async with self._lock:
+            self._refresh_task = None
+            if self._zeroconf is not None:
+                await self._close_zeroconf_locked()
+            self._start_args = {"host": host, "port": port, "path": path}
+            try:
+                advertisement = await self._start_locked(host=host, port=port, path=path)
+            except Exception:
+                self._start_args = None
+                self._last_advertised_addresses = None
+                raise
+            if advertisement is None:
+                self._start_args = None
+                self._last_advertised_addresses = None
+                return
+            self._last_advertised_addresses = tuple(advertisement.parsed_addresses)
+            self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    async def _start_locked(
+        self, *, host: str, port: int, path: str = "/"
+    ) -> MdnsAdvertisement | None:
         advertisement = build_advertisement(host=host, port=port, path=path)
         if advertisement is None:
-            return
+            return None
 
+        await self._register_advertisement_locked(advertisement)
+        return advertisement
+
+    async def _register_advertisement_locked(
+        self, advertisement: MdnsAdvertisement
+    ) -> None:
         AsyncZeroconf, ServiceInfo = _load_zeroconf_classes()
         # Constrain zeroconf to the IPv4 interfaces we actually advertise on.
         # The default ``InterfaceChoice.All`` makes zeroconf bind a socket on
@@ -326,13 +369,28 @@ class MdnsAdvertiser:
                 advertisement.service_name,
             )
         logger.info(
-            "mDNS advertising %s on port %d with addresses %s",
+            "mDNS advertising %s on port %d with addresses %s reason=register",
             registered_name,
             advertisement.port,
             ", ".join(advertisement.parsed_addresses),
         )
 
     async def stop(self) -> None:
+        task = self._refresh_task
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=1.0)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
+
+        async with self._lock:
+            await self._close_zeroconf_locked()
+            self._refresh_task = None
+            self._last_advertised_addresses = None
+            self._start_args = None
+
+    async def _close_zeroconf_locked(self) -> None:
         zeroconf = self._zeroconf
         info = self._service_info
         self._zeroconf = None
@@ -345,3 +403,69 @@ class MdnsAdvertiser:
                 await zeroconf.async_unregister_service(info)
         finally:
             await zeroconf.async_close()
+
+    async def _reconfigure(self) -> None:
+        async with self._lock:
+            if self._start_args is None:
+                return
+            old_addresses = self._last_advertised_addresses
+            advertisement = build_advertisement(**self._start_args)
+            if advertisement is None:
+                logger.info(
+                    "mDNS reconfigure skipped: build_advertisement returned None "
+                    "(transient empty address state); refresh loop continues "
+                    "reason=transient_empty_address_state old=%s",
+                    old_addresses,
+                )
+                return
+
+            await self._close_zeroconf_locked()
+            await self._register_advertisement_locked(advertisement)
+            new_addresses = tuple(advertisement.parsed_addresses)
+            self._last_advertised_addresses = new_addresses
+            registered_name = getattr(
+                self._service_info,
+                "name",
+                advertisement.service_name,
+            )
+            logger.info(
+                "mDNS reconfigured: reason=address_changed old=%s new=%s "
+                "registered_name=%s",
+                old_addresses,
+                new_addresses,
+                registered_name,
+            )
+
+    async def _refresh_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._refresh_interval)
+                current_addresses = tuple(_enumerate_usable_ipv4_addresses())
+                old_addresses = self._last_advertised_addresses
+                if current_addresses == old_addresses:
+                    continue
+
+                logger.info(
+                    "mDNS refresh observed address change: reason=address_changed "
+                    "old=%s new=%s debounce=started",
+                    old_addresses,
+                    current_addresses,
+                )
+                await asyncio.sleep(self._refresh_interval)
+                confirmed_addresses = tuple(_enumerate_usable_ipv4_addresses())
+                if confirmed_addresses != current_addresses:
+                    logger.info(
+                        "mDNS refresh dropped transient address change: "
+                        "reason=debounce_mismatch old=%s first=%s second=%s",
+                        old_addresses,
+                        current_addresses,
+                        confirmed_addresses,
+                    )
+                    continue
+
+                await self._reconfigure()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.exception("mDNS refresh loop error; continuing")
+                continue

--- a/gateway/stackchan_mcp/mdns_advertiser.py
+++ b/gateway/stackchan_mcp/mdns_advertiser.py
@@ -368,7 +368,15 @@ class MdnsAdvertiser:
         )
         try:
             await zeroconf.async_register_service(info, allow_name_change=True)
-        except Exception:
+        except BaseException:
+            # Catch BaseException (not just Exception) so that an
+            # ``asyncio.CancelledError`` arriving mid-registration —
+            # e.g. an external ``stop()`` or a double-``start()`` racing
+            # this registration — still closes the partially-constructed
+            # ``AsyncZeroconf``. Otherwise the bound multicast sockets
+            # and any partial registration would leak past the cancelled
+            # task. ``raise`` preserves the cancellation semantics for
+            # the surrounding ``async with self._lock`` caller.
             await zeroconf.async_close()
             raise
         self._zeroconf = zeroconf
@@ -435,17 +443,21 @@ class MdnsAdvertiser:
                 )
                 return
 
-            await self._close_zeroconf_locked()
-            # Clear the cached advertised set immediately after closing the old
-            # zeroconf instance. If the subsequent re-registration raises (or
-            # the host IP later reverts to ``old_addresses``), the refresh
-            # loop's ``current != _last_advertised_addresses`` check would
-            # otherwise compare against the stale value and stay quiet — the
-            # advertisement would remain dead until a manual restart. Setting
-            # this to ``None`` here guarantees the next refresh tick observes
-            # a divergence and retries registration regardless of which
-            # address state the host happens to be in.
+            # Clear the cached advertised set BEFORE closing so that even a
+            # failure inside ``_close_zeroconf_locked()`` itself (e.g. the
+            # old interface has vanished mid-cycle and ``async_unregister``
+            # / ``async_close`` raise) still leaves the refresh loop in a
+            # "must retry" state. If the subsequent close raises, or the
+            # re-registration raises, or the host IP later reverts to
+            # ``old_addresses``, the refresh loop's
+            # ``current != _last_advertised_addresses`` check would
+            # otherwise compare against the stale value and stay quiet —
+            # the advertisement would remain dead until a manual restart.
+            # Setting this to ``None`` here guarantees the next refresh
+            # tick observes a divergence and retries registration
+            # regardless of which address state the host happens to be in.
             self._last_advertised_addresses = None
+            await self._close_zeroconf_locked()
             await self._register_advertisement_locked(advertisement)
             new_addresses = tuple(advertisement.parsed_addresses)
             self._last_advertised_addresses = new_addresses

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -706,3 +706,96 @@ async def test_stop_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert instances[0].close_count == close_count
     assert len(instances[0].unregistered) == unregister_count
+
+
+@pytest.mark.asyncio
+async def test_refresh_with_concrete_host_ignores_unrelated_interface_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review round 2 Finding 1: when started with a concrete HOST
+    (not a wildcard), the refresh loop must compare against that HOST's
+    resolution only — not against the full host-interface enumeration.
+    Otherwise a multi-NIC / Tailscale host churns the registration on every
+    refresh tick even though the actually-advertised set never changes.
+    """
+    instances = install_recording_zeroconf(monkeypatch)
+
+    # The concrete-host resolver stays constant across all refresh ticks.
+    monkeypatch.setattr(
+        mdns,
+        "_resolve_concrete_host_ipv4_addresses",
+        lambda host: ["192.0.2.10"] if host == "192.0.2.10" else [],
+    )
+    # The wildcard enumerator returns a DIFFERENT (extra) set that must NOT
+    # influence the refresh decision when host is concrete.
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        lambda: ["192.0.2.10", "10.0.0.5"],
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="192.0.2.10", port=8765, path="/")
+
+    # Let several refresh cycles run; the concrete-host comparison must stay
+    # stable so no second zeroconf instance is ever created.
+    await asyncio.sleep(advertiser._refresh_interval * 3)
+
+    assert len(instances) == 1
+    assert instances[0].unregistered == []
+    assert advertiser._last_advertised_addresses == ("192.0.2.10",)
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_register_failure_then_ip_revert_still_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review round 2 Finding 2: if a reconfigure closes the old
+    registration but the new registration then fails, the cached
+    ``_last_advertised_addresses`` must not point at the now-defunct old
+    value. Otherwise, if the host IP reverts to the old value (Wi-Fi
+    re-association, DHCP renewal returning the previous lease, etc.), the
+    refresh loop sees ``current == _last_advertised`` and stays quiet —
+    leaving the advertisement permanently dead until manual restart.
+    """
+    old = ["198.51.100.10"]
+    new = ["203.0.113.20"]
+
+    # Sequence: initial register (old) → refresh observes new → debounce
+    # confirm new → reconfigure: close old, register new fails → IP reverts
+    # to old → refresh observes old (≠ None after the failed reconfigure)
+    # → debounce confirm old → reconfigure: register succeeds.
+    instances = install_recording_zeroconf(
+        monkeypatch,
+        register_errors=[None, RuntimeError("mock reconfigure register fail"), None],
+    )
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([old, new, new, old, old, old, old]),
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+
+    # Wait until the third zeroconf instance is created — this is the recovery
+    # that only happens if the previous failure cleared _last_advertised.
+    await wait_until(
+        lambda: len(instances) == 3 and advertiser._zeroconf is instances[2]
+    )
+
+    # instance 0: original (old IP) was closed during the failed reconfigure.
+    assert instances[0].closed is True
+    # instance 1: register call raised, no successful registration recorded,
+    # internal cleanup closes the partially-constructed zeroconf.
+    assert instances[1].registered == []
+    assert instances[1].closed is True
+    # instance 2: recovery succeeded against the reverted (old) IP.
+    assert len(instances[2].registered) == 1
+    assert advertiser._last_advertised_addresses == tuple(old)
+    assert advertiser._refresh_task is not None
+    assert not advertiser._refresh_task.done()
+
+    await advertiser.stop()

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from stackchan_mcp import mdns_advertiser as mdns
@@ -377,3 +379,330 @@ async def test_advertiser_closes_zeroconf_when_registration_fails(
     assert len(instances) == 1
     assert instances[0].closed is True
 
+
+class RecordingServiceInfo:
+    def __init__(self, service_type: str, service_name: str, **kwargs) -> None:
+        self.type = service_type
+        self.name = service_name
+        self.kwargs = kwargs
+
+
+class RecordingAsyncZeroconf:
+    instances: list[RecordingAsyncZeroconf] = []
+    register_errors: list[Exception | None] = []
+
+    @classmethod
+    def reset(cls, register_errors: list[Exception | None] | None = None) -> None:
+        cls.instances = []
+        cls.register_errors = list(register_errors or [])
+
+    def __init__(self, *, interfaces=None) -> None:
+        self.interfaces = interfaces
+        self.registered = []
+        self.register_attempts = []
+        self.unregistered = []
+        self.closed = False
+        self.close_count = 0
+        self.instances.append(self)
+
+    async def async_register_service(
+        self, info: RecordingServiceInfo, *, allow_name_change: bool = False
+    ) -> None:
+        self.register_attempts.append((info, allow_name_change))
+        if self.register_errors:
+            error = self.register_errors.pop(0)
+            if error is not None:
+                raise error
+        self.registered.append((info, allow_name_change))
+
+    async def async_unregister_service(self, info: RecordingServiceInfo) -> None:
+        self.unregistered.append(info)
+
+    async def async_close(self) -> None:
+        self.closed = True
+        self.close_count += 1
+
+
+def install_recording_zeroconf(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    register_errors: list[Exception | None] | None = None,
+) -> list[RecordingAsyncZeroconf]:
+    RecordingAsyncZeroconf.reset(register_errors)
+    monkeypatch.setattr(
+        mdns,
+        "_load_zeroconf_classes",
+        lambda: (RecordingAsyncZeroconf, RecordingServiceInfo),
+    )
+    return RecordingAsyncZeroconf.instances
+
+
+def fast_advertiser(interval: float = 0.01) -> MdnsAdvertiser:
+    # Production intervals are validated at 10-300 seconds; tests shorten the
+    # private sleep value after construction so debounce behavior is practical.
+    advertiser = MdnsAdvertiser(refresh_interval=10.0)
+    advertiser._refresh_interval = interval
+    return advertiser
+
+
+def sequence_addresses(values: list[list[str]]):
+    remaining = [list(value) for value in values]
+    fallback = list(remaining[-1])
+
+    def next_addresses() -> list[str]:
+        if remaining:
+            return list(remaining.pop(0))
+        return list(fallback)
+
+    return next_addresses
+
+
+async def wait_until(predicate, *, timeout: float = 1.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    assert predicate()
+
+
+@pytest.mark.asyncio
+async def test_refresh_stable_address_list_does_not_reconfigure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        lambda: ["198.51.100.10"],
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+    await asyncio.sleep(advertiser._refresh_interval * 6)
+
+    assert len(instances) == 1
+    assert instances[0].unregistered == []
+    assert len(instances[0].registered) == 1
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_refresh_changed_address_list_reconfigures_once_after_debounce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = ["198.51.100.10"]
+    new = ["203.0.113.20"]
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([old, old, new, new, new]),
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+    await wait_until(lambda: len(instances) == 2)
+
+    assert instances[0].unregistered == [instances[0].registered[0][0]]
+    assert instances[0].closed is True
+    assert len(instances[1].registered) == 1
+    assert advertiser._last_advertised_addresses == tuple(new)
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_refresh_transient_single_tick_change_does_not_reconfigure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = ["198.51.100.10"]
+    transient = ["203.0.113.20"]
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([old, transient, old, old, old, old]),
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+    await asyncio.sleep(advertiser._refresh_interval * 6)
+
+    assert len(instances) == 1
+    assert instances[0].unregistered == []
+    assert advertiser._last_advertised_addresses == tuple(old)
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_refresh_survives_transient_empty_build_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = ["198.51.100.10"]
+    new = ["203.0.113.20"]
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([old, new, new, new, new, new]),
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+
+    original_build_advertisement = mdns.build_advertisement
+    empty_builds = [None]
+
+    def flaky_build_advertisement(*, host: str, port: int, path: str = "/"):
+        if empty_builds:
+            return empty_builds.pop(0)
+        return original_build_advertisement(host=host, port=port, path=path)
+
+    monkeypatch.setattr(mdns, "build_advertisement", flaky_build_advertisement)
+    await wait_until(lambda: len(instances) == 2)
+
+    assert advertiser._refresh_task is not None
+    assert not advertiser._refresh_task.done()
+    assert instances[0].unregistered == [instances[0].registered[0][0]]
+    assert advertiser._last_advertised_addresses == tuple(new)
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_double_start_closes_previous_registration_before_new_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    instances = install_recording_zeroconf(monkeypatch)
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="198.51.100.10", port=8765, path="/")
+    first_task = advertiser._refresh_task
+    await advertiser.start(host="203.0.113.20", port=8765, path="/")
+
+    assert first_task is not None
+    assert first_task.done()
+    assert len(instances) == 2
+    assert instances[0].unregistered == [instances[0].registered[0][0]]
+    assert instances[0].closed is True
+    assert instances[1].closed is False
+    assert advertiser._zeroconf is instances[1]
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_active_refresh_task_and_closes_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    instances = install_recording_zeroconf(monkeypatch)
+
+    advertiser = fast_advertiser(interval=0.05)
+    await advertiser.start(host="198.51.100.10", port=8765, path="/")
+    refresh_task = advertiser._refresh_task
+    await advertiser.stop()
+
+    assert refresh_task is not None
+    assert refresh_task.done()
+    assert instances[0].unregistered == [instances[0].registered[0][0]]
+    assert instances[0].closed is True
+    assert advertiser._refresh_task is None
+    assert advertiser._zeroconf is None
+    assert advertiser._service_info is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_compares_canonical_address_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = ["198.51.100.10", "203.0.113.20"]
+    forced_order = ["203.0.113.20", "198.51.100.10"]
+
+    # The refresh loop compares the canonical list returned by the enumerator.
+    # Raw interface ordering is normalized by _select_advertised_addresses; if
+    # the canonical order is unchanged, no recycle is needed.
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([canonical, canonical, canonical, canonical]),
+    )
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+    await asyncio.sleep(advertiser._refresh_interval * 3)
+    assert len(instances) == 1
+    assert instances[0].unregistered == []
+    await advertiser.stop()
+
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([canonical, forced_order, forced_order, forced_order]),
+    )
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+    await wait_until(lambda: len(instances) == 2)
+    assert instances[0].unregistered == [instances[0].registered[0][0]]
+    assert advertiser._last_advertised_addresses == tuple(forced_order)
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_refresh_register_failure_cleans_up_and_loop_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = ["198.51.100.10"]
+    new = ["203.0.113.20"]
+    instances = install_recording_zeroconf(
+        monkeypatch,
+        register_errors=[None, RuntimeError("mock refresh registration failure"), None],
+    )
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([old, new, new, new, new, new]),
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+    await wait_until(lambda: len(instances) == 3 and advertiser._zeroconf is instances[2])
+
+    assert instances[0].unregistered == [instances[0].registered[0][0]]
+    assert instances[0].closed is True
+    assert instances[1].registered == []
+    assert instances[1].closed is True
+    assert len(instances[2].registered) == 1
+    assert advertiser._refresh_task is not None
+    assert not advertiser._refresh_task.done()
+    assert advertiser._last_advertised_addresses == tuple(new)
+
+    await advertiser.stop()
+
+
+def test_refresh_interval_validation() -> None:
+    with pytest.raises(ValueError):
+        MdnsAdvertiser(refresh_interval=5)
+    with pytest.raises(ValueError):
+        MdnsAdvertiser(refresh_interval=500)
+    assert MdnsAdvertiser(refresh_interval=30)._refresh_interval == 30
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    instances = install_recording_zeroconf(monkeypatch)
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="198.51.100.10", port=8765, path="/")
+    await advertiser.stop()
+    close_count = instances[0].close_count
+    unregister_count = len(instances[0].unregistered)
+
+    await advertiser.stop()
+
+    assert instances[0].close_count == close_count
+    assert len(instances[0].unregistered) == unregister_count

--- a/gateway/tests/test_mdns_advertiser.py
+++ b/gateway/tests/test_mdns_advertiser.py
@@ -799,3 +799,115 @@ async def test_reconfigure_register_failure_then_ip_revert_still_recovers(
     assert not advertiser._refresh_task.done()
 
     await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_close_failure_then_revert_to_old_ip_still_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review round 2 Finding 3: if the OLD-instance close itself
+    raises during reconfigure (e.g. the old interface vanished and
+    ``async_unregister`` / ``async_close`` fail), the cached
+    ``_last_advertised_addresses`` must already have been cleared so that
+    a subsequent IP revert is still picked up by the refresh loop. If we
+    cleared only after a successful close, this code path would leave the
+    cache pointing at the old (now-dead) registration and silently stop
+    advertising forever.
+    """
+    old = ["198.51.100.10"]
+    new = ["203.0.113.20"]
+
+    # Two healthy registrations bracket the failing reconfigure attempt.
+    # instance 0 is the initial register; instance 1 is the recovery
+    # register after the IP reverts.
+    instances = install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        sequence_addresses([old, new, new, old, old, old, old]),
+    )
+
+    # Make the close path fail exactly once — on the FIRST close that
+    # follows the initial register. Subsequent closes (on the recovery
+    # path and stop()) succeed normally.
+    close_calls = {"n": 0}
+    original_close = RecordingAsyncZeroconf.async_close
+
+    async def flaky_async_close(self: RecordingAsyncZeroconf) -> None:
+        close_calls["n"] += 1
+        if close_calls["n"] == 1:
+            self.closed = True
+            self.close_count += 1
+            raise RuntimeError("mock async_close failure on old-interface teardown")
+        await original_close(self)
+
+    monkeypatch.setattr(
+        RecordingAsyncZeroconf, "async_close", flaky_async_close
+    )
+
+    advertiser = fast_advertiser()
+    await advertiser.start(host="0.0.0.0", port=8765, path="/")
+
+    # Wait for the recovery: a second zeroconf instance is only created
+    # if the refresh loop saw _last_advertised_addresses == None after
+    # the failed close (rather than the stale old value) and re-tried.
+    await wait_until(
+        lambda: len(instances) == 2 and advertiser._zeroconf is instances[1]
+    )
+
+    # instance 0: marked closed (the mock still set the flag) and the
+    # failure was raised so reconfigure aborted partway through.
+    assert instances[0].closed is True
+    # instance 1: recovery succeeded against the reverted (old) IP.
+    assert len(instances[1].registered) == 1
+    assert advertiser._last_advertised_addresses == tuple(old)
+    assert advertiser._refresh_task is not None
+    assert not advertiser._refresh_task.done()
+
+    await advertiser.stop()
+
+
+@pytest.mark.asyncio
+async def test_register_advertisement_cancellation_closes_zeroconf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review round 2 Finding 4: an ``asyncio.CancelledError`` arriving
+    mid-``async_register_service`` (e.g. external ``stop()`` races the
+    initial register, or a ``double-start()`` cancels the previous in-flight
+    register) must still close the partially-constructed ``AsyncZeroconf``.
+    Otherwise the multicast sockets and any partial registration leak past
+    the cancelled task. ``except Exception`` is not sufficient because
+    ``CancelledError`` derives from ``BaseException`` in Python 3.8+.
+    """
+    install_recording_zeroconf(monkeypatch)
+    monkeypatch.setattr(
+        mdns,
+        "_enumerate_usable_ipv4_addresses",
+        lambda: ["192.0.2.10"],
+    )
+
+    # Make register raise CancelledError; capture the zeroconf instance
+    # whose async_close should still be called.
+    captured: dict[str, RecordingAsyncZeroconf | None] = {"zc": None}
+
+    async def cancelling_register(
+        self: RecordingAsyncZeroconf,
+        info: RecordingServiceInfo,
+        *,
+        allow_name_change: bool = False,
+    ) -> None:
+        captured["zc"] = self
+        raise asyncio.CancelledError("mock cancellation during register")
+
+    monkeypatch.setattr(
+        RecordingAsyncZeroconf, "async_register_service", cancelling_register
+    )
+
+    advertiser = fast_advertiser()
+    with pytest.raises(asyncio.CancelledError):
+        await advertiser.start(host="0.0.0.0", port=8765, path="/")
+
+    # The partially-constructed AsyncZeroconf must have been closed
+    # even though the failure was a BaseException-derived CancelledError.
+    assert captured["zc"] is not None
+    assert captured["zc"].closed is True


### PR DESCRIPTION
## Summary

Pair fix for #277 — `gateway/mdns: refresh advertised IP on host network change`. This PR lands both halves of the auto-recovery loop required when the gateway host's primary IPv4 changes during process lifetime (DHCP lease renewal, Wi-Fi switch, sleep/wake, dock/undock):

- **Gateway side** — periodic IP-change detection on `MdnsAdvertiser` that recycles the underlying `AsyncZeroconf` instance when the host's resolved IPv4 set actually changes, with `asyncio.Lock`-coordinated start / stop / `_reconfigure`, debounce against single-tick transients, transient-empty-address tolerance, and clean recovery from close-failure / register-failure / cancellation paths.
- **Firmware side** — `DiscoverStackchanGateway()` now surfaces candidates from every supported `_stackchan-mcp._tcp.local.` instance in one browse instead of only the first. Combined with the existing `websocket_protocol.cc` per-candidate fallback (5→30 s reconnect backoff), the device walks past stale renamed instances and reaches the fresh one within the existing per-candidate timeout window.

## Why a paired fix

The Issue body covers the full rationale. Briefly:

- The gateway-side fix uses `allow_name_change=True` (intentionally retained by #244), so a recycle after host-IP change can land under a renamed instance (`stackchan-mcp-2`).
- The old registration stays in the firmware's mDNS cache for the TTL window (RFC 6762 recommends 75 min for shared records).
- ESP-IDF `mdns_query_ptr()` does not guarantee result ordering; the firmware previously discarded all but the first matching instance via `break;`, so a stale-first ordering would lock the device on the old IP indefinitely.
- The firmware-side `mdns_query_ptr` retries (#245) and the `websocket_protocol.cc` per-candidate fallback already iterate over the candidates the discovery layer hands them. Surfacing all supported instances activates that existing machinery.

## Design review

Two rounds of adversarial design review by another model + five rounds of `codex review` on the implementation (final round clean). Each round's fixes land as a separate commit so the iteration is traceable:

- `721a57d` — initial implementation (gateway + firmware + tests + docs).
- `a1d04fe` — round 1 findings: (1) refresh loop must compare against the host-aware resolver (same one `build_advertisement` uses), not the full host-interface enumeration; otherwise a concrete-HOST gateway in a multi-NIC environment would churn the registration on every refresh tick. (2) Clear `_last_advertised_addresses` after the old close so a failed re-registration plus IP-revert still recovers on the next tick instead of locking out.
- `13799f0` — round 2 findings: (3) Move the `_last_advertised_addresses = None` assignment to *before* the close so even a close failure leaves the loop in a "must retry" state. (4) Widen `except Exception` to `except BaseException` in `_register_advertisement_locked` so an `asyncio.CancelledError` mid-registration still closes the partially-constructed `AsyncZeroconf`.
- `4aa41c2` — round 3 finding: ESP-IDF / newlib-nano does not handle `%zu` in `ESP_LOGI`; cast `size_t` to `unsigned int` and use `%u` to avoid a misaligned-argument crash on every successful mDNS discovery.
- `c346d8e` — round 4 finding (docs only): worst-case recovery latency is `2 × refresh_interval` (one polling interval to observe + one debounce-confirm interval), not `refresh_interval`. CHANGELOG wording fixed.

Round 5 returned clean.

## Out of scope (carved out separately)

- #278 — firmware-side cap on mDNS-derived candidate count (per-pass count or wall-clock cap). Future hardening for pathological flapping scenarios that accumulate many renamed instances during a single TTL window. The current paired fix is correct without this; #278 only matters once flapping starts compounding.
- #279 — firmware-side host-test infrastructure for pure C++ helpers (e.g. unit tests against `ExtractGatewayCandidatesFromMdnsResults`). This PR extracts the pure function so it becomes unit-testable later, but does not introduce a test runner / CI job in `firmware/`. The function is currently covered only by the existing `Firmware build` CI job (compile / link check) plus real-device flash + observation.

## Test plan

- [x] `gateway/tests/test_mdns_advertiser.py` — 33 pass (29 existing + 4 new; covers reconfigure / debounce / transient empty / register failure / close failure / cancellation / double-start / address ordering / interval validation / stop idempotency / concrete-HOST comparison).
- [x] `ruff check gateway` — clean for the touched files.
- [ ] `Firmware build` (CI) — Docker ESP-IDF v5.5.2 compile + link check for both boards.
- [ ] Real-device verification — flash on a CoreS3 + Stack-chan, induce a host-IP change (Wi-Fi switch on the gateway laptop) and observe that the device walks past the stale instance and reconnects within ~30–60 s without manual gateway restart.

## Related prior art

- #26 — original mDNS auto-discovery (landed via PR #229).
- #231 — non-LAN address de-prioritisation in the advertiser.
- #244 — `allow_name_change=True` retained intentionally for service-type-browse semantics; service-specific hostname avoids host-level mDNS conflict.
- #245 — firmware-side `mdns_query_ptr` retry hardening (5→30 s backoff, 3-attempt in-call retry, Wi-Fi PS toggle).

Closes #277.
