### PR TITLE
feat(firmware): #279 host-test infrastructure for pure C++ helpers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,23 @@ jobs:
             firmware/build/merged-binary.bin
             firmware/releases/v2.2.6_stackchan.zip
 
+  firmware-host-test:
+    name: Firmware host test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure firmware host tests
+        run: cmake -S firmware/host_test -B /tmp/firmware-host-test-build
+
+      - name: Build firmware host tests
+        run: cmake --build /tmp/firmware-host-test-build
+
+      - name: Run firmware host tests
+        run: ctest --test-dir /tmp/firmware-host-test-build --output-on-failure
+
   gateway-test:
     name: Gateway test
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ documented-only.
 
 ## [Unreleased]
 
+### Firmware
+
+- Added standalone CMake host-test infrastructure for firmware pure C++ helpers,
+  covering mDNS gateway candidate extraction edge cases. (#279)
+
 ## [0.10.0] - 2026-06-09
 
 ### Gateway

--- a/firmware/host_test/CMakeLists.txt
+++ b/firmware/host_test/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(stackchan_firmware_host_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.17.0
+)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+add_executable(mdns_candidate_extract_test
+    test_mdns_candidate_extract.cc
+    ../main/protocols/mdns_candidate_extract.cc
+)
+
+target_compile_definitions(mdns_candidate_extract_test
+    PRIVATE STACKCHAN_MDNS_HOST_TEST
+)
+
+target_include_directories(mdns_candidate_extract_test
+    PRIVATE
+        stubs
+        ../main/protocols
+)
+
+target_link_libraries(mdns_candidate_extract_test
+    PRIVATE GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(mdns_candidate_extract_test)

--- a/firmware/host_test/stubs/esp_netif_ip_addr.h
+++ b/firmware/host_test/stubs/esp_netif_ip_addr.h
@@ -1,0 +1,47 @@
+#ifndef STACKCHAN_HOST_TEST_ESP_NETIF_IP_ADDR_H_
+#define STACKCHAN_HOST_TEST_ESP_NETIF_IP_ADDR_H_
+
+// Minimal ESP-IDF v5.5.2 esp_netif_ip_addr.h stub for host tests.
+// Mirrors only fields/macros used by protocols/mdns_candidate_extract.cc.
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ESP_IPADDR_TYPE_V4 = 0,
+    ESP_IPADDR_TYPE_V6 = 6,
+    ESP_IPADDR_TYPE_ANY = 46,
+} esp_ip_addr_type_t;
+
+typedef struct esp_ip4_addr {
+    uint32_t addr;
+} esp_ip4_addr_t;
+
+typedef struct esp_ip6_addr {
+    uint32_t addr[4];
+    uint8_t zone;
+} esp_ip6_addr_t;
+
+typedef struct esp_ip_addr {
+    union {
+        esp_ip6_addr_t ip6;
+        esp_ip4_addr_t ip4;
+    } u_addr;
+    esp_ip_addr_type_t type;
+} esp_ip_addr_t;
+
+#define IPSTR "%d.%d.%d.%d"
+#define IP2STR(ipaddr)                           \
+    (int)((((ipaddr)->addr) >> 24) & 0xff),      \
+        (int)((((ipaddr)->addr) >> 16) & 0xff),  \
+        (int)((((ipaddr)->addr) >> 8) & 0xff),   \
+        (int)(((ipaddr)->addr) & 0xff)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STACKCHAN_HOST_TEST_ESP_NETIF_IP_ADDR_H_

--- a/firmware/host_test/stubs/mdns.h
+++ b/firmware/host_test/stubs/mdns.h
@@ -1,0 +1,41 @@
+#ifndef STACKCHAN_HOST_TEST_MDNS_H_
+#define STACKCHAN_HOST_TEST_MDNS_H_
+
+// Minimal ESP-IDF v5.5.2 mdns.h stub for host tests.
+// Mirrors only fields used by protocols/mdns_candidate_extract.cc.
+
+#include "esp_netif_ip_addr.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mdns_txt_item {
+    const char* key;
+    const char* value;
+} mdns_txt_item_t;
+
+typedef struct mdns_ip_addr {
+    esp_ip_addr_t addr;
+    struct mdns_ip_addr* next;
+} mdns_ip_addr_t;
+
+typedef struct mdns_result {
+    struct mdns_result* next;
+    const char* instance_name;
+    const char* hostname;
+    uint16_t port;
+    mdns_txt_item_t* txt;
+    size_t txt_count;
+    uint8_t* txt_value_len;
+    mdns_ip_addr_t* addr;
+} mdns_result_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STACKCHAN_HOST_TEST_MDNS_H_

