### PR TITLE
release: cut pair release firmware-v1.10.0 + v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-09
+
 ### Gateway
 
 - Add periodic IP-change detection to the mDNS advertiser; the gateway now
@@ -38,18 +40,9 @@ documented-only.
   Recovery latency is bounded by approximately `2 × refresh_interval` (one
   polling interval to observe the address change, plus one debounce-confirm
   interval before re-registering; default 30 s → worst case ~60 s).
-  Pair with Firmware vX.Y.Z+ for automatic device-side recovery — earlier
+  Pair with Firmware v1.10.0+ for automatic device-side recovery — earlier
   firmware versions may still get stuck on the stale mDNS instance until
   manual reboot. (#277)
-
-### Firmware
-
-- mDNS gateway discovery now considers all supported `_stackchan-mcp._tcp.local.`
-  service instances in one browse, not only the first. Combined with Gateway
-  vA.B.C+ mDNS IP refresh, the device recovers automatically from a gateway
-  host-IP change even while a stale mDNS instance is still in the cache. The
-  existing `websocket_protocol.cc` per-candidate fallback (5→30 s reconnect
-  backoff) handles the additional candidates. (#277)
 
 ### Examples
 
@@ -59,6 +52,17 @@ documented-only.
   authentication, deployment instructions, and a shared-secret
   rotation guide. The Worker uses only generally-available Cloudflare
   primitives (Workers WS API, Cloudflare Tunnel public hostnames).
+
+## [firmware-v1.10.0] - 2026-06-09
+
+### Firmware
+
+- mDNS gateway discovery now considers all supported `_stackchan-mcp._tcp.local.`
+  service instances in one browse, not only the first. Combined with Gateway
+  v0.10.0+ mDNS IP refresh, the device recovers automatically from a gateway
+  host-IP change even while a stale mDNS instance is still in the cache. The
+  existing `websocket_protocol.cc` per-candidate fallback (5→30 s reconnect
+  backoff) handles the additional candidates. (#277)
 
 ## [0.9.1] - 2026-06-08
 
@@ -1571,7 +1575,9 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.1...v0.10.0
+[firmware-v1.10.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.9.0...firmware-v1.10.0
 [0.9.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.8.0...v0.9.0
 [firmware-v1.9.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.8.0...firmware-v1.9.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.9.1"
+version = "0.10.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Pair release v0.10.0 + firmware-v1.10.0. Promotes the `[Unreleased]`
entries landed in main since v0.9.1 / firmware-v1.9.0:

- **Gateway v0.10.0** — periodic mDNS IP-change detection on the
  advertiser, so the gateway re-registers automatically when the
  host's primary IPv4 changes (DHCP / Wi-Fi switch / sleep/wake /
  dock/undock). Pairs with firmware v1.10.0+ for end-to-end
  auto-recovery. Landed via PR #280 (Closes #277).
- **Firmware v1.10.0** — mDNS discovery now considers all supported
  `_stackchan-mcp._tcp.local.` instances per browse, not only the
  first. Combined with gateway v0.10.0 IP refresh, the device walks
  past stale renamed mDNS instances and reconnects via the existing
  per-candidate 5→30 s backoff. Landed via PR #280 (Closes #277).
- **Examples** — `examples/cloudflare-relay/` Cloudflare Workers
  relay example landed (PR #276), grouped under the gateway release
  entry (PyPI-side wheel is unaffected; firmware bin is unaffected).

## Promotion details

- Promote `[Unreleased]` to `[0.10.0] - 2026-06-09` (Gateway +
  Examples) and `[firmware-v1.10.0] - 2026-06-09` (Firmware).
- Resolve placeholder version refs in the release notes
  ("Firmware vX.Y.Z+" -> "v1.10.0+", "Gateway vA.B.C+" -> "v0.10.0+").
- Add compare links for `[0.10.0]` and `[firmware-v1.10.0]`; advance
  `[Unreleased]` base to v0.10.0.
- Bump `gateway/pyproject.toml` version 0.9.1 -> 0.10.0.

## Pre-flight 4 checks (per release-flow conventions)

1. release-blocker / verify Issues — none
2. Parallel concurrent release-prep sessions — none
3. priority/medium-or-higher bug Open — none touching the release
   paths (gateway mDNS advertiser, firmware mDNS discovery)
4. CHANGELOG `[Unreleased]` vs git log — both `gateway/` and
   `firmware/` diff is the same single commit (PR #280), all three
   subsections (Gateway / Firmware / Examples) accounted for, no
   gaps

## Test plan

- [x] CHANGELOG promotion produces well-formed Keep a Changelog
      entries and consistent compare links
- [x] `gateway/pyproject.toml` version matches the new tag (v0.10.0)
- [ ] After merge: push `firmware-v1.10.0` tag — `firmware-release.yml`
      builds ESP-IDF firmware (Docker `espressif/idf:v5.5.2`) + uploads
      release assets (merged-binary.bin / xiaozhi.bin / zip)
- [ ] After firmware release: push `v0.10.0` tag — Trusted Publishing
      uploads stackchan-mcp 0.10.0 to PyPI
- [ ] GitHub Release notes for both tags hand-edited from the new
      CHANGELOG entries
