### PR TITLE
feat(tts): add Irodori TTS engine as a selectable synthesis engine (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ documented-only.
 
 ### Gateway
 
+- Add the Irodori TTS engine as a second selectable synthesis engine
+  alongside VOICEVOX. It calls an external MP3 synthesis service (decoded
+  to PCM via the new `tts-irodori` extra) and reuses the existing
+  `say` → Opus → WebSocket pipeline. The endpoint and optional API key
+  are read from the environment only (`STACKCHAN_IRODORI_URL` is required,
+  no default), and a new `STACKCHAN_TTS_ENGINE` variable can change the
+  default engine; VOICEVOX stays the default when it is unset. (#286)
 - Harden ownership lock stale detection by recording and verifying the
   owning process start time, preventing recycled PIDs from being treated
   as the original live gateway. (#253)

--- a/README.ja.md
+++ b/README.ja.md
@@ -380,9 +380,57 @@ gateway は VOICEVOX に POST → 返ってきた WAV をデコード →
 既存の WebSocket バイナリチャネルでデバイスへ送信、という流れで
 喋らせます。デバイスは受け取ったフレームを既存の音声デコーダで
 再生するだけなので、**ファームウェア側の変更は不要**です。
-TTS フレームワークはエンジン非依存なので、Irodori-TTS による
-ボイスクローン等、他のエンジンも `say` API を変えずに後から
-追加できます。
+TTS フレームワークはエンジン非依存なので、他のエンジンも同じ
+`say` API の裏に差し込めます — 下記の Irodori エンジンを参照。
+
+#### 別エンジン: Irodori
+
+Irodori は MP3 を返す外部合成サービスを呼ぶ 2 つ目の TTS
+エンジンです。VOICEVOX と同じ `say` パイプラインに乗り（MP3 を
+16 kHz mono PCM にデコードしてから Opus にエンコード）、入力
+テキストに含まれる絵文字を声質スタイルの指示として解釈します。
+
+**デフォルトのエンドポイントはありません** — 合成バックエンドは
+ホスト型サービスであり、URL をハードコードすると全インストールが
+他人のデプロイを指してしまうためです。互換性のある合成 API を
+自分でホストし（例: 参照元の Hugging Face Space を複製する、または
+同じリクエスト/レスポンス契約に従う独自サービスを動かす）、
+gateway をそこに向けてください。
+
+extras のインストール:
+
+```bash
+pip install 'stackchan-mcp[tts-irodori]'
+```
+
+これで `httpx`・`opuslib`・`miniaudio`（プレビルト wheel 付きの
+小さな自己完結型 MP3/音声デコーダ。`opuslib` が要求する `libopus`
+以外に追加のシステムライブラリは不要）が入ります。
+
+環境変数で設定します（URL とキーは環境変数からのみ読み込み —
+コミットしないでください）:
+
+| 環境変数 | デフォルト | 補足 |
+|---|---|---|
+| `STACKCHAN_IRODORI_URL` | _(必須)_ | 自前ホストした合成サービスのエンドポイント URL。未設定 → エンジンは一覧に出るが `say(voice="irodori")` は明確なエラーを返す |
+| `STACKCHAN_IRODORI_KEY` | _(なし)_ | 任意の API キー。クエリパラメータとして送信 |
+| `STACKCHAN_IRODORI_SPEAKER` | `3` | デフォルト話者 ID |
+| `STACKCHAN_IRODORI_STEPS` | `24` | デフォルト拡散ステップ数（大きいほど遅く高品質） |
+
+呼び出しごとに Irodori を選択:
+
+```
+say(text="やったね😊", voice="irodori")
+```
+
+または `voice` を省略した全 `say` 呼び出しのデフォルトエンジンに:
+
+```bash
+export STACKCHAN_TTS_ENGINE=irodori
+```
+
+`STACKCHAN_TTS_ENGINE` 未設定なら VOICEVOX がデフォルトのままで、
+明示的な `voice` 引数は常にデフォルトを上書きします。
 
 ### 5. オプション: STT セットアップ (faster-whisper)
 

--- a/README.md
+++ b/README.md
@@ -432,9 +432,57 @@ The gateway POSTs to VOICEVOX, decodes the returned WAV, resamples to
 WebSocket binary frames to the device — which decodes and plays them
 through its speaker. **No firmware changes are required**: the
 existing audio decoder pipeline already accepts these frames. The
-TTS framework is engine-agnostic, so additional engines (Irodori-TTS
-voice cloning is on the roadmap) can be added without changing the
-`say` API.
+TTS framework is engine-agnostic, so additional engines plug in behind
+the same `say` API — see the Irodori engine below.
+
+#### Alternative engine: Irodori
+
+Irodori is a second TTS engine that calls an external synthesis service
+returning MP3. It plugs into the same `say` pipeline as VOICEVOX (MP3 is
+decoded to 16 kHz mono PCM, then encoded to Opus), and it interprets
+emoji embedded in the input text as a voice-style cue.
+
+There is **no default endpoint** — the synthesis backend is a hosted
+service, and shipping a hard-coded URL would point every install at
+someone else's deployment. You must self-host a compatible synthesis API
+(for example, duplicate the reference Hugging Face Space, or run your own
+service that honours the same request/response contract) and point the
+gateway at it.
+
+Install the extra:
+
+```bash
+pip install 'stackchan-mcp[tts-irodori]'
+```
+
+This pulls in `httpx`, `opuslib`, and `miniaudio` (a small self-contained
+MP3/audio decoder with prebuilt wheels, so no extra system library is
+needed beyond the `libopus` that `opuslib` already requires).
+
+Configure via environment variables (URL and key are read from the
+environment only — never commit them):
+
+| Environment variable | Default | Notes |
+|---|---|---|
+| `STACKCHAN_IRODORI_URL` | _(required)_ | Synthesis endpoint URL of your self-hosted service. Unset → the engine still lists but `say(voice="irodori")` returns a clear error. |
+| `STACKCHAN_IRODORI_KEY` | _(none)_ | Optional API key, forwarded as a query parameter. |
+| `STACKCHAN_IRODORI_SPEAKER` | `3` | Default speaker identifier. |
+| `STACKCHAN_IRODORI_STEPS` | `24` | Default diffusion step count (higher = slower, higher quality). |
+
+Select Irodori per call:
+
+```
+say(text="やったね😊", voice="irodori")
+```
+
+Or make it the default engine for every `say` call that omits `voice`:
+
+```bash
+export STACKCHAN_TTS_ENGINE=irodori
+```
+
+VOICEVOX remains the default when `STACKCHAN_TTS_ENGINE` is unset, and an
+explicit `voice` argument always overrides the default.
 
 ### 5. Optional: STT setup (faster-whisper)
 

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 [project.optional-dependencies]
 # Phase 4 TTS — see Issue #70.
 # Concrete engines (VOICEVOX, Irodori) consume these libraries:
-#   * httpx     — VOICEVOX HTTP engine client
+#   * httpx     — VOICEVOX / Irodori HTTP engine client
 #   * opuslib   — Opus encoding for the device's audio decoder
 # `tts-voicevox` is a no-op alias provided so users can declare intent
 # explicitly; the VOICEVOX engine itself is an external HTTP process and
@@ -62,6 +62,17 @@ tts = [
 ]
 tts-voicevox = [
     "stackchan-mcp[tts]",
+]
+# Irodori is an external HTTP synthesis service that returns MP3 (see
+# Issue #286). On top of the base `[tts]` extra (httpx + opuslib) it adds
+# `miniaudio` to decode the MP3 response to PCM. miniaudio is a small,
+# self-contained C extension (MIT) with prebuilt wheels for Windows,
+# macOS (x86_64 + arm64), and Linux, so it installs without a system
+# audio library — unlike a ffmpeg/libav binding — which keeps the
+# Windows wheel path (and the CI windows-smoke job) simple.
+tts-irodori = [
+    "stackchan-mcp[tts]",
+    "miniaudio>=1.59",
 ]
 
 # Phase 4 STT — see Issue #91.

--- a/gateway/stackchan_mcp/tts/__init__.py
+++ b/gateway/stackchan_mcp/tts/__init__.py
@@ -48,7 +48,14 @@ def _register_voicevox() -> None:
     get_registry().register(VoicevoxEngine())
 
 
+def _register_irodori() -> None:
+    from .irodori import IrodoriEngine
+
+    get_registry().register(IrodoriEngine())
+
+
 _try_register(_register_voicevox, "voicevox")
+_try_register(_register_irodori, "irodori")
 
 
 __all__ = [

--- a/gateway/stackchan_mcp/tts/irodori.py
+++ b/gateway/stackchan_mcp/tts/irodori.py
@@ -168,32 +168,44 @@ class IrodoriEngine(TTSEngine):
         self._url_override = url.strip() if url and url.strip() else None
         self._api_key_override = api_key
 
-        if default_speaker is not None:
-            self._default_speaker = default_speaker
-        else:
-            self._default_speaker = (
-                os.getenv("STACKCHAN_IRODORI_SPEAKER") or DEFAULT_IRODORI_SPEAKER
-            )
-
-        if default_steps is not None:
-            self._default_steps = default_steps
-        else:
-            self._default_steps = (
-                os.getenv("STACKCHAN_IRODORI_STEPS") or DEFAULT_IRODORI_STEPS
-            )
+        # Speaker / steps defaults are resolved lazily (see the
+        # properties below) for the same reason as the URL: with
+        # ``serve --transport streamable-http`` this engine is
+        # constructed at import time, before ``.env`` is loaded, so
+        # capturing the environment here would silently ignore
+        # dotenv-provided values. Only explicit constructor overrides
+        # are pinned at construction time.
+        self._default_speaker_override = default_speaker
+        self._default_steps_override = default_steps
 
         self._timeout_seconds = timeout_seconds
         self._transport = transport
 
     @property
     def default_speaker(self) -> str:
-        """Speaker identifier used when ``speaker_id`` is omitted."""
-        return self._default_speaker
+        """Speaker identifier used when ``speaker_id`` is omitted.
+
+        Resolved lazily — constructor override, then
+        ``STACKCHAN_IRODORI_SPEAKER``, then
+        :data:`DEFAULT_IRODORI_SPEAKER` — so values loaded from ``.env``
+        after import still take effect.
+        """
+        if self._default_speaker_override is not None:
+            return self._default_speaker_override
+        return os.getenv("STACKCHAN_IRODORI_SPEAKER") or DEFAULT_IRODORI_SPEAKER
 
     @property
     def default_steps(self) -> str:
-        """Diffusion step count used when ``steps`` is omitted."""
-        return self._default_steps
+        """Diffusion step count used when ``steps`` is omitted.
+
+        Resolved lazily — constructor override, then
+        ``STACKCHAN_IRODORI_STEPS``, then
+        :data:`DEFAULT_IRODORI_STEPS` — so values loaded from ``.env``
+        after import still take effect.
+        """
+        if self._default_steps_override is not None:
+            return self._default_steps_override
+        return os.getenv("STACKCHAN_IRODORI_STEPS") or DEFAULT_IRODORI_STEPS
 
     def _resolve_url(self) -> str:
         """Return the configured endpoint URL or raise a clear error.
@@ -264,10 +276,10 @@ class IrodoriEngine(TTSEngine):
         # contract; a caller passing an int is coerced rather than
         # rejected so the say() tool's uniform argument set still works.
         speaker_raw = opts.get("speaker_id")
-        speaker = str(speaker_raw) if speaker_raw is not None else self._default_speaker
+        speaker = str(speaker_raw) if speaker_raw is not None else self.default_speaker
 
         steps_raw = opts.get("steps")
-        steps = str(steps_raw) if steps_raw is not None else self._default_steps
+        steps = str(steps_raw) if steps_raw is not None else self.default_steps
 
         params: dict[str, str] = {
             "text": text,

--- a/gateway/stackchan_mcp/tts/irodori.py
+++ b/gateway/stackchan_mcp/tts/irodori.py
@@ -1,0 +1,337 @@
+"""Irodori engine — HTTP client for a user-run Irodori synthesis API.
+
+Irodori is a separate text-to-speech service that returns an MP3 stream.
+The gateway never links Irodori code; it only issues an HTTP request and
+fetches the resulting MP3, so the engine stays a thin client and the
+gateway remains MIT-licensed.
+
+Unlike the VOICEVOX engine, there is **no default endpoint URL**. The
+synthesis backend is a third-party hosted service, and hard-coding a
+specific deployment would point every user at someone else's private
+instance. ``STACKCHAN_IRODORI_URL`` is therefore required: the engine
+still registers (so it shows up in the engine list) when the variable is
+unset, but :meth:`IrodoriEngine.synthesize` fails with a clear error
+telling the user to point it at their own deployment.
+
+Configuration (environment variables):
+
+    ``STACKCHAN_IRODORI_URL``
+        Synthesis endpoint URL. **Required** — no default. Self-host a
+        compatible synthesis API (e.g. duplicate the reference Hugging
+        Face Space) and set this to its URL.
+
+    ``STACKCHAN_IRODORI_KEY``
+        Optional API key, forwarded as the ``key`` query parameter.
+        Read from the environment only; never commit it.
+
+    ``STACKCHAN_IRODORI_SPEAKER``
+        Default speaker identifier. Default ``"3"``.
+
+    ``STACKCHAN_IRODORI_STEPS``
+        Default diffusion step count. Default ``"24"``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from .audio_utils import (
+    DEVICE_SAMPLE_RATE,
+    resample_pcm16_linear,
+)
+from .base import TTSEngine
+
+logger = logging.getLogger(__name__)
+
+
+#: Default speaker identifier used when ``speaker_id`` is omitted from a
+#: call. Sent verbatim as the ``speaker`` query parameter, so it is kept
+#: as a string to match the HTTP contract.
+DEFAULT_IRODORI_SPEAKER = "3"
+
+#: Default diffusion step count. Higher values trade synthesis latency
+#: for quality. Sent verbatim as the ``steps`` query parameter.
+DEFAULT_IRODORI_STEPS = "24"
+
+#: HTTP timeout for both the synthesis request and the MP3 fetch.
+#: Synthesis on a cold backend can take several seconds, so this errs on
+#: the generous side (matching the VOICEVOX engine's default).
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30.0
+
+
+def _decode_mp3_to_pcm16_mono(mp3_bytes: bytes) -> tuple[int, bytes]:
+    """Decode an MP3 blob into ``(sample_rate, raw_pcm)``.
+
+    The PCM is returned as signed 16-bit little-endian mono. ``miniaudio``
+    is imported lazily here so the rest of the TTS framework — and the
+    Irodori module itself — stays importable when the ``[tts-irodori]``
+    extra is not installed; the failure only surfaces when synthesis is
+    actually attempted. Callers get a clear ``RuntimeError`` that points
+    at the right install command.
+
+    miniaudio decodes natively to interleaved signed-16-bit samples, so
+    we ask for mono directly and let it downmix; only the sample rate may
+    differ from the device's, which the caller resamples.
+    """
+    try:
+        import miniaudio  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via integration
+        raise RuntimeError(
+            "miniaudio is not installed. Install with "
+            "'pip install stackchan-mcp[tts-irodori]' to enable Irodori support."
+        ) from exc
+
+    decoded = miniaudio.decode(
+        mp3_bytes,
+        output_format=miniaudio.SampleFormat.SIGNED16,
+        nchannels=1,
+    )
+    return decoded.sample_rate, decoded.samples.tobytes()
+
+
+class IrodoriEngine(TTSEngine):
+    """Synthesise text by calling a running Irodori synthesis HTTP API.
+
+    The endpoint returns JSON describing where to fetch the synthesised
+    MP3; the engine fetches it, decodes it to 16 kHz mono PCM, and hands
+    the PCM back to the orchestrator (which owns Opus encoding and the
+    WebSocket push).
+
+    Setup: self-host a compatible synthesis API (e.g. duplicate the
+    reference Hugging Face Space, or run your own service that honours the
+    same request/response contract) and set ``STACKCHAN_IRODORI_URL`` to
+    its URL.
+
+    HTTP contract::
+
+        GET {url}?text=<text>&speaker=<speaker>&steps=<steps>
+            [&seconds=<seconds>][&key=<key>]
+
+        -> 200 JSON {
+               "success": bool,
+               "mp3StreamingUrl": str | null,
+               "mp3DownloadUrl": str | null,
+               "error": str | null
+           }
+
+    A non-200 response or ``success: false`` is treated as an engine
+    failure, using the server-provided ``error`` text when present.
+    """
+
+    name = "irodori"
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        api_key: str | None = None,
+        default_speaker: str | None = None,
+        default_steps: str | None = None,
+        timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+        transport: Any = None,
+    ) -> None:
+        """Construct an Irodori engine.
+
+        Args:
+            url: Synthesis endpoint URL. When ``None`` the
+                ``STACKCHAN_IRODORI_URL`` environment variable is read at
+                synthesis time. There is no default URL; an unset URL is
+                reported as a clear error when :meth:`synthesize` runs.
+            api_key: Optional API key. When ``None`` the
+                ``STACKCHAN_IRODORI_KEY`` environment variable is read.
+            default_speaker: Speaker identifier used when ``speaker_id``
+                is omitted from a call. Falls back to
+                ``STACKCHAN_IRODORI_SPEAKER`` then
+                :data:`DEFAULT_IRODORI_SPEAKER`.
+            default_steps: Diffusion step count used when ``steps`` is
+                omitted. Falls back to ``STACKCHAN_IRODORI_STEPS`` then
+                :data:`DEFAULT_IRODORI_STEPS`.
+            timeout_seconds: HTTP timeout for the synthesis request and
+                the MP3 fetch.
+            transport: An :class:`httpx.BaseTransport` (or compatible)
+                handed straight to :class:`httpx.AsyncClient`. Tests pass
+                a :class:`httpx.MockTransport` to avoid hitting the
+                network; production callers leave it ``None``.
+        """
+        # The URL is intentionally resolved lazily (at synthesis time) so
+        # that registration never fails just because the variable is
+        # unset — the engine stays visible in the registry, and the
+        # missing-URL condition becomes an actionable synthesis-time
+        # error instead.
+        self._url_override = url.rstrip("/") if url else None
+        self._api_key_override = api_key
+
+        if default_speaker is not None:
+            self._default_speaker = default_speaker
+        else:
+            self._default_speaker = (
+                os.getenv("STACKCHAN_IRODORI_SPEAKER") or DEFAULT_IRODORI_SPEAKER
+            )
+
+        if default_steps is not None:
+            self._default_steps = default_steps
+        else:
+            self._default_steps = (
+                os.getenv("STACKCHAN_IRODORI_STEPS") or DEFAULT_IRODORI_STEPS
+            )
+
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    @property
+    def default_speaker(self) -> str:
+        """Speaker identifier used when ``speaker_id`` is omitted."""
+        return self._default_speaker
+
+    @property
+    def default_steps(self) -> str:
+        """Diffusion step count used when ``steps`` is omitted."""
+        return self._default_steps
+
+    def _resolve_url(self) -> str:
+        """Return the configured endpoint URL or raise a clear error.
+
+        Resolution order: constructor override, then
+        ``STACKCHAN_IRODORI_URL``. There is deliberately no fallback
+        default — pointing at an unconfigured third-party service would
+        be wrong — so an unset URL raises ``RuntimeError`` with setup
+        guidance.
+        """
+        if self._url_override:
+            return self._url_override
+        env_url = os.getenv("STACKCHAN_IRODORI_URL")
+        if env_url and env_url.strip():
+            return env_url.strip().rstrip("/")
+        raise RuntimeError(
+            "Irodori synthesis URL is not configured. Set the "
+            "STACKCHAN_IRODORI_URL environment variable to the URL of a "
+            "self-hosted Irodori-compatible synthesis API (e.g. a "
+            "duplicated Hugging Face Space). The Irodori engine ships no "
+            "default endpoint by design."
+        )
+
+    def _resolve_api_key(self) -> str | None:
+        """Return the API key from the override or the environment."""
+        if self._api_key_override is not None:
+            return self._api_key_override
+        return os.getenv("STACKCHAN_IRODORI_KEY")
+
+    async def synthesize(self, text: str, **opts: Any) -> bytes:
+        """Call Irodori, fetch the MP3, return 16 kHz mono PCM.
+
+        Recognised opts:
+
+            ``speaker_id``
+                Speaker identifier. Sent verbatim as the ``speaker``
+                query parameter; falls back to :attr:`default_speaker`.
+
+            ``steps``
+                Diffusion step count. Falls back to :attr:`default_steps`.
+
+            ``seconds``
+                Optional target duration; forwarded as the ``seconds``
+                query parameter only when provided.
+
+        The text is passed through verbatim, including any emoji —
+        Irodori interprets emoji natively as a voice-style cue, so the
+        engine must not parse or strip them.
+        """
+        try:
+            import httpx  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised via integration
+            raise RuntimeError(
+                "httpx is not installed. Install with "
+                "'pip install stackchan-mcp[tts-irodori]' to enable Irodori "
+                "support."
+            ) from exc
+
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("Irodori synthesize: 'text' must be a non-empty string")
+
+        url = self._resolve_url()
+
+        # Speaker / steps are sent verbatim as strings to match the HTTP
+        # contract; a caller passing an int is coerced rather than
+        # rejected so the say() tool's uniform argument set still works.
+        speaker_raw = opts.get("speaker_id")
+        speaker = str(speaker_raw) if speaker_raw is not None else self._default_speaker
+
+        steps_raw = opts.get("steps")
+        steps = str(steps_raw) if steps_raw is not None else self._default_steps
+
+        params: dict[str, str] = {
+            "text": text,
+            "speaker": speaker,
+            "steps": steps,
+        }
+
+        seconds_raw = opts.get("seconds")
+        if seconds_raw is not None:
+            params["seconds"] = str(seconds_raw)
+
+        api_key = self._resolve_api_key()
+        if api_key:
+            params["key"] = api_key
+
+        client_kwargs: dict[str, Any] = {"timeout": self._timeout_seconds}
+        if self._transport is not None:
+            client_kwargs["transport"] = self._transport
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            # 1. Request synthesis. A non-200 is an engine failure; the
+            #    response body may carry a server-provided error message.
+            synth_resp = await client.get(url, params=params)
+            if synth_resp.status_code != 200:
+                raise RuntimeError(
+                    f"Irodori synthesis request failed: HTTP "
+                    f"{synth_resp.status_code} {synth_resp.text[:200]!r}"
+                )
+
+            payload = synth_resp.json()
+            if not isinstance(payload, dict):
+                raise RuntimeError(
+                    f"Irodori returned an unexpected response shape: "
+                    f"{type(payload).__name__} (expected a JSON object)"
+                )
+
+            if not payload.get("success"):
+                server_error = payload.get("error")
+                detail = f": {server_error}" if server_error else ""
+                raise RuntimeError(f"Irodori synthesis was not successful{detail}")
+
+            # 2. Prefer the streaming URL; fall back to the download URL.
+            mp3_url = payload.get("mp3StreamingUrl") or payload.get("mp3DownloadUrl")
+            if not mp3_url:
+                raise RuntimeError(
+                    "Irodori response did not include an MP3 URL "
+                    "(neither 'mp3StreamingUrl' nor 'mp3DownloadUrl' was present)."
+                )
+
+            # 3. Fetch the MP3 bytes.
+            mp3_resp = await client.get(mp3_url)
+            if mp3_resp.status_code != 200:
+                raise RuntimeError(
+                    f"Irodori MP3 fetch failed: HTTP {mp3_resp.status_code} "
+                    f"for {mp3_url}"
+                )
+            mp3_bytes = mp3_resp.content
+
+        if not mp3_bytes:
+            raise RuntimeError("Irodori MP3 fetch returned an empty body.")
+
+        # 4. Decode MP3 -> PCM and resample to the device's 16 kHz rate.
+        sample_rate, pcm = _decode_mp3_to_pcm16_mono(mp3_bytes)
+        if sample_rate != DEVICE_SAMPLE_RATE:
+            pcm = resample_pcm16_linear(pcm, sample_rate, DEVICE_SAMPLE_RATE)
+
+        logger.info(
+            "Irodori synthesised %d bytes PCM (16 kHz mono) for "
+            "speaker=%s, steps=%s, text=%r",
+            len(pcm),
+            speaker,
+            steps,
+            text[:60],
+        )
+        return pcm

--- a/gateway/stackchan_mcp/tts/irodori.py
+++ b/gateway/stackchan_mcp/tts/irodori.py
@@ -160,7 +160,12 @@ class IrodoriEngine(TTSEngine):
         # unset — the engine stays visible in the registry, and the
         # missing-URL condition becomes an actionable synthesis-time
         # error instead.
-        self._url_override = url.rstrip("/") if url else None
+        #
+        # Only surrounding whitespace is stripped. The value is the
+        # synthesis *endpoint* URL (not a base URL), so a trailing slash
+        # is significant: stripping it would request a different path on
+        # strict-routing deployments.
+        self._url_override = url.strip() if url and url.strip() else None
         self._api_key_override = api_key
 
         if default_speaker is not None:
@@ -198,12 +203,15 @@ class IrodoriEngine(TTSEngine):
         default — pointing at an unconfigured third-party service would
         be wrong — so an unset URL raises ``RuntimeError`` with setup
         guidance.
+
+        Only surrounding whitespace is stripped; a trailing slash is
+        preserved because the value is the endpoint URL itself.
         """
         if self._url_override:
             return self._url_override
         env_url = os.getenv("STACKCHAN_IRODORI_URL")
         if env_url and env_url.strip():
-            return env_url.strip().rstrip("/")
+            return env_url.strip()
         raise RuntimeError(
             "Irodori synthesis URL is not configured. Set the "
             "STACKCHAN_IRODORI_URL environment variable to the URL of a "

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
@@ -45,10 +46,30 @@ TTS_START_TRANSITION_DELAY_S = 0.05
 logger = logging.getLogger(__name__)
 
 
-#: Default engine name when ``voice`` is omitted from the tool call.
-#: VOICEVOX is the canonical default (Issue #70); the concrete engine
-#: ships in PR2 of that Issue.
+#: Built-in default engine name when ``voice`` is omitted from the tool
+#: call and ``STACKCHAN_TTS_ENGINE`` is unset. VOICEVOX is the canonical
+#: default (Issue #70).
 DEFAULT_VOICE = "voicevox"
+
+#: Environment variable that overrides the default engine selected when a
+#: ``say`` call omits ``voice``. The per-call ``voice`` argument still
+#: takes precedence over this; this only changes the fallback when no
+#: ``voice`` is given. Unset → :data:`DEFAULT_VOICE`.
+TTS_ENGINE_ENV_VAR = "STACKCHAN_TTS_ENGINE"
+
+
+def _resolve_default_engine() -> str:
+    """Return the default engine name, honouring ``STACKCHAN_TTS_ENGINE``.
+
+    The environment variable lets an operator make a non-VOICEVOX engine
+    (e.g. ``irodori``) the default for ``say`` calls that don't pass an
+    explicit ``voice``. A blank or whitespace-only value is ignored so an
+    empty export does not silently break engine lookup.
+    """
+    env_engine = os.getenv(TTS_ENGINE_ENV_VAR)
+    if env_engine and env_engine.strip():
+        return env_engine.strip()
+    return DEFAULT_VOICE
 
 
 async def synthesize_and_send(
@@ -63,7 +84,9 @@ async def synthesize_and_send(
         arguments: MCP tool arguments. Recognised keys:
 
             * ``text`` (required): non-empty string to speak.
-            * ``voice``: engine name; defaults to :data:`DEFAULT_VOICE`.
+            * ``voice``: engine name; when omitted, the default is
+              resolved from ``STACKCHAN_TTS_ENGINE`` and otherwise
+              :data:`DEFAULT_VOICE`.
             * ``speaker_id``: engine-specific speaker identifier
               (e.g. VOICEVOX speaker).
             * ``reference_audio``: path to a reference audio sample
@@ -100,8 +123,16 @@ async def synthesize_and_send(
     if not isinstance(text, str) or not text.strip():
         raise ValueError("'text' is required and must be a non-empty string")
 
-    voice_raw = arguments.get("voice", DEFAULT_VOICE)
-    voice = voice_raw if isinstance(voice_raw, str) and voice_raw else DEFAULT_VOICE
+    # An explicit, non-empty ``voice`` argument always wins. Otherwise the
+    # default engine is resolved from STACKCHAN_TTS_ENGINE (falling back to
+    # DEFAULT_VOICE), so an operator can switch the default without every
+    # caller passing ``voice``.
+    voice_raw = arguments.get("voice")
+    voice = (
+        voice_raw
+        if isinstance(voice_raw, str) and voice_raw
+        else _resolve_default_engine()
+    )
 
     reg = registry if registry is not None else get_registry()
     engine = reg.get(voice)

--- a/gateway/tests/test_irodori.py
+++ b/gateway/tests/test_irodori.py
@@ -127,6 +127,23 @@ def test_constructor_args_override_env(monkeypatch):
     assert engine.default_steps == "16"
 
 
+def test_defaults_resolve_lazily_after_construction(monkeypatch):
+    """Env defaults set after construction still take effect.
+
+    With ``serve --transport streamable-http`` the tts package is
+    imported (and the engine registered) before ``.env`` is loaded, so
+    speaker / steps must be read at use time, not captured at
+    construction time.
+    """
+    monkeypatch.delenv("STACKCHAN_IRODORI_SPEAKER", raising=False)
+    monkeypatch.delenv("STACKCHAN_IRODORI_STEPS", raising=False)
+    engine = IrodoriEngine(url=_SYNTH_URL)  # constructed before env is set
+    monkeypatch.setenv("STACKCHAN_IRODORI_SPEAKER", "7")
+    monkeypatch.setenv("STACKCHAN_IRODORI_STEPS", "48")
+    assert engine.default_speaker == "7"
+    assert engine.default_steps == "48"
+
+
 # ---------------------------------------------------------------------------
 # Unset URL — registers but fails clearly on synthesize
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_irodori.py
+++ b/gateway/tests/test_irodori.py
@@ -1,0 +1,375 @@
+"""Tests for the Irodori engine HTTP client (Issue #286).
+
+The HTTP layer is exercised with an ``httpx.MockTransport`` (no real
+network). MP3 decoding is the one piece that would otherwise need the
+``miniaudio`` C extension from the ``[tts-irodori]`` extra, so the decode
+boundary (``_decode_mp3_to_pcm16_mono``) is monkeypatched: these tests
+verify the engine's request building, response handling, URL-selection,
+and error paths, not miniaudio's decoder.
+"""
+
+from __future__ import annotations
+
+import array
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from stackchan_mcp.tts import irodori as irodori_mod  # noqa: E402
+from stackchan_mcp.tts.irodori import (  # noqa: E402
+    DEFAULT_IRODORI_SPEAKER,
+    DEFAULT_IRODORI_STEPS,
+    IrodoriEngine,
+)
+
+_SYNTH_URL = "http://irodori.test/api/synthesize"
+_MP3_STREAM_URL = "http://irodori.test/files/out.mp3?stream=1"
+_MP3_DOWNLOAD_URL = "http://irodori.test/files/out.mp3"
+
+#: A non-empty placeholder standing in for MP3 bytes. The decode boundary
+#: is monkeypatched, so the actual contents never reach a real decoder.
+_FAKE_MP3 = b"ID3fake-mp3-bytes"
+
+
+def _fake_pcm_16k(n_samples: int = 480) -> bytes:
+    """Build ``n_samples`` of signed-16-bit mono PCM at the device rate."""
+    samples = array.array("h", [(i % 100) - 50 for i in range(n_samples)])
+    return samples.tobytes()
+
+
+def _patch_decode(monkeypatch, *, sample_rate: int = 16000, pcm: bytes | None = None):
+    """Replace the MP3 decode boundary with a deterministic fake.
+
+    Returns a one-element list capturing the bytes handed to the decoder
+    so callers can assert the engine fetched the right MP3.
+    """
+    captured: list[bytes] = []
+    payload = pcm if pcm is not None else _fake_pcm_16k()
+
+    def fake_decode(mp3_bytes: bytes):
+        captured.append(mp3_bytes)
+        return sample_rate, payload
+
+    monkeypatch.setattr(irodori_mod, "_decode_mp3_to_pcm16_mono", fake_decode)
+    return captured
+
+
+def _build_handler(
+    captured: list[dict],
+    *,
+    synth_status: int = 200,
+    synth_json: dict | None = None,
+    mp3_status: int = 200,
+    mp3_body: bytes = _FAKE_MP3,
+):
+    """Construct an httpx mock handler emulating the Irodori service.
+
+    The synthesis endpoint (``_SYNTH_URL``) returns ``synth_json``; any
+    other GET is treated as the MP3 fetch and returns ``mp3_body``.
+    """
+    if synth_json is None:
+        synth_json = {
+            "success": True,
+            "mp3StreamingUrl": _MP3_STREAM_URL,
+            "mp3DownloadUrl": _MP3_DOWNLOAD_URL,
+        }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_no_query = str(request.url).split("?", 1)[0]
+        captured.append(
+            {
+                "method": request.method,
+                "url": url_no_query,
+                "params": dict(request.url.params),
+            }
+        )
+        if url_no_query == _SYNTH_URL:
+            return httpx.Response(synth_status, json=synth_json)
+        # Anything else is the MP3 fetch.
+        return httpx.Response(mp3_status, content=mp3_body)
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Defaults / construction
+# ---------------------------------------------------------------------------
+
+
+def test_engine_name_is_irodori():
+    """The registry uses ``name`` to look up engines from the say tool's voice arg."""
+    engine = IrodoriEngine(url=_SYNTH_URL)
+    assert engine.name == "irodori"
+
+
+def test_default_speaker_and_steps_constants():
+    """Defaults pinned so docs stay honest."""
+    assert DEFAULT_IRODORI_SPEAKER == "3"
+    assert DEFAULT_IRODORI_STEPS == "24"
+
+
+def test_defaults_read_from_env(monkeypatch):
+    """Speaker / steps fall back to env vars when not passed to the constructor."""
+    monkeypatch.setenv("STACKCHAN_IRODORI_SPEAKER", "7")
+    monkeypatch.setenv("STACKCHAN_IRODORI_STEPS", "32")
+    engine = IrodoriEngine(url=_SYNTH_URL)
+    assert engine.default_speaker == "7"
+    assert engine.default_steps == "32"
+
+
+def test_constructor_args_override_env(monkeypatch):
+    """Constructor arguments win over the environment."""
+    monkeypatch.setenv("STACKCHAN_IRODORI_SPEAKER", "7")
+    monkeypatch.setenv("STACKCHAN_IRODORI_STEPS", "32")
+    engine = IrodoriEngine(url=_SYNTH_URL, default_speaker="2", default_steps="16")
+    assert engine.default_speaker == "2"
+    assert engine.default_steps == "16"
+
+
+# ---------------------------------------------------------------------------
+# Unset URL — registers but fails clearly on synthesize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_without_url_raises_clear_error(monkeypatch):
+    """No STACKCHAN_IRODORI_URL -> RuntimeError naming the env var.
+
+    The engine still constructs (so it stays discoverable in the
+    registry); the missing-URL condition surfaces only when synthesis is
+    attempted.
+    """
+    monkeypatch.delenv("STACKCHAN_IRODORI_URL", raising=False)
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine()  # no url, no env
+
+    with pytest.raises(RuntimeError, match="STACKCHAN_IRODORI_URL"):
+        await engine.synthesize("hello")
+
+
+@pytest.mark.asyncio
+async def test_synthesize_reads_url_from_env(monkeypatch):
+    """When no url is passed, STACKCHAN_IRODORI_URL is used."""
+    monkeypatch.setenv("STACKCHAN_IRODORI_URL", _SYNTH_URL)
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(transport=transport)
+
+    pcm = await engine.synthesize("hello")
+
+    assert isinstance(pcm, bytes)
+    assert len(pcm) > 0
+    assert captured[0]["url"] == _SYNTH_URL
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_happy_path_get_json_fetch_pcm(monkeypatch):
+    """GET synth -> JSON -> fetch streaming MP3 -> decoded PCM bytes."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    decode_captured = _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    pcm = await engine.synthesize("こんにちは")
+
+    # Two GETs: the synthesis request then the MP3 fetch.
+    assert len(captured) == 2
+    assert captured[0]["method"] == "GET"
+    assert captured[0]["url"] == _SYNTH_URL
+    assert captured[0]["params"]["text"] == "こんにちは"
+    assert captured[0]["params"]["speaker"] == DEFAULT_IRODORI_SPEAKER
+    assert captured[0]["params"]["steps"] == DEFAULT_IRODORI_STEPS
+    # Streaming URL is preferred over the download URL.
+    assert captured[1]["url"] == _MP3_STREAM_URL.split("?", 1)[0]
+    # The fetched MP3 bytes were the ones handed to the decoder.
+    assert decode_captured == [_FAKE_MP3]
+    assert isinstance(pcm, bytes)
+    assert len(pcm) > 0
+
+
+@pytest.mark.asyncio
+async def test_synthesize_passes_speaker_and_steps_overrides(monkeypatch):
+    """speaker_id / steps opts are forwarded as query params verbatim."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    await engine.synthesize("hi", speaker_id=9, steps=40, seconds=5)
+
+    params = captured[0]["params"]
+    assert params["speaker"] == "9"
+    assert params["steps"] == "40"
+    assert params["seconds"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_forwards_api_key_when_set(monkeypatch):
+    """An API key (env) is forwarded as the 'key' query param."""
+    monkeypatch.setenv("STACKCHAN_IRODORI_KEY", "secret-token")
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    await engine.synthesize("hi")
+
+    assert captured[0]["params"]["key"] == "secret-token"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_omits_key_when_unset(monkeypatch):
+    """No API key -> no 'key' query param (not an empty one)."""
+    monkeypatch.delenv("STACKCHAN_IRODORI_KEY", raising=False)
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    await engine.synthesize("hi")
+
+    assert "key" not in captured[0]["params"]
+
+
+@pytest.mark.asyncio
+async def test_synthesize_passes_emoji_through_verbatim(monkeypatch):
+    """Emoji in the text must reach the API unmodified (style cue)."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    await engine.synthesize("やったね😊🎉")
+
+    assert captured[0]["params"]["text"] == "やったね😊🎉"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_falls_back_to_download_url(monkeypatch):
+    """When only mp3DownloadUrl is present, it is used."""
+    captured: list[dict] = []
+    handler = _build_handler(
+        captured,
+        synth_json={
+            "success": True,
+            "mp3StreamingUrl": None,
+            "mp3DownloadUrl": _MP3_DOWNLOAD_URL,
+        },
+    )
+    transport = httpx.MockTransport(handler)
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    await engine.synthesize("hi")
+
+    assert captured[1]["url"] == _MP3_DOWNLOAD_URL.split("?", 1)[0]
+
+
+@pytest.mark.asyncio
+async def test_synthesize_resamples_non_device_rate(monkeypatch):
+    """A 48 kHz decode is resampled down to the device's 16 kHz."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    # 48 kHz, 1440 samples (30 ms). Resampled to 16 kHz -> ~480 samples.
+    _patch_decode(monkeypatch, sample_rate=48000, pcm=_fake_pcm_16k(1440))
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    pcm = await engine.synthesize("hi")
+
+    decoded = array.array("h")
+    decoded.frombytes(pcm)
+    # 1440 * 16000 / 48000 = 480, allow tiny interpolation tolerance.
+    assert 470 <= len(decoded) <= 490
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_rejects_empty_text(monkeypatch):
+    """Empty/whitespace text fails fast before any HTTP call."""
+    captured: list[dict] = []
+    transport = httpx.MockTransport(_build_handler(captured))
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    with pytest.raises(ValueError, match="text"):
+        await engine.synthesize("   ")
+
+    assert captured == []  # never reached the network
+
+
+@pytest.mark.asyncio
+async def test_synthesize_success_false_raises_with_server_error(monkeypatch):
+    """success: false surfaces the server-provided error text."""
+    captured: list[dict] = []
+    handler = _build_handler(
+        captured,
+        synth_json={"success": False, "error": "speaker out of range"},
+    )
+    transport = httpx.MockTransport(handler)
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    with pytest.raises(RuntimeError, match="speaker out of range"):
+        await engine.synthesize("hi")
+
+    # Only the synthesis request happened; no MP3 fetch.
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_synthesize_http_non_200_raises(monkeypatch):
+    """A non-200 from the synthesis endpoint is an engine failure."""
+    captured: list[dict] = []
+    handler = _build_handler(
+        captured,
+        synth_status=503,
+        synth_json={"error": "overloaded"},
+    )
+    transport = httpx.MockTransport(handler)
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    with pytest.raises(RuntimeError, match="503"):
+        await engine.synthesize("hi")
+
+
+@pytest.mark.asyncio
+async def test_synthesize_missing_mp3_url_raises(monkeypatch):
+    """success: true but no MP3 URL fields -> clear error."""
+    captured: list[dict] = []
+    handler = _build_handler(
+        captured,
+        synth_json={"success": True, "mp3StreamingUrl": None, "mp3DownloadUrl": None},
+    )
+    transport = httpx.MockTransport(handler)
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    with pytest.raises(RuntimeError, match="MP3 URL"):
+        await engine.synthesize("hi")
+
+    assert len(captured) == 1  # no fetch attempted
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_fetch_non_200_raises(monkeypatch):
+    """A non-200 on the MP3 fetch is an engine failure."""
+    captured: list[dict] = []
+    handler = _build_handler(captured, mp3_status=404)
+    transport = httpx.MockTransport(handler)
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=_SYNTH_URL, transport=transport)
+
+    with pytest.raises(RuntimeError, match="MP3 fetch failed"):
+        await engine.synthesize("hi")

--- a/gateway/tests/test_irodori.py
+++ b/gateway/tests/test_irodori.py
@@ -164,6 +164,47 @@ async def test_synthesize_reads_url_from_env(monkeypatch):
     assert captured[0]["url"] == _SYNTH_URL
 
 
+@pytest.mark.asyncio
+async def test_synthesize_preserves_trailing_slash_url(monkeypatch):
+    """A trailing slash on the endpoint URL is requested verbatim.
+
+    The configured value is the synthesis *endpoint* URL, not a base
+    URL: a deployment defined as ``.../api/synthesize/`` must not be
+    rewritten to ``.../api/synthesize``, which strict-routing servers
+    treat as a different path.
+    """
+    slash_url = _SYNTH_URL + "/"
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_no_query = str(request.url).split("?", 1)[0]
+        requests.append(url_no_query)
+        if url_no_query == slash_url:
+            return httpx.Response(
+                200,
+                json={"success": True, "mp3StreamingUrl": _MP3_STREAM_URL},
+            )
+        return httpx.Response(200, content=_FAKE_MP3)
+
+    _patch_decode(monkeypatch)
+    engine = IrodoriEngine(url=slash_url, transport=httpx.MockTransport(handler))
+
+    pcm = await engine.synthesize("hello")
+
+    assert requests[0] == slash_url
+    assert isinstance(pcm, bytes)
+    assert len(pcm) > 0
+
+
+def test_resolve_url_env_trailing_slash_and_whitespace(monkeypatch):
+    """Env URL keeps its trailing slash; only surrounding whitespace goes."""
+    slash_url = _SYNTH_URL + "/"
+    monkeypatch.setenv("STACKCHAN_IRODORI_URL", f"  {slash_url}  ")
+    engine = IrodoriEngine()
+
+    assert engine._resolve_url() == slash_url
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_tts_framework.py
+++ b/gateway/tests/test_tts_framework.py
@@ -16,6 +16,10 @@ from stackchan_mcp.tts import (
     get_registry,
     synthesize_and_send,
 )
+from stackchan_mcp.tts.orchestrator import (
+    TTS_ENGINE_ENV_VAR,
+    _resolve_default_engine,
+)
 
 
 class _FakeEngine(TTSEngine):
@@ -171,3 +175,71 @@ async def test_synthesize_and_send_lists_available_engines_in_error():
     msg = str(exc_info.value)
     assert "alpha" in msg
     assert "beta" in msg
+
+
+# ---------------------------------------------------------------------------
+# STACKCHAN_TTS_ENGINE default-engine override (Issue #286)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_engine_unset_is_voicevox(monkeypatch):
+    """No STACKCHAN_TTS_ENGINE -> the built-in DEFAULT_VOICE."""
+    monkeypatch.delenv(TTS_ENGINE_ENV_VAR, raising=False)
+    assert _resolve_default_engine() == DEFAULT_VOICE
+
+
+def test_resolve_default_engine_env_override(monkeypatch):
+    """STACKCHAN_TTS_ENGINE selects the default engine."""
+    monkeypatch.setenv(TTS_ENGINE_ENV_VAR, "irodori")
+    assert _resolve_default_engine() == "irodori"
+
+
+def test_resolve_default_engine_blank_env_ignored(monkeypatch):
+    """A blank/whitespace value is ignored, falling back to DEFAULT_VOICE."""
+    monkeypatch.setenv(TTS_ENGINE_ENV_VAR, "   ")
+    assert _resolve_default_engine() == DEFAULT_VOICE
+
+
+@pytest.mark.asyncio
+async def test_synthesize_and_send_uses_env_default_engine(monkeypatch):
+    """With no 'voice' arg, the engine looked up comes from the env override.
+
+    The unregistered-engine error names the resolved engine, which lets
+    us confirm the orchestrator consulted STACKCHAN_TTS_ENGINE without
+    standing up a full gateway.
+    """
+    monkeypatch.setenv(TTS_ENGINE_ENV_VAR, "irodori")
+    reg = EngineRegistry()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send({"text": "hello"}, registry=reg)
+
+    assert "irodori" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_explicit_voice_overrides_env_default(monkeypatch):
+    """An explicit 'voice' argument still wins over STACKCHAN_TTS_ENGINE."""
+    monkeypatch.setenv(TTS_ENGINE_ENV_VAR, "irodori")
+    reg = EngineRegistry()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send(
+            {"text": "hello", "voice": "voicevox"}, registry=reg
+        )
+
+    msg = str(exc_info.value)
+    assert "voicevox" in msg
+    assert "irodori" not in msg
+
+
+@pytest.mark.asyncio
+async def test_omitted_voice_with_env_unset_uses_default_voice(monkeypatch):
+    """Omitted 'voice' + unset env -> DEFAULT_VOICE is the looked-up engine."""
+    monkeypatch.delenv(TTS_ENGINE_ENV_VAR, raising=False)
+    reg = EngineRegistry()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await synthesize_and_send({"text": "hello"}, registry=reg)
+
+    assert DEFAULT_VOICE in str(exc_info.value)

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -940,6 +940,47 @@ wheels = [
 ]
 
 [[package]]
+name = "miniaudio"
+version = "1.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/8f/8a792b93d27e57862754dbce780c6363ddbad7e56f40568dd3838b8d6862/miniaudio-1.71-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:19dc58e4c50ffc48db2ce988019c28f05ca0eaa7c10b45b5c99b70107e610c8a", size = 367726, upload-time = "2026-04-29T21:20:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3a/645db5b3ba8f7c1ff319e38a7150054f35818795ed312a3a5e4f061624b0/miniaudio-1.71-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aee8e4eec8d7bde4ee78066561329235a04231a221c9b247f1ffaf850551087d", size = 351407, upload-time = "2026-04-29T21:20:02.286Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a8/91140e67b45efc1457bb78fae48cff691097c4bef9b4eeb16f9d3ee83ade/miniaudio-1.71-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14892ad9b884e637029a22a781dea569b292a1be13682380fd14cefcf80ea4ed", size = 643696, upload-time = "2026-04-29T21:20:04.001Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/f1688175ac1b598fbd2985d75830e85ce604eca7f0f85710dcd282971377/miniaudio-1.71-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f7042af3a4db5b90e5efaea257b6dfcff9389239ea643e6b0faa80169528e2e6", size = 645512, upload-time = "2026-04-29T21:20:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/63/8eacdc9e60c1f5a3622ad007f56e503f4c7e725b82808bc30349fa4abe21/miniaudio-1.71-cp310-cp310-win32.whl", hash = "sha256:ea86ae04ddbbf2beed20b9970af4a0baca8e6ed0e9625e1ed957be5540c943fd", size = 235043, upload-time = "2026-04-29T21:20:06.731Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bc/846a6e427848317eac2b773f9df5b88c105248a662cd5265029a367188a5/miniaudio-1.71-cp310-cp310-win_amd64.whl", hash = "sha256:978cc4d58d8beef1a705e1141dc177a8a357c10ba3a16f7d71482ee722023bbd", size = 274192, upload-time = "2026-04-29T21:20:08.009Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1a/8ded8b04490e0d50e2a404fc99858163c9567a135eaab35990b42bdfad72/miniaudio-1.71-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ac4a37ebbbfbfbeca50f4390e50f9952807ca61ac62f0c3bcbbc7dd698531dd3", size = 367726, upload-time = "2026-04-29T21:20:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/4b13ac3c36a2574e0d70f322246d80259606cd24523279f542abc9ac6063/miniaudio-1.71-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5009b4e29cd43de3631d2d5ab09cc074192c085b4c8dd8a121b856ce1af6bab7", size = 351405, upload-time = "2026-04-29T21:20:10.533Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7b/0087c224b373a8b179dfdadc7506f504531f670b41e2444823c3540b6755/miniaudio-1.71-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06222d80b057ca4beccb6f97a134c2c2bf646ef7890e1759cfc09db7eecec44d", size = 643689, upload-time = "2026-04-29T21:20:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ee/f744ea9b6e09125120d30f0dd345e456d300956f54aa745bdf2648ad832f/miniaudio-1.71-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:166516449e2bb5f628d89cedbbb8720dceb96a0562c7e08a0e8e3cb10f58647c", size = 645509, upload-time = "2026-04-29T21:20:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/42/52/dae0cb47b6aa4c9641ed26e9e78c5c51f5cbd9daa8ae40d209f7b9d18e9f/miniaudio-1.71-cp311-cp311-win32.whl", hash = "sha256:9f379d4995f1fac6dcae65810f6a31cba264339b3e591a14b233f85a6d03d81e", size = 235040, upload-time = "2026-04-29T21:20:14.363Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/2c97c0638c04b784c60114a61fd653f2ac04e35de912c26ed85d331a180f/miniaudio-1.71-cp311-cp311-win_amd64.whl", hash = "sha256:50d66729e1dd7a4cf13edc25115ac54f776dd9f67803ba1a7cd1128ebf2e8cfe", size = 274186, upload-time = "2026-04-29T21:20:15.504Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d3/71124f5abbcdcae62e040f58d3dca3bd3d90fd01faa7bb276b112387b47a/miniaudio-1.71-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:62db602651bc20a2698f36a0d356d7217ed6f4f917550c7ffb3705c8e8be90cf", size = 377186, upload-time = "2026-04-29T21:20:16.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ac/30a324f758bed1b193e017ec25183cfb10a79e549656331f5d068a2d343a/miniaudio-1.71-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fc1a4f084cc1b4b25c567d22f54d1e46bfa505c17ed777c8b198e5c53d0f785", size = 351485, upload-time = "2026-04-29T21:20:17.761Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/62/ae884a9d3b2ebec9c2ed1db857593e74bff45b70c4ab17fccc11db31cbeb/miniaudio-1.71-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19be6f0a1e601c2237433e579734cfaf6469191b224c20c9e5f73c32ef9ee2b9", size = 643556, upload-time = "2026-04-29T21:20:18.87Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/39/84fc665e2ea8f9f1301b6370226e3a24f08d5ad5d97143b69b4ae7ac260a/miniaudio-1.71-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e6287f15caa808a88aad0700a182bec1ff6d98769717425adf9ebf41259d1936", size = 645176, upload-time = "2026-04-29T21:20:20.194Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b8/37d9f67d4511da29bdb82b6c73a3ef6f4ebf2fbd30f9524f1e4a84d6f033/miniaudio-1.71-cp312-cp312-win32.whl", hash = "sha256:ab100e5240b104b5326e4ec1be07b6ae461f7d3d4d7a694857fd2f0493d210f9", size = 235095, upload-time = "2026-04-29T21:20:21.653Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/c1a19e6800e725b6e2b4576407620a798d69e3528ebdea9aea84d69d7088/miniaudio-1.71-cp312-cp312-win_amd64.whl", hash = "sha256:f4a44b70b66628b0c307e40ae0ae857695978cae18462179b806d8edc807d416", size = 274252, upload-time = "2026-04-29T21:20:22.824Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/85/44545f767ec21142ffed5f9108406d11dc8a19aafed9bd57621a0892bb60/miniaudio-1.71-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:61b86f26d653040db32d9d15b05446321dd10e45beba25b44f841e26935213d5", size = 377184, upload-time = "2026-04-29T21:20:24.109Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d1/071a560000c8ce903dc919968ecce40fbe7a73213ac399051b887184f8a3/miniaudio-1.71-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d9dc15eff711bcfc62a9d05e0c78e4bc34821a455595e049629f2fea7491a523", size = 351488, upload-time = "2026-04-29T21:20:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/46/24/5873a569451cae5686fb656ebd78ffe0b5eebe48ca21ef61e227d237d20a/miniaudio-1.71-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12bc33e7e61072b4b541c14e10ef76119d5643e6bbb98e2dec0c0738889438fb", size = 643552, upload-time = "2026-04-29T21:20:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/90/9b/25785525e6b5ff9afd7f4c4279215dc09c3317ea4d837275b1ae17912b36/miniaudio-1.71-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:70fa2ea5353e6919aca59b8c5768144af009d18c3bca251749d66fb497424563", size = 645171, upload-time = "2026-04-29T21:20:27.494Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6d/cbfd55fdc40256231f7b0c861e2bf79cc289bfbbe5e15869317944e6d673/miniaudio-1.71-cp313-cp313-win32.whl", hash = "sha256:1bf93aeede652926f27f430f0fd69ef0cf8a949c07b537d6a2f295602c747037", size = 235088, upload-time = "2026-04-29T21:20:29.031Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8d/d5059c04b247b1079c0e48914a9ec20352910a3b9373060fb258dfd194ab/miniaudio-1.71-cp313-cp313-win_amd64.whl", hash = "sha256:4c849ccb1349f7b3553a77a66fe7e972315185f5c4c44a0bbda7ebcdd224db37", size = 274247, upload-time = "2026-04-29T21:20:29.96Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e7/b3e0df641d2d5283446d7960fc407195ba722b9a0789bb0a1429bf9ee855/miniaudio-1.71-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3ef441d139264f8a5dcb9aa6fcd0b1e1e69f58715baae416ff33f045ffba6ad5", size = 378418, upload-time = "2026-04-29T21:20:31.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ea/f5940232d0c83777562e802f376a841046d78e94753450fb9a6685a44190/miniaudio-1.71-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:84139a10ef172acd762ccf120142877b037a1aaf71def99d2c75f66329f89d8b", size = 351473, upload-time = "2026-04-29T21:20:32.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a6/6b5ae21b74fe70da935de389e01b3cce86c790ca4083f6a63c3ee922673e/miniaudio-1.71-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a28ff4ad23e55bbde8808ce525d3bb7d249d7612f77646b30e06fc6b7a778ac", size = 643683, upload-time = "2026-04-29T21:20:33.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/ef851e2e1d9dfde2b97cc053f0d79c6612088b27044698ed5d8c687f05de/miniaudio-1.71-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:33986d5d725ebcbc253551e7358689bc81b19b6950b33cec8e8c1142ca4fc0a9", size = 645203, upload-time = "2026-04-29T21:20:34.713Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/0da61fea8b8469d51b77d43846572ef9255d54c9b6b65a552446bbd55f90/miniaudio-1.71-cp314-cp314-win32.whl", hash = "sha256:3bbeb1e068fe42475e017e8150e9e345182b583d0dd4d9e77ffa20c39935d9ec", size = 241126, upload-time = "2026-04-29T21:20:35.975Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d0/ad7bfa63e1baacd2d4803ee04862bb06fcfbbb34a340bf2bf3979e0068dc/miniaudio-1.71-cp314-cp314-win_amd64.whl", hash = "sha256:154b085dd914a0e79e3d93160e1a07aacb27d66c65f9ef6a0d87c1a194f32c04", size = 281740, upload-time = "2026-04-29T21:20:37.07Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2046,6 +2087,11 @@ tts = [
     { name = "httpx" },
     { name = "opuslib" },
 ]
+tts-irodori = [
+    { name = "httpx" },
+    { name = "miniaudio" },
+    { name = "opuslib" },
+]
 tts-voicevox = [
     { name = "httpx" },
     { name = "opuslib" },
@@ -2064,6 +2110,7 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'stt-faster-whisper'", specifier = ">=1.0" },
     { name = "httpx", marker = "extra == 'tts'", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.27,<2.0" },
+    { name = "miniaudio", marker = "extra == 'tts-irodori'", specifier = ">=1.59" },
     { name = "openai", marker = "extra == 'stt-openai'", specifier = ">=1.0" },
     { name = "opuslib", marker = "extra == 'stt'", specifier = ">=3" },
     { name = "opuslib", marker = "extra == 'tts'", specifier = ">=3" },
@@ -2072,11 +2119,12 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-faster-whisper'" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-openai'" },
+    { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-irodori'" },
     { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-voicevox'" },
     { name = "websockets", specifier = ">=12" },
     { name = "zeroconf", specifier = ">=0.149" },
 ]
-provides-extras = ["tts", "tts-voicevox", "stt", "stt-faster-whisper", "stt-openai"]
+provides-extras = ["tts", "tts-voicevox", "tts-irodori", "stt", "stt-faster-whisper", "stt-openai"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds the Irodori TTS engine as a second selectable synthesis engine alongside VOICEVOX. Closes #286.

- New `gateway/stackchan_mcp/tts/irodori.py`: a thin HTTP client for a self-hosted Irodori-compatible synthesis API. Flow: `GET` synthesis request → JSON (`mp3StreamingUrl` / `mp3DownloadUrl`) → MP3 fetch → decode to 16 kHz mono PCM. Opus encoding and the WebSocket push stay in the orchestrator, so the engine rides the existing `say` pipeline unchanged.
- New `tts-irodori` optional extra: adds `miniaudio` (MIT, self-contained C extension with prebuilt wheels for Windows / macOS / Linux — keeps the windows-smoke CI path simple) on top of the base `[tts]` extra for MP3 decoding. Imports are lazy-guarded so the TTS framework works without the extra installed.
- New `STACKCHAN_TTS_ENGINE` env var: overrides the default engine for `say` calls that omit `voice`. VOICEVOX remains the default when unset, and an explicit `voice` argument always wins.
- No default endpoint URL by design: `STACKCHAN_IRODORI_URL` is required (self-host premise — shipping a hard-coded URL would point every install at someone else's deployment). The engine still registers for discoverability; synthesis without the URL fails with clear setup guidance.
- Emoji in the input text pass through verbatim — Irodori interprets them natively as a voice-style cue. #289 builds on this; no emoji parsing happens here.
- EN/JP README sections (same commit) + CHANGELOG `[Unreleased]` Gateway entry.

## Review

Local codex review: 3 rounds, converged at 0 findings.

- R1 finding (P2): trailing slash in the endpoint URL was being stripped; the value is the endpoint URL itself, not a base URL. Fixed in 3674324 with regression tests for both the constructor and env paths.
- R2 finding (P2): speaker/steps defaults captured the environment at construction time, which ignores `.env` values under `serve --transport streamable-http` (the engine is registered at import time, before dotenv loads). Now resolved lazily like the URL and API key. Fixed in feb446c.

## Validation / Test plan

- `cd gateway && uv run pytest` — 513 passed, 1 skipped (21 new Irodori tests + `STACKCHAN_TTS_ENGINE` override tests; HTTP fully mocked via `httpx.MockTransport`, decode boundary monkeypatched so no C extension is needed in CI)
- `cd gateway && uv run ruff check .` — clean
- `uv lock` re-run; `gateway/uv.lock` committed with the new extra
- CHANGELOG `[Unreleased]` Gateway entry added
- On-device listening test deferred until a synthesis endpoint is available: the engine is env-gated and inert unless configured, and the VOICEVOX path is unchanged (existing tests cover it)

## Out of scope / follow-up candidates

- Warmup request support to hide cold-start latency (listed as optional in #286; deliberately deferred to keep this PR thin)
- Lazy env resolution for the VOICEVOX engine URL (same import-order pattern, pre-existing)
- Stale `say` tool description in `stdio_server.py` (predates this change; docs-sync nit)
- Lip-sync threshold tuning across engines (#85) and emoji-driven expression bundling (#289)
