### PR TITLE
fix(firmware): #252 clamp raw speed_dps below step-safe floor in WriteHeadAngles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ documented-only.
 
 - Added standalone CMake host-test infrastructure for firmware pure C++ helpers,
   covering mDNS gateway candidate extraction edge cases. (#279)
+- Clamp positive `speed_dps` values below 15 dps to the step-safe floor in
+  `WriteHeadAngles`, avoiding sub-step servo interpolation while preserving the
+  existing slow-motion preset behavior. (#252)
 
 ## [0.10.0] - 2026-06-09
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -796,6 +796,14 @@ private:
     static constexpr uint32_t MOTION_TICK_MS = 20;
     static constexpr uint32_t MOTION_DEFAULT_DURATION_MS = 600;
     // Speed-based motion API (Issue #129).
+    // MIN_STEP_SAFE_SPEED_DPS prevents the raw-integer speed_dps escape hatch
+    // from advancing less than one SCS0009 step per ServoTask tick. The
+    // physical step is 300 deg / 1024 = 0.293 deg; at MOTION_TICK_MS=20 ms
+    // this is 14.65 deg/s, rounded up to 15 deg/s for headroom. This shares
+    // the same physical origin as BOOT_INIT_TARGET_DEG_PER_SEC (#121/#141),
+    // but stays separate because the boot path carries its own duration-floor
+    // semantics. See the Issue #129 -> #134 stepped-motion observation lineage.
+    static constexpr int MIN_STEP_SAFE_SPEED_DPS = 15;
     // MIN_SMOOTH_SPEED_DPS is the on-device measured smoothness floor
     // (5 step/tick "transition out", measured 2026-05-15). Speeds below
     // this look textured on SCS0009 at MOTION_TICK_MS=20 ms; the firmware
@@ -3668,6 +3676,10 @@ private:
         int safe_speed = speed_dps;
         if (safe_speed <= 0) {
             safe_speed = DEFAULT_SPEED_DPS;
+        } else if (safe_speed < MIN_STEP_SAFE_SPEED_DPS) {
+            ESP_LOGW(TAG, "WriteHeadAngles: speed_dps=%d below MIN_STEP_SAFE_SPEED_DPS=%d, clamping",
+                     speed_dps, MIN_STEP_SAFE_SPEED_DPS);
+            safe_speed = MIN_STEP_SAFE_SPEED_DPS;
         } else if (safe_speed < MIN_SMOOTH_SPEED_DPS) {
             // Below the on-device measured smoothness floor -- motion will look
             // textured on SCS0009 at MOTION_TICK_MS=20 ms. This is intentionally
@@ -5020,7 +5032,7 @@ private:
         // spot) above, plus Issue #80 / #98.
         mcp_server.AddTool(
             "self.robot.set_head_angles",
-            "Set the head angles of the robot. yaw: horizontal (-90 to 90). pitch: vertical. M5Stack-recommended operating range is 5 to 85 degrees per https://docs.m5stack.com/en/StackChan (\"Motion Angle Notice\"). The firmware also accepts values up to 88 degrees (the hard clamp guards against the audible sub-stall observed at pitch=89 on real hardware), but values outside 5-85 degrees are not officially endorsed and may stress the servo over time. Requests below 0 degrees or above 88 degrees are silently clamped with an ESP_LOGW. Optional speed_dps: angular speed in degrees per second. If omitted or zero, the existing duration-based default applies. See README \"Hardware safety notes\".",
+            "Set the head angles of the robot. yaw: horizontal (-90 to 90). pitch: vertical. M5Stack-recommended operating range is 5 to 85 degrees per https://docs.m5stack.com/en/StackChan (\"Motion Angle Notice\"). The firmware also accepts values up to 88 degrees (the hard clamp guards against the audible sub-stall observed at pitch=89 on real hardware), but values outside 5-85 degrees are not officially endorsed and may stress the servo over time. Requests below 0 degrees or above 88 degrees are silently clamped with an ESP_LOGW. Optional speed_dps: angular speed in degrees per second. If omitted or zero, the existing duration-based default applies; positive values below 15 dps are clamped to the step-safe floor. See README \"Hardware safety notes\".",
             // Pitch schema range is intentionally permissive across the
             // entire `int` value range (std::numeric_limits<int>::min/max):
             // the authoritative Tier 1 enforcement lives in the handler


### PR DESCRIPTION
## Summary

Closes the sub-step stall gap on the raw-integer `speed_dps` escape hatch of `move_head` / `WriteHeadAngles`.

The preset speeds ("low" = 30, "mid" = 120, "high" = 240 °/s) all sit above the physical step floor, but a raw integer in `(0, 15)` °/s drives the 20 ms motion tick below one SCS0009 step (300° / 1024 = 0.293°) per tick: interpolation then re-sends the same target across multiple ticks before the servo advances one step — the "movement looks stuck" pattern characterized in Issue #129's design discussion and first observed under #134.

## What changed

- `firmware/main/boards/stackchan/stackchan.cc`
  - New `MIN_STEP_SAFE_SPEED_DPS = 15` constant next to the existing speed constants, with the derivation documented (0.293° / 20 ms ≈ 14.65 °/s, rounded up for headroom) and a cross-reference to `BOOT_INIT_TARGET_DEG_PER_SEC` (#121/#141) — same physical origin, intentionally kept separate because the boot path carries its own duration-floor semantics.
  - `WriteHeadAngles(yaw, pitch, speed_dps)`: positive values below the floor are clamped up with one `ESP_LOGW` reporting requested and clamped values. The `<= 0` → default path and the warn-only smoothness band `[15, 72)` are unchanged.
  - The `self.robot.set_head_angles` MCP tool description notes the new lower-bound clamp.
- `CHANGELOG.md`: `[Unreleased]` → `### Firmware` entry.

## Verification

- Pre-PR review: clean (no findings).
- ESP-IDF Docker build (`release.py stackchan`): artifacts produced (`xiaozhi.bin` / `merged-binary.bin`).
- Real-device motion check at boundary speeds (e.g. raw 14 vs 15 vs 30) is deferred to the next on-device session; the change is conservative (raises only the stall band, never lowers speed).

## Refs

Closes #252.
