### PR TITLE
feat(gateway): #253 verify process start time in stale-lock detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Harden ownership lock stale detection by recording and verifying the
+  owning process start time, preventing recycled PIDs from being treated
+  as the original live gateway. (#253)
+
 ### Firmware
 
 - Added standalone CMake host-test infrastructure for firmware pure C++ helpers,

--- a/gateway/stackchan_mcp/ownership.py
+++ b/gateway/stackchan_mcp/ownership.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import socket
+import subprocess
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -13,6 +15,8 @@ from typing import Literal, TypedDict
 
 LOCK_DIR = Path.home() / ".stackchan-mcp"
 LOCK_PATH = LOCK_DIR / "owner.lock"
+PROC_START_TOLERANCE_SECONDS = 2.0
+_PROC_ROOT = Path("/proc")
 
 
 LockMode = Literal["stdio", "streamable-http"]
@@ -29,6 +33,7 @@ class LockInfo(_BaseLockInfo, total=False):
     mode: LockMode
     http_endpoint: str | None
     started_by: str | None
+    proc_start_epoch: float
 
 
 class OwnershipError(RuntimeError):
@@ -63,6 +68,101 @@ def is_pid_alive(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def get_process_start_time(pid: int) -> float | None:
+    """Return the kernel-reported process start time as epoch seconds.
+
+    Supported on Linux (``/proc``) and macOS (``ps lstart``). On other
+    platforms — notably Windows — this returns ``None``, so the identity
+    check is skipped and stale-lock detection falls back to the PID-only
+    liveness check (the pre-#253 behavior). Windows process-identity
+    verification is deferred per Issue #253's acceptance criteria.
+    """
+    if pid <= 0:
+        return None
+    if sys.platform.startswith("linux"):
+        return _get_process_start_time_linux(pid)
+    if sys.platform == "darwin":
+        return _get_process_start_time_macos(pid)
+    return None
+
+
+def _get_process_start_time_linux(pid: int) -> float | None:
+    try:
+        stat_text = (_PROC_ROOT / str(pid) / "stat").read_text(encoding="utf-8")
+        proc_stat_text = (_PROC_ROOT / "stat").read_text(encoding="utf-8")
+        ticks_per_second = os.sysconf("SC_CLK_TCK")
+    except (OSError, ValueError):
+        return None
+
+    if not isinstance(ticks_per_second, int) or ticks_per_second <= 0:
+        return None
+
+    try:
+        after_comm = stat_text.rsplit(")", 1)[1].strip()
+        fields = after_comm.split()
+        start_ticks = int(fields[19])
+    except (IndexError, ValueError):
+        return None
+
+    boot_time: int | None = None
+    for line in proc_stat_text.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[0] == "btime":
+            try:
+                boot_time = int(parts[1])
+            except ValueError:
+                return None
+            break
+    if boot_time is None:
+        return None
+
+    return float(boot_time) + (float(start_ticks) / float(ticks_per_second))
+
+
+def _get_process_start_time_macos(pid: int) -> float | None:
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            check=False,
+            env=env,
+            text=True,
+        )
+    except OSError:
+        return None
+
+    output = result.stdout.strip()
+    if not output:
+        return None
+
+    line = output.splitlines()[0].strip()
+    try:
+        started = datetime.strptime(line, "%a %b %d %H:%M:%S %Y")
+    except ValueError:
+        return None
+    return started.timestamp()
+
+
+def _coerce_proc_start_epoch(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    proc_start_epoch = float(value)
+    if not math.isfinite(proc_start_epoch):
+        return None
+    return proc_start_epoch
+
+
+def _process_identity_matches(pid: int, expected_start: float | None) -> bool:
+    if expected_start is None:
+        return True
+    actual_start = get_process_start_time(pid)
+    if actual_start is None:
+        return True
+    return abs(actual_start - expected_start) <= PROC_START_TOLERANCE_SECONDS
 
 
 def _is_pid_alive_windows(pid: int) -> bool:
@@ -152,6 +252,11 @@ def read_lock(path: Path = LOCK_PATH) -> LockInfo | None:
         if started_by is None or isinstance(started_by, str):
             info["started_by"] = started_by
 
+    if "proc_start_epoch" in raw:
+        proc_start_epoch = _coerce_proc_start_epoch(raw["proc_start_epoch"])
+        if proc_start_epoch is not None:
+            info["proc_start_epoch"] = proc_start_epoch
+
     return info
 
 
@@ -178,10 +283,11 @@ def acquire_lock(
 ) -> LockInfo:
     """Acquire the ownership lock. Raise OwnershipError on refuse.
 
-    The default stdio-mode call writes the original #177 lock shape so
-    older lock readers and ``stackchan-mcp --check`` output remain
-    compatible. Daemon transports can attach optional metadata for
-    diagnostics without changing the atomic hardlink claim.
+    The default stdio-mode call writes the original #177 lock base fields
+    plus additive process identity metadata. Older lock readers remain
+    compatible because the new field is optional JSON. Daemon transports
+    can attach optional metadata for diagnostics without changing the
+    atomic hardlink claim.
     """
     if mode not in ("stdio", "streamable-http"):
         raise ValueError(f"unsupported lock mode: {mode!r}")
@@ -195,25 +301,39 @@ def acquire_lock(
         existing = read_lock(path)
         if existing is not None:
             if is_pid_alive(existing["pid"]):
-                raise OwnershipError(
-                    "stackchan-mcp: device already owned by "
-                    f"{existing['owner_id']} "
-                    f"(pid {existing['pid']}, since {existing['start_ts']})"
+                if _process_identity_matches(
+                    existing["pid"], existing.get("proc_start_epoch")
+                ):
+                    raise OwnershipError(
+                        "stackchan-mcp: device already owned by "
+                        f"{existing['owner_id']} "
+                        f"(pid {existing['pid']}, since {existing['start_ts']})"
+                    )
+                print(
+                    "stackchan-mcp: removed stale lock from recycled pid "
+                    f"{existing['pid']}",
+                    file=sys.stderr,
                 )
-            print(
-                f"stackchan-mcp: removed stale lock from dead pid {existing['pid']}",
-                file=sys.stderr,
-            )
+            else:
+                print(
+                    "stackchan-mcp: removed stale lock from dead pid "
+                    f"{existing['pid']}",
+                    file=sys.stderr,
+                )
             path.unlink(missing_ok=True)
         elif path.exists():
             path.unlink()
 
+        pid = os.getpid()
+        proc_start_epoch = get_process_start_time(pid)
         info: LockInfo = {
             "owner_id": owner_id,
-            "pid": os.getpid(),
+            "pid": pid,
             "start_ts": _now_iso(),
             "host": socket.gethostname(),
         }
+        if proc_start_epoch is not None:
+            info["proc_start_epoch"] = proc_start_epoch
         if mode != "stdio":
             info["mode"] = mode
         if http_endpoint is not None:
@@ -246,8 +366,9 @@ def release_lock_if_owner(info: LockInfo, path: Path = LOCK_PATH) -> bool:
     """Remove the lock file only if it still belongs to ``info``.
 
     Returns ``True`` if the lock was removed, ``False`` if the on-disk
-    lock has a different ``owner_id`` / ``pid`` / ``start_ts`` or no
-    longer exists. This is the owner-scoped counterpart to
+    lock has a different ``owner_id`` / ``pid`` / ``start_ts`` /
+    ``proc_start_epoch`` or no longer exists. This is the owner-scoped
+    counterpart to
     :func:`release_lock` and is intended for cleanup paths (``finally``
     blocks, ``atexit.register``) where the caller may have lost ownership
     between claim and cleanup — for example after the gateway exited and
@@ -261,6 +382,12 @@ def release_lock_if_owner(info: LockInfo, path: Path = LOCK_PATH) -> bool:
         existing.get("owner_id") != info.get("owner_id")
         or existing.get("pid") != info.get("pid")
         or existing.get("start_ts") != info.get("start_ts")
+    ):
+        return False
+    if (
+        "proc_start_epoch" in existing
+        and "proc_start_epoch" in info
+        and existing["proc_start_epoch"] != info["proc_start_epoch"]
     ):
         return False
     try:

--- a/gateway/tests/test_ownership.py
+++ b/gateway/tests/test_ownership.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime
 from pathlib import Path
 
 import pytest
 
+from stackchan_mcp import ownership as ownership_module
 from stackchan_mcp.ownership import (
     OwnershipError,
     acquire_lock,
     generate_owner_id,
+    get_process_start_time,
     is_pid_alive,
     read_lock,
     release_lock,
+    release_lock_if_owner,
 )
 
 
@@ -30,6 +34,20 @@ def test_acquire_when_no_lock_succeeds(lock_path: Path) -> None:
     assert lock_path.exists()
     data = json.loads(lock_path.read_text(encoding="utf-8"))
     assert data["owner_id"] == "test-owner-1"
+
+
+def test_acquire_writes_proc_start_epoch_when_available(
+    monkeypatch: pytest.MonkeyPatch, lock_path: Path
+) -> None:
+    monkeypatch.setattr(
+        ownership_module, "get_process_start_time", lambda pid: 1234.5
+    )
+
+    info = acquire_lock("test-owner-1", lock_path)
+
+    assert info["proc_start_epoch"] == 1234.5
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert data["proc_start_epoch"] == 1234.5
 
 
 def test_acquire_when_live_lock_refuses(lock_path: Path) -> None:
@@ -57,6 +75,121 @@ def test_acquire_when_stale_lock_overwrites(lock_path: Path) -> None:
     assert data["owner_id"] == "new-owner"
 
 
+def test_acquire_when_live_pid_has_wrong_proc_start_overwrites(
+    monkeypatch: pytest.MonkeyPatch, lock_path: Path
+) -> None:
+    live_pid = 4242
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "recycled-owner",
+                "pid": live_pid,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 1000.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ownership_module, "is_pid_alive", lambda pid: True)
+
+    def fake_start_time(pid: int) -> float | None:
+        if pid == live_pid:
+            return 2000.0
+        if pid == os.getpid():
+            return 3000.0
+        return None
+
+    monkeypatch.setattr(
+        ownership_module, "get_process_start_time", fake_start_time
+    )
+
+    info = acquire_lock("new-owner", lock_path)
+
+    assert info["owner_id"] == "new-owner"
+    assert info["proc_start_epoch"] == 3000.0
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert data["owner_id"] == "new-owner"
+
+
+def test_acquire_when_live_pid_has_matching_proc_start_refuses(
+    monkeypatch: pytest.MonkeyPatch, lock_path: Path
+) -> None:
+    live_pid = 4242
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "live-owner",
+                "pid": live_pid,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 1000.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ownership_module, "is_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        ownership_module,
+        "get_process_start_time",
+        lambda pid: 1001.5 if pid == live_pid else None,
+    )
+
+    with pytest.raises(OwnershipError, match="already owned by live-owner"):
+        acquire_lock("new-owner", lock_path)
+
+
+def test_acquire_when_old_schema_live_lock_refuses_without_start_check(
+    monkeypatch: pytest.MonkeyPatch, lock_path: Path
+) -> None:
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "old-owner",
+                "pid": 4242,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ownership_module, "is_pid_alive", lambda pid: True)
+
+    def fail_start_time(pid: int) -> float | None:
+        pytest.fail("old-schema locks must fall back to PID-only checks")
+
+    monkeypatch.setattr(
+        ownership_module, "get_process_start_time", fail_start_time
+    )
+
+    with pytest.raises(OwnershipError, match="already owned by old-owner"):
+        acquire_lock("new-owner", lock_path)
+
+
+def test_acquire_when_proc_start_cannot_be_verified_refuses(
+    monkeypatch: pytest.MonkeyPatch, lock_path: Path
+) -> None:
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "unverified-owner",
+                "pid": 4242,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 1000.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ownership_module, "is_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        ownership_module, "get_process_start_time", lambda pid: None
+    )
+
+    with pytest.raises(OwnershipError, match="already owned by unverified-owner"):
+        acquire_lock("new-owner", lock_path)
+
+
 def test_release_is_idempotent(lock_path: Path) -> None:
     acquire_lock("owner", lock_path)
     release_lock(lock_path)
@@ -64,8 +197,109 @@ def test_release_is_idempotent(lock_path: Path) -> None:
     release_lock(lock_path)
 
 
+def test_release_if_owner_compares_proc_start_when_both_have_it(
+    lock_path: Path,
+) -> None:
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "owner",
+                "pid": 123,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 1000.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        release_lock_if_owner(
+            {
+                "owner_id": "owner",
+                "pid": 123,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 2000.0,
+            },
+            lock_path,
+        )
+        is False
+    )
+    assert lock_path.exists()
+
+
+def test_release_if_owner_falls_back_when_proc_start_missing(
+    lock_path: Path,
+) -> None:
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "owner",
+                "pid": 123,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        release_lock_if_owner(
+            {
+                "owner_id": "owner",
+                "pid": 123,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 2000.0,
+            },
+            lock_path,
+        )
+        is True
+    )
+    assert not lock_path.exists()
+
+
 def test_read_lock_returns_none_when_missing(lock_path: Path) -> None:
     assert read_lock(lock_path) is None
+
+
+def test_read_lock_parses_proc_start_epoch(lock_path: Path) -> None:
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "owner",
+                "pid": 123,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": 1000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    info = read_lock(lock_path)
+
+    assert info is not None
+    assert info["proc_start_epoch"] == 1000.0
+
+
+def test_read_lock_ignores_invalid_proc_start_epoch(lock_path: Path) -> None:
+    lock_path.write_text(
+        json.dumps(
+            {
+                "owner_id": "owner",
+                "pid": 123,
+                "start_ts": "2000-01-01T00:00:00Z",
+                "host": "test-host",
+                "proc_start_epoch": "invalid",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    info = read_lock(lock_path)
+
+    assert info is not None
+    assert "proc_start_epoch" not in info
 
 
 def test_is_pid_alive_for_self_returns_true() -> None:
@@ -74,6 +308,114 @@ def test_is_pid_alive_for_self_returns_true() -> None:
 
 def test_is_pid_alive_for_dead_pid_returns_false() -> None:
     assert is_pid_alive(999999) is False
+
+
+def test_get_process_start_time_linux_reads_proc_stat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc_root = tmp_path / "proc"
+    pid_dir = proc_root / "123"
+    pid_dir.mkdir(parents=True)
+    stat_fields_after_comm = [
+        "S",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+        "250",
+    ]
+    (pid_dir / "stat").write_text(
+        f"123 (name with spaces) {' '.join(stat_fields_after_comm)}",
+        encoding="utf-8",
+    )
+    (proc_root / "stat").write_text(
+        "cpu  1 2 3 4\nbtime 1700000000\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ownership_module.sys, "platform", "linux")
+    monkeypatch.setattr(ownership_module, "_PROC_ROOT", proc_root)
+    monkeypatch.setattr(ownership_module.os, "sysconf", lambda name: 100)
+
+    assert get_process_start_time(123) == 1700000002.5
+
+
+def test_get_process_start_time_linux_handles_comm_with_parens(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc_root = tmp_path / "proc"
+    pid_dir = proc_root / "123"
+    pid_dir.mkdir(parents=True)
+    fields = ["S", *[str(index) for index in range(1, 19)], "300"]
+    (pid_dir / "stat").write_text(
+        f"123 (name ) with parens) {' '.join(fields)}",
+        encoding="utf-8",
+    )
+    (proc_root / "stat").write_text("btime 1700000000\n", encoding="utf-8")
+    monkeypatch.setattr(ownership_module.sys, "platform", "linux")
+    monkeypatch.setattr(ownership_module, "_PROC_ROOT", proc_root)
+    monkeypatch.setattr(ownership_module.os, "sysconf", lambda name: 100)
+
+    assert get_process_start_time(123) == 1700000003.0
+
+
+def test_get_process_start_time_macos_reads_lstart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Result:
+        stdout = "Thu Jun 11 12:34:56 2026\n"
+
+    def fake_run(
+        args: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        env: dict[str, str],
+        text: bool,
+    ) -> Result:
+        assert args == ["ps", "-o", "lstart=", "-p", "123"]
+        assert capture_output is True
+        assert check is False
+        assert env["LC_ALL"] == "C"
+        assert text is True
+        return Result()
+
+    monkeypatch.setattr(ownership_module.sys, "platform", "darwin")
+    monkeypatch.setattr(ownership_module.subprocess, "run", fake_run)
+
+    expected = datetime.strptime(
+        "Thu Jun 11 12:34:56 2026", "%a %b %d %H:%M:%S %Y"
+    ).timestamp()
+    assert get_process_start_time(123) == expected
+
+
+def test_get_process_start_time_macos_empty_output_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Result:
+        stdout = "\n"
+
+    monkeypatch.setattr(ownership_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        ownership_module.subprocess,
+        "run",
+        lambda *args, **kwargs: Result(),
+    )
+
+    assert get_process_start_time(123) is None
 
 
 def test_generate_owner_id_uses_env_when_set(


### PR DESCRIPTION
## Summary

Hardens the gateway ownership lock against PID-recycling false positives. The stale-lock check previously relied on `is_pid_alive(pid)` alone: if a crashed gateway's PID was later recycled by an unrelated long-lived process, the lock was reported as live and subsequent gateway startups refused with a misleading "already owned" message until the lock file was deleted manually.

The lock now records the owning process's kernel-reported start time (`proc_start_epoch`, epoch seconds) and verifies it during stale-lock detection. A live PID whose start time does not match the recorded one (±2.0 s tolerance) is treated as a recycled PID, and the stale lock is taken over exactly like the existing dead-PID path.

## What changed

- `gateway/stackchan_mcp/ownership.py`
  - New `proc_start_epoch` optional field on `LockInfo` (additive JSON — locks remain parseable by older readers).
  - New `get_process_start_time(pid)` helper, stdlib-only: Linux reads `/proc/<pid>/stat` (field 22) + `btime` + `SC_CLK_TCK`; macOS parses `ps -o lstart=` under `LC_ALL=C`; other platforms return `None`.
  - `acquire_lock` verifies process identity before refusing; mismatch → stale takeover with a `removed stale lock from recycled pid` notice.
  - `release_lock_if_owner` includes `proc_start_epoch` in the identity comparison when both sides have it.
  - All unverifiable cases (old-schema locks, unsupported platform, unreadable start time) conservatively fall back to the pre-existing PID-only liveness check.
- `gateway/tests/test_ownership.py`: 13 new tests — recycled-PID takeover, matching-identity refuse, old-schema fallback, tolerant parsing, and platform-helper units (Linux `/proc` path incl. parens-in-comm, macOS `lstart` path) via monkeypatching, so the full decision logic runs on any host.
- `CHANGELOG.md`: `[Unreleased]` → `### Gateway` entry.

## Verification

- `uv run pytest` — 482 passed, 5 skipped (skips are pre-existing optional-dependency guards).
- `uv run ruff check .` — clean.
- No regression in the #177 ownership test set.

## Known limitations

- Windows process-identity verification is deferred, per the issue's acceptance criteria (the platform helper returns `None`, preserving the pre-#253 PID-only behavior there). Surfaced by pre-PR review; the behavior boundary is documented in the helper's docstring. A `GetProcessTimes`-based implementation needs a Windows CI runner to be testable, which is tracked separately in the issue.
- `boot_id` (Linux) is not part of this MVP; the schema can gain it later if start-time-only proves insufficient in the field.

## Refs

Closes #253.