--- a/firmware/host_test/test_mdns_candidate_extract.cc
+++ b/firmware/host_test/test_mdns_candidate_extract.cc
@@ -1,0 +1,217 @@
+#include "mdns_candidate_extract.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+using stackchan::mdns::CountResults;
+using stackchan::mdns::ExtractGatewayCandidatesFromMdnsResults;
+
+esp_ip_addr_t Ipv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+    esp_ip_addr_t ip{};
+    ip.type = ESP_IPADDR_TYPE_V4;
+    ip.u_addr.ip4.addr = (static_cast<uint32_t>(a) << 24) |
+                         (static_cast<uint32_t>(b) << 16) |
+                         (static_cast<uint32_t>(c) << 8) |
+                         static_cast<uint32_t>(d);
+    return ip;
+}
+
+esp_ip_addr_t Ipv6() {
+    esp_ip_addr_t ip{};
+    ip.type = ESP_IPADDR_TYPE_V6;
+    return ip;
+}
+
+mdns_ip_addr_t MdnsAddress(const esp_ip_addr_t& ip, mdns_ip_addr_t* next = nullptr) {
+    mdns_ip_addr_t address{};
+    address.addr = ip;
+    address.next = next;
+    return address;
+}
+
+mdns_result_t MdnsResult(const char* instance_name,
+                         const char* hostname,
+                         uint16_t port,
+                         mdns_ip_addr_t* address,
+                         mdns_txt_item_t* txt = nullptr,
+                         size_t txt_count = 0,
+                         uint8_t* txt_value_len = nullptr,
+                         mdns_result_t* next = nullptr) {
+    mdns_result_t result{};
+    result.next = next;
+    result.instance_name = instance_name;
+    result.hostname = hostname;
+    result.port = port;
+    result.txt = txt;
+    result.txt_count = txt_count;
+    result.txt_value_len = txt_value_len;
+    result.addr = address;
+    return result;
+}
+
+std::vector<std::string> CandidateUrls(const std::vector<MdnsGatewayCandidate>& candidates) {
+    std::vector<std::string> urls;
+    for (const auto& candidate : candidates) {
+        urls.push_back(candidate.url);
+    }
+    return urls;
+}
+
+std::vector<std::string> CandidatePaths(const std::vector<MdnsGatewayCandidate>& candidates) {
+    std::vector<std::string> paths;
+    for (const auto& candidate : candidates) {
+        paths.push_back(candidate.path);
+    }
+    return paths;
+}
+
+TEST(MdnsCandidateExtractTest, AccumulatesCandidatesFromMultipleInstances) {
+    mdns_txt_item_t txt_one[] = {{"version", "1"}, {"path", "/one"}};
+    uint8_t txt_one_lengths[] = {1, 4};
+    auto addr_one = MdnsAddress(Ipv4(192, 168, 0, 10));
+    auto result_one = MdnsResult("gateway-one", "host-one", 8765, &addr_one,
+                                 txt_one, 2, txt_one_lengths);
+
+    mdns_txt_item_t txt_two[] = {{"version", "1"}, {"path", "/two"}};
+    uint8_t txt_two_lengths[] = {1, 4};
+    auto addr_two = MdnsAddress(Ipv4(192, 168, 0, 11));
+    auto result_two = MdnsResult("gateway-two", "host-two", 8766, &addr_two,
+                                 txt_two, 2, txt_two_lengths);
+    result_one.next = &result_two;
+
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(&result_one,
+                                                             CountResults(&result_one));
+
+    EXPECT_EQ(extracted.accepted_instances, 2);
+    ASSERT_EQ(extracted.candidates.size(), 2U);
+    EXPECT_EQ(extracted.candidates[0].instance_name, "gateway-one");
+    EXPECT_EQ(extracted.candidates[1].instance_name, "gateway-two");
+    EXPECT_EQ(CandidateUrls(extracted.candidates),
+              (std::vector<std::string>{
+                  "ws://192.168.0.10:8765/one",
+                  "ws://192.168.0.11:8766/two",
+              }));
+}
+
+TEST(MdnsCandidateExtractTest, SkipsUnsupportedTxtVersion) {
+    mdns_txt_item_t txt[] = {{"version", "2"}};
+    uint8_t txt_lengths[] = {1};
+    auto address = MdnsAddress(Ipv4(192, 168, 0, 20));
+    auto result = MdnsResult("gateway", "host", 8765, &address, txt, 1, txt_lengths);
+
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(&result, CountResults(&result));
+
+    EXPECT_EQ(extracted.accepted_instances, 0);
+    EXPECT_TRUE(extracted.candidates.empty());
+}
+
+TEST(MdnsCandidateExtractTest, SkipsZeroPort) {
+    mdns_txt_item_t txt[] = {{"version", "1"}};
+    uint8_t txt_lengths[] = {1};
+    auto address = MdnsAddress(Ipv4(192, 168, 0, 30));
+    auto result = MdnsResult("gateway", "host", 0, &address, txt, 1, txt_lengths);
+
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(&result, CountResults(&result));
+
+    EXPECT_EQ(extracted.accepted_instances, 0);
+    EXPECT_TRUE(extracted.candidates.empty());
+}
+
+TEST(MdnsCandidateExtractTest, SkipsIpv6OnlyResult) {
+    auto address = MdnsAddress(Ipv6());
+    auto result = MdnsResult("gateway", "host", 8765, &address);
+
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(&result, CountResults(&result));
+
+    EXPECT_EQ(extracted.accepted_instances, 0);
+    EXPECT_TRUE(extracted.candidates.empty());
+}
+
+TEST(MdnsCandidateExtractTest, NormalizesPathTxtForms) {
+    auto addr_missing = MdnsAddress(Ipv4(192, 168, 1, 10));
+    mdns_txt_item_t txt_empty[] = {{"path", ""}};
+    uint8_t txt_empty_lengths[] = {0};
+    auto addr_empty = MdnsAddress(Ipv4(192, 168, 1, 11));
+    auto result_empty = MdnsResult("empty", "host-empty", 8765, &addr_empty,
+                                   txt_empty, 1, txt_empty_lengths);
+
+    mdns_txt_item_t txt_relative[] = {{"path", "api"}};
+    uint8_t txt_relative_lengths[] = {3};
+    auto addr_relative = MdnsAddress(Ipv4(192, 168, 1, 12));
+    auto result_relative = MdnsResult("relative", "host-relative", 8765, &addr_relative,
+                                      txt_relative, 1, txt_relative_lengths);
+
+    mdns_txt_item_t txt_root[] = {{"path", "/"}};
+    uint8_t txt_root_lengths[] = {1};
+    auto addr_root = MdnsAddress(Ipv4(192, 168, 1, 13));
+    auto result_root = MdnsResult("root", "host-root", 8765, &addr_root,
+                                  txt_root, 1, txt_root_lengths);
+
+    mdns_txt_item_t txt_nested[] = {{"path", "/api/v1"}};
+    uint8_t txt_nested_lengths[] = {7};
+    auto addr_nested = MdnsAddress(Ipv4(192, 168, 1, 14));
+    auto result_nested = MdnsResult("nested", "host-nested", 8765, &addr_nested,
+                                    txt_nested, 1, txt_nested_lengths);
+
+    auto result_missing = MdnsResult("missing", "host-missing", 8765, &addr_missing);
+    result_missing.next = &result_empty;
+    result_empty.next = &result_relative;
+    result_relative.next = &result_root;
+    result_root.next = &result_nested;
+
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(&result_missing,
+                                                             CountResults(&result_missing));
+
+    EXPECT_EQ(extracted.accepted_instances, 5);
+    ASSERT_EQ(extracted.candidates.size(), 5U);
+    EXPECT_EQ(CandidatePaths(extracted.candidates),
+              (std::vector<std::string>{"/", "/", "/api", "/", "/api/v1"}));
+    EXPECT_EQ(CandidateUrls(extracted.candidates),
+              (std::vector<std::string>{
+                  "ws://192.168.1.10:8765/",
+                  "ws://192.168.1.11:8765/",
+                  "ws://192.168.1.12:8765/api",
+                  "ws://192.168.1.13:8765/",
+                  "ws://192.168.1.14:8765/api/v1",
+              }));
+}
+
+TEST(MdnsCandidateExtractTest, PropagatesRawResultCountAndAcceptedInstanceCountSeparately) {
+    auto secondary_address = MdnsAddress(Ipv4(192, 168, 2, 11));
+    auto primary_address = MdnsAddress(Ipv4(192, 168, 2, 10), &secondary_address);
+    auto accepted_one = MdnsResult("accepted-one", "host-one", 8765, &primary_address);
+
+    mdns_txt_item_t skipped_txt[] = {{"version", "2"}};
+    uint8_t skipped_txt_lengths[] = {1};
+    auto skipped_address = MdnsAddress(Ipv4(192, 168, 2, 12));
+    auto skipped = MdnsResult("skipped", "host-skipped", 8765, &skipped_address,
+                              skipped_txt, 1, skipped_txt_lengths);
+
+    auto accepted_two_address = MdnsAddress(Ipv4(192, 168, 2, 13));
+    auto accepted_two = MdnsResult("accepted-two", "host-two", 8766, &accepted_two_address);
+    accepted_one.next = &skipped;
+    skipped.next = &accepted_two;
+
+    auto extracted = ExtractGatewayCandidatesFromMdnsResults(&accepted_one,
+                                                             CountResults(&accepted_one));
+
+    EXPECT_EQ(CountResults(&accepted_one), 3);
+    EXPECT_EQ(extracted.accepted_instances, 2);
+    ASSERT_EQ(extracted.candidates.size(), 3U);
+    for (const auto& candidate : extracted.candidates) {
+        EXPECT_EQ(candidate.result_count, 3);
+    }
+    EXPECT_EQ(CandidateUrls(extracted.candidates),
+              (std::vector<std::string>{
+                  "ws://192.168.2.10:8765/",
+                  "ws://192.168.2.11:8765/",
+                  "ws://192.168.2.13:8766/",
+              }));
+}
+
+}  // namespace

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1025,6 +1025,7 @@ if(CONFIG_BOARD_TYPE_ESP_VOCAT)
     )
 endif()
 if(CONFIG_STACKCHAN_MDNS_DISCOVERY)
