### PR TITLE
fix(gateway): sync uv.lock with v0.10.0 pyproject.toml version

### DIFF
--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2018,7 +2018,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

`gateway/uv.lock` sync fix for the v0.10.0 publish.

The v0.10.0 release commit (#281) bumped `gateway/pyproject.toml`
from `0.9.1` to `0.10.0` but did not include the corresponding
`gateway/uv.lock` update. The `publish.yml` `uv lock --check`
gate caught the drift on the `v0.10.0` tag push:

```
The lockfile at `uv.lock` needs to be updated, but `--check` was
provided. To update the lockfile, run `uv lock`.
```

As a result, v0.10.0 did not reach PyPI and no GitHub Release was
auto-created. The paired `firmware-v1.10.0` release landed cleanly
(build + Release + notes all green).

## Fix

- Re-run `uv lock` against the bumped `pyproject.toml`.
- Stage the resulting `gateway/uv.lock`.
- Diff is restricted to the `stackchan-mcp` package version line
  (`"0.9.1"` -> `"0.10.0"`); no transitive dependency changes
  (`Resolved 83 packages in 334ms / Updated stackchan-mcp v0.9.1 -> v0.10.0`).

## Follow-up after merge

1. Delete the existing `v0.10.0` tag (local + remote) — it points
   at the release commit that omitted the lockfile and never
   reached PyPI / GitHub Release.
2. Re-tag `v0.10.0` on the merge commit of this PR.
3. Push the new tag to trigger `publish.yml` again.
4. Upload `v0.10.0` Release notes once the Release is auto-created.

## Why a fresh `v0.10.0` instead of `v0.10.1`

- `v0.10.0` never reached PyPI, so there is no published artifact
  to supersede.
- The paired `firmware-v1.10.0` release already references
  `v0.10.0` in its release notes; re-cutting the same version
  keeps the pair-release naming consistent.

## Test plan

- [x] `uv lock` runs cleanly against the bumped `pyproject.toml`
- [x] Diff in `gateway/uv.lock` is limited to the package version
      line
- [ ] After merge + tag re-push, `publish.yml` passes the
      `uv lock --check` gate and the rest of the publish job
- [ ] PyPI receives `stackchan-mcp 0.10.0`
- [ ] GitHub Release `v0.10.0` is auto-created
- [ ] `v0.10.0` Release notes uploaded