+    list(APPEND SOURCES "protocols/mdns_candidate_extract.cc")
     list(APPEND MAIN_PRIV_REQUIRES_EXTRA espressif__mdns)
 endif()
 

--- a/firmware/main/protocols/mdns_candidate_extract.cc
+++ b/firmware/main/protocols/mdns_candidate_extract.cc
@@ -1,0 +1,166 @@
+#include "mdns_candidate_extract.h"
+
+#include <esp_netif_ip_addr.h>
+
+#if defined(STACKCHAN_MDNS_HOST_TEST)
+#define ESP_LOGI(tag, format, ...) \
+    do {                           \
+        (void)(tag);               \
+    } while (0)
+#define ESP_LOGW(tag, format, ...) \
+    do {                           \
+        (void)(tag);               \
+    } while (0)
+#else
+#include <esp_log.h>
+#endif
+
+#include <cstdio>
+#include <cstring>
+#include <optional>
+
+#define TAG "WS"
+
+namespace stackchan::mdns {
+
+std::string SafeString(const char* value) {
+    return value == nullptr ? std::string() : std::string(value);
+}
+
+int CountResults(const mdns_result_t* results) {
+    int count = 0;
+    for (const mdns_result_t* result = results; result != nullptr; result = result->next) {
+        ++count;
+    }
+    return count;
+}
+
+std::optional<std::string> TxtValue(const mdns_result_t* result, const char* key) {
+    if (result == nullptr || key == nullptr) {
+        return std::nullopt;
+    }
+    for (size_t i = 0; i < result->txt_count; ++i) {
+        if (result->txt[i].key == nullptr || strcmp(result->txt[i].key, key) != 0) {
+            continue;
+        }
+        if (result->txt[i].value == nullptr) {
+            return std::string();
+        }
+        if (result->txt_value_len != nullptr) {
+            return std::string(result->txt[i].value, result->txt_value_len[i]);
+        }
+        return std::string(result->txt[i].value);
+    }
+    return std::nullopt;
+}
+
+std::string NormalizePath(const std::optional<std::string>& maybe_path) {
+    if (!maybe_path.has_value() || maybe_path->empty()) {
+        return "/";
+    }
+    if ((*maybe_path)[0] == '/') {
+        return *maybe_path;
+    }
+    return "/" + *maybe_path;
+}
+
+bool IsUsableIpv4String(const std::string& address) {
+    if (address.empty() || address == "0.0.0.0") {
+        return false;
+    }
+    if (address.rfind("127.", 0) == 0) {
+        return false;
+    }
+    int first_octet = 0;
+    if (sscanf(address.c_str(), "%d", &first_octet) != 1) {
+        return false;
+    }
+    return first_octet < 224;
+}
+
+std::vector<std::string> UsableIpv4Addresses(const mdns_result_t* result) {
+    std::vector<std::string> addresses;
+    for (mdns_ip_addr_t* address = result == nullptr ? nullptr : result->addr;
+         address != nullptr;
+         address = address->next) {
+        if (address->addr.type != ESP_IPADDR_TYPE_V4) {
+            continue;
+        }
+        char buffer[16] = {0};
+        snprintf(buffer, sizeof(buffer), IPSTR, IP2STR(&address->addr.u_addr.ip4));
+        std::string ipv4(buffer);
+        if (!IsUsableIpv4String(ipv4)) {
+            continue;
+        }
+        addresses.push_back(ipv4);
+    }
+    return addresses;
+}
+
+std::string JoinAddresses(const std::vector<std::string>& addresses) {
+    if (addresses.empty()) {
+        return std::string();
+    }
+    std::string joined = addresses.front();
+    for (size_t i = 1; i < addresses.size(); ++i) {
+        joined += ",";
+        joined += addresses[i];
+    }
+    return joined;
+}
+
+std::string BuildWebSocketUrl(const std::string& address, uint16_t port, const std::string& path) {
+    return "ws://" + address + ":" + std::to_string(port) + path;
+}
+
+ExtractedGatewayCandidates ExtractGatewayCandidatesFromMdnsResults(const mdns_result_t* results,
+                                                                   int result_count) {
+    ExtractedGatewayCandidates extracted;
+    for (const mdns_result_t* result = results; result != nullptr; result = result->next) {
+        std::string instance_name = SafeString(result->instance_name);
+        std::string hostname = SafeString(result->hostname);
+
+        auto version = TxtValue(result, "version");
+        if (version.has_value() && *version != "1") {
+            ESP_LOGI(TAG,
+                     "Skipping mDNS gateway instance=\"%s\" host=\"%s\": unsupported TXT version=\"%s\"",
+                     instance_name.c_str(), hostname.c_str(), version->c_str());
+            continue;
+        }
+
+        if (result->port == 0) {
+            ESP_LOGW(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": zero port",
+                     instance_name.c_str(), hostname.c_str());
+            continue;
+        }
+
+        auto addresses = UsableIpv4Addresses(result);
+        if (addresses.empty()) {
+            ESP_LOGI(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": no usable IPv4 address",
+                     instance_name.c_str(), hostname.c_str());
+            continue;
+        }
+
+        std::string path = NormalizePath(TxtValue(result, "path"));
+        ESP_LOGI(TAG,
+                 "Accepting mDNS gateway instance=\"%s\" host=\"%s\" port=%u path=\"%s\" addresses=%s",
+                 instance_name.c_str(), hostname.c_str(),
+                 static_cast<unsigned>(result->port), path.c_str(),
+                 JoinAddresses(addresses).c_str());
+        ++extracted.accepted_instances;
+        for (const auto& address : addresses) {
+            MdnsGatewayCandidate candidate;
+            candidate.url = BuildWebSocketUrl(address, result->port, path);
+            candidate.instance_name = instance_name;
+            candidate.hostname = hostname;
+            candidate.address = address;
+            candidate.port = result->port;
+            candidate.path = path;
+            candidate.result_count = result_count;
+            extracted.candidates.push_back(candidate);
+        }
+    }
+    return extracted;
+}
+
+}  // namespace stackchan::mdns

--- a/firmware/main/protocols/mdns_candidate_extract.h
+++ b/firmware/main/protocols/mdns_candidate_extract.h
@@ -1,0 +1,24 @@
+#ifndef _MDNS_CANDIDATE_EXTRACT_H_
+#define _MDNS_CANDIDATE_EXTRACT_H_
+
+#include "mdns_gateway_discovery.h"
+
+#include <mdns.h>
+
+#include <vector>
+
+namespace stackchan::mdns {
+
+struct ExtractedGatewayCandidates {
+    int accepted_instances = 0;
+    std::vector<MdnsGatewayCandidate> candidates;
+};
+
+int CountResults(const mdns_result_t* results);
+
+ExtractedGatewayCandidates ExtractGatewayCandidatesFromMdnsResults(const mdns_result_t* results,
+                                                                   int result_count);
+
+}  // namespace stackchan::mdns
+
+#endif  // _MDNS_CANDIDATE_EXTRACT_H_

--- a/firmware/main/protocols/mdns_gateway_discovery.cc
+++ b/firmware/main/protocols/mdns_gateway_discovery.cc
@@ -2,14 +2,13 @@
 
 #include <esp_log.h>
 
-#include <cstdio>
-#include <cstring>
 #include <utility>
 #include <vector>
 
 #if CONFIG_STACKCHAN_MDNS_DISCOVERY
+#include "mdns_candidate_extract.h"
+
 #include <esp_err.h>
-#include <esp_netif_ip_addr.h>
 #include <esp_wifi.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -29,80 +28,6 @@ constexpr size_t kMaxResults = 8;
 constexpr int kQueryAttempts = 3;
 constexpr uint32_t kQueryRetryGapMs = 200;
 
-std::string SafeString(const char* value) {
-    return value == nullptr ? std::string() : std::string(value);
-}
-
-int CountResults(const mdns_result_t* results) {
-    int count = 0;
-    for (const mdns_result_t* result = results; result != nullptr; result = result->next) {
-        ++count;
-    }
-    return count;
-}
-
-std::optional<std::string> TxtValue(const mdns_result_t* result, const char* key) {
-    if (result == nullptr || key == nullptr) {
-        return std::nullopt;
-    }
-    for (size_t i = 0; i < result->txt_count; ++i) {
-        if (result->txt[i].key == nullptr || strcmp(result->txt[i].key, key) != 0) {
-            continue;
-        }
-        if (result->txt[i].value == nullptr) {
-            return std::string();
-        }
-        if (result->txt_value_len != nullptr) {
-            return std::string(result->txt[i].value, result->txt_value_len[i]);
-        }
-        return std::string(result->txt[i].value);
-    }
-    return std::nullopt;
-}
-
-std::string NormalizePath(const std::optional<std::string>& maybe_path) {
-    if (!maybe_path.has_value() || maybe_path->empty()) {
-        return "/";
-    }
-    if ((*maybe_path)[0] == '/') {
-        return *maybe_path;
-    }
-    return "/" + *maybe_path;
-}
-
-bool IsUsableIpv4String(const std::string& address) {
-    if (address.empty() || address == "0.0.0.0") {
-        return false;
-    }
-    if (address.rfind("127.", 0) == 0) {
-        return false;
-    }
-    int first_octet = 0;
-    if (sscanf(address.c_str(), "%d", &first_octet) != 1) {
-        return false;
-    }
-    return first_octet < 224;
-}
-
-std::vector<std::string> UsableIpv4Addresses(const mdns_result_t* result) {
-    std::vector<std::string> addresses;
-    for (mdns_ip_addr_t* address = result == nullptr ? nullptr : result->addr;
-         address != nullptr;
-         address = address->next) {
-        if (address->addr.type != ESP_IPADDR_TYPE_V4) {
-            continue;
-        }
-        char buffer[16] = {0};
-        snprintf(buffer, sizeof(buffer), IPSTR, IP2STR(&address->addr.u_addr.ip4));
-        std::string ipv4(buffer);
-        if (!IsUsableIpv4String(ipv4)) {
-            continue;
-        }
-        addresses.push_back(ipv4);
-    }
-    return addresses;
-}
-
 std::string JoinCandidateAddresses(const std::vector<MdnsGatewayCandidate>& candidates) {
     if (candidates.empty()) {
         return std::string();
@@ -113,77 +38,6 @@ std::string JoinCandidateAddresses(const std::vector<MdnsGatewayCandidate>& cand
         joined += candidates[i].address;
     }
     return joined;
-}
-
-std::string JoinAddresses(const std::vector<std::string>& addresses) {
-    if (addresses.empty()) {
-        return std::string();
-    }
-    std::string joined = addresses.front();
-    for (size_t i = 1; i < addresses.size(); ++i) {
-        joined += ",";
-        joined += addresses[i];
-    }
-    return joined;
-}
-
-std::string BuildWebSocketUrl(const std::string& address, uint16_t port, const std::string& path) {
-    return "ws://" + address + ":" + std::to_string(port) + path;
-}
-
-struct ExtractedGatewayCandidates {
-    int accepted_instances = 0;
-    std::vector<MdnsGatewayCandidate> candidates;
-};
-
-ExtractedGatewayCandidates ExtractGatewayCandidatesFromMdnsResults(const mdns_result_t* results,
-                                                                   int result_count) {
-    ExtractedGatewayCandidates extracted;
-    for (const mdns_result_t* result = results; result != nullptr; result = result->next) {
-        std::string instance_name = SafeString(result->instance_name);
-        std::string hostname = SafeString(result->hostname);
-
-        auto version = TxtValue(result, "version");
-        if (version.has_value() && *version != "1") {
-            ESP_LOGI(TAG,
-                     "Skipping mDNS gateway instance=\"%s\" host=\"%s\": unsupported TXT version=\"%s\"",
-                     instance_name.c_str(), hostname.c_str(), version->c_str());
-            continue;
-        }
-
-        if (result->port == 0) {
-            ESP_LOGW(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": zero port",
-                     instance_name.c_str(), hostname.c_str());
-            continue;
-        }
-
-        auto addresses = UsableIpv4Addresses(result);
-        if (addresses.empty()) {
-            ESP_LOGI(TAG, "Skipping mDNS gateway instance=\"%s\" host=\"%s\": no usable IPv4 address",
-                     instance_name.c_str(), hostname.c_str());
-            continue;
-        }
-
-        std::string path = NormalizePath(TxtValue(result, "path"));
-        ESP_LOGI(TAG,
-                 "Accepting mDNS gateway instance=\"%s\" host=\"%s\" port=%u path=\"%s\" addresses=%s",
-                 instance_name.c_str(), hostname.c_str(),
-                 static_cast<unsigned>(result->port), path.c_str(),
-                 JoinAddresses(addresses).c_str());
-        ++extracted.accepted_instances;
-        for (const auto& address : addresses) {
-            MdnsGatewayCandidate candidate;
-            candidate.url = BuildWebSocketUrl(address, result->port, path);
-            candidate.instance_name = instance_name;
-            candidate.hostname = hostname;
-            candidate.address = address;
-            candidate.port = result->port;
-            candidate.path = path;
-            candidate.result_count = result_count;
-            extracted.candidates.push_back(candidate);
-        }
-    }
-    return extracted;
 }
 
 #endif  // CONFIG_STACKCHAN_MDNS_DISCOVERY
@@ -249,10 +103,10 @@ std::optional<std::vector<MdnsGatewayCandidate>> DiscoverStackchanGateway(uint32
         return std::nullopt;
     }
 
-    int result_count = CountResults(results);
+    int result_count = stackchan::mdns::CountResults(results);
     // Keep the count next to the extracted candidates so summary logs stay
     // accurate without a mutable out-parameter.
-    auto extracted = ExtractGatewayCandidatesFromMdnsResults(results, result_count);
+    auto extracted = stackchan::mdns::ExtractGatewayCandidatesFromMdnsResults(results, result_count);
     std::optional<std::vector<MdnsGatewayCandidate>> all_candidates;
     if (!extracted.candidates.empty()) {
         all_candidates = std::move(extracted.candidates);


### PR DESCRIPTION
## Summary

Introduces a firmware host-test lane so pure C++ helpers can be unit-tested on a desktop host (CI runner or dev machine) without flashing a device — the coverage gap called out when `ExtractGatewayCandidatesFromMdnsResults` was extracted during the #277 paired fix.

Implementation follows path (a) from the issue: a standalone CMake project under `firmware/host_test/`, independent of the ESP-IDF build, using GoogleTest via `FetchContent`.

## What changed

- `firmware/main/protocols/mdns_candidate_extract.{h,cc}` (new): the pure mDNS gateway-candidate logic (`CountResults`, `ExtractGatewayCandidatesFromMdnsResults`, and their pure helpers) moved out of `mdns_gateway_discovery.cc` into the `stackchan::mdns` namespace. Behavior-identical mechanical extraction; on-target logging is preserved (`ESP_LOGx` compiles as-is for firmware, and a no-op shim applies only under `STACKCHAN_MDNS_HOST_TEST`).
- `firmware/main/protocols/mdns_gateway_discovery.cc`: now calls the extracted functions; duplicate local definitions removed.
- `firmware/main/CMakeLists.txt`: compiles the new translation unit when `CONFIG_STACKCHAN_MDNS_DISCOVERY` is enabled.
- `firmware/host_test/` (new): standalone CMake project — GoogleTest pinned via `FetchContent`, minimal ESP-IDF type stubs (`stubs/mdns.h`, `stubs/esp_netif_ip_addr.h`, mirroring only the fields the extracted code uses, against ESP-IDF v5.5.2), and `test_mdns_candidate_extract.cc`.
- `.github/workflows/build.yml`: new `firmware-host-test` job (ubuntu-latest, plain `cmake` + `ctest`, no Docker).
- `CHANGELOG.md`: `[Unreleased]` → `### Firmware` entry.

## Test coverage

The suite covers the #277 Step 5 edge-case set:

1. multi-instance candidate accumulation
2. unsupported TXT `version` skip
3. `port == 0` skip
4. IPv6-only (no usable IPv4) skip
5. `path` TXT normalisation forms
6. `result_count` / accepted-instance count propagation

## Verification

- Host tests: 6/6 passed locally (macOS / AppleClang) — the same configure/build/ctest sequence the CI job runs.
- Pre-PR review: clean (no findings).
- ESP-IDF Docker build (`release.py stackchan`): artifacts produced, confirming the extraction keeps the firmware build intact.

## Refs

Closes #279. Related: #277, #278 (the candidate-count cap tracked there can now be developed against this host-test lane).
