### PR TITLE
feat(gateway): expose self.port_b.ws2812.* as MCP tools (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ documented-only.
 
 ### Gateway
 
+- Added gateway-side MCP wrappers for
+  `self.port_b.ws2812.{init,set_pixel,set_strip,refresh,clear}`, forwarding
+  Port B (GPIO 9) WS2812 calls to firmware and JSON-encoding
+  `set_strip.colors` for the device MCP property layer. (#224)
 - Add emoji-driven expression handling to `say`: a supported emoji
   switches the avatar face in the same MCP call, Irodori receives emoji
   verbatim for voice style, and non-emoji-aware engines strip emoji before

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -537,6 +537,26 @@ async def _dispatch_mcp_tool(
             "self.led.clear",
             {},
         ),
+        "port_b_ws2812_init": (
+            "self.port_b.ws2812.init",
+            arguments,
+        ),
+        "port_b_ws2812_set_pixel": (
+            "self.port_b.ws2812.set_pixel",
+            arguments,
+        ),
+        "port_b_ws2812_set_strip": (
+            "self.port_b.ws2812.set_strip",
+            {"colors": json.dumps(arguments.get("colors", []))},
+        ),
+        "port_b_ws2812_refresh": (
+            "self.port_b.ws2812.refresh",
+            {},
+        ),
+        "port_b_ws2812_clear": (
+            "self.port_b.ws2812.clear",
+            {},
+        ),
         "i2c_scan": (
             "self.i2c.scan",
             {},
@@ -1027,6 +1047,139 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
             Tool(
                 name="clear_leds",
                 description="Turn off all 12 RGB LEDs on the StackChan base.",
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="port_b_ws2812_init",
+                description=(
+                    "Initialize a WS2812-compatible LED strip connected to "
+                    "Port B (CoreS3 HY2.0-4P digital OUTPUT, GPIO 9). "
+                    "led_count is the number of LEDs in the strip (1..256). "
+                    "Repeated calls with the same led_count are no-ops; a "
+                    "different led_count rebuilds the strip handle. Port B "
+                    "outputs 3.3 V CMOS data on GPIO 9; older strict 5 V "
+                    "WS2812 variants may require a level shifter."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "led_count": {
+                            "type": "integer",
+                            "description": "Number of LEDs in the strip (1..256).",
+                            "minimum": 1,
+                            "maximum": 256,
+                        },
+                    },
+                    "required": ["led_count"],
+                },
+            ),
+            Tool(
+                name="port_b_ws2812_set_pixel",
+                description=(
+                    "Set one LED in the Port B WS2812 strip buffer. Call "
+                    "port_b_ws2812_init first. index is 0..255, with the "
+                    "effective range bounded by led_count. r, g, and b are "
+                    "0..255. By default the color is buffered only; pass "
+                    "refresh=true to latch it immediately, or call "
+                    "port_b_ws2812_refresh after several buffered updates. "
+                    "Port B outputs 3.3 V CMOS data on GPIO 9; older strict "
+                    "5 V WS2812 variants may require a level shifter."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "description": "LED index (0..255).",
+                            "minimum": 0,
+                            "maximum": 255,
+                        },
+                        "r": {
+                            "type": "integer",
+                            "description": "Red 0..255.",
+                            "minimum": 0,
+                            "maximum": 255,
+                        },
+                        "g": {
+                            "type": "integer",
+                            "description": "Green 0..255.",
+                            "minimum": 0,
+                            "maximum": 255,
+                        },
+                        "b": {
+                            "type": "integer",
+                            "description": "Blue 0..255.",
+                            "minimum": 0,
+                            "maximum": 255,
+                        },
+                        "refresh": {
+                            "type": "boolean",
+                            "description": "True to latch the update immediately.",
+                            "default": False,
+                        },
+                    },
+                    "required": ["index", "r", "g", "b"],
+                },
+            ),
+            Tool(
+                name="port_b_ws2812_set_strip",
+                description=(
+                    "Set multiple LEDs in the Port B WS2812 strip and refresh "
+                    "immediately. Call port_b_ws2812_init first. colors is an "
+                    "array of [r,g,b] integer triples applied from LED index 0; "
+                    "up to led_count entries are written, extras are ignored, "
+                    "and missing trailing entries preserve the previous buffer. "
+                    "The firmware validates the full payload before writing. "
+                    "Port B outputs 3.3 V CMOS data on GPIO 9; older strict "
+                    "5 V WS2812 variants may require a level shifter."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "colors": {
+                            "type": "array",
+                            "description": (
+                                "Array of [r,g,b] triples, each integer 0..255."
+                            ),
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 255,
+                                },
+                                "minItems": 3,
+                                "maxItems": 3,
+                            },
+                            "minItems": 1,
+                            "maxItems": 256,
+                        },
+                    },
+                    "required": ["colors"],
+                },
+            ),
+            Tool(
+                name="port_b_ws2812_refresh",
+                description=(
+                    "Refresh the Port B WS2812 strip, latching the current "
+                    "buffered colors out on CoreS3 HY2.0-4P digital OUTPUT "
+                    "GPIO 9. Call port_b_ws2812_init first. Use this after "
+                    "one or more port_b_ws2812_set_pixel calls made with "
+                    "refresh=false. Port B outputs 3.3 V CMOS data; older "
+                    "strict 5 V WS2812 variants may require a level shifter."
+                ),
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="port_b_ws2812_clear",
+                description=(
+                    "Turn off every LED in the Port B WS2812 strip and "
+                    "refresh immediately on CoreS3 HY2.0-4P digital OUTPUT "
+                    "GPIO 9. Call port_b_ws2812_init first. This clears the "
+                    "driver's per-pixel buffer. Port B outputs 3.3 V CMOS "
+                    "data; older strict 5 V WS2812 variants may require a "
+                    "level shifter."
+                ),
                 inputSchema={"type": "object", "properties": {}},
             ),
             Tool(

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -394,6 +394,178 @@ async def test_set_mouth_sequence_relays_steps_as_json_string(monkeypatch):
     assert json.loads(arguments["steps_json"]) == steps
 
 
+_PORT_B_WS2812_TOOL_NAMES = (
+    "port_b_ws2812_init",
+    "port_b_ws2812_set_pixel",
+    "port_b_ws2812_set_strip",
+    "port_b_ws2812_refresh",
+    "port_b_ws2812_clear",
+)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_port_b_ws2812_tools_with_schemas():
+    """Port B WS2812 wrappers are exposed with LLM-facing schemas."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tools_by_name = {tool.name: tool for tool in result.root.tools}
+    for tool_name in _PORT_B_WS2812_TOOL_NAMES:
+        assert tool_name in tools_by_name, f"{tool_name} tool should be registered"
+        description = tools_by_name[tool_name].description
+        assert "Port B" in description
+        assert "GPIO 9" in description
+        assert "3.3 V CMOS data" in description
+        assert "level shifter" in description
+
+    init_schema = tools_by_name["port_b_ws2812_init"].inputSchema
+    assert init_schema["properties"]["led_count"] == {
+        "type": "integer",
+        "description": "Number of LEDs in the strip (1..256).",
+        "minimum": 1,
+        "maximum": 256,
+    }
+    assert init_schema["required"] == ["led_count"]
+
+    pixel_schema = tools_by_name["port_b_ws2812_set_pixel"].inputSchema
+    assert pixel_schema["properties"]["index"]["minimum"] == 0
+    assert pixel_schema["properties"]["index"]["maximum"] == 255
+    for channel in ("r", "g", "b"):
+        assert pixel_schema["properties"][channel]["minimum"] == 0
+        assert pixel_schema["properties"][channel]["maximum"] == 255
+    assert pixel_schema["properties"]["refresh"] == {
+        "type": "boolean",
+        "description": "True to latch the update immediately.",
+        "default": False,
+    }
+    assert pixel_schema["required"] == ["index", "r", "g", "b"]
+
+    strip_schema = tools_by_name["port_b_ws2812_set_strip"].inputSchema
+    colors_schema = strip_schema["properties"]["colors"]
+    assert colors_schema["type"] == "array"
+    assert colors_schema["minItems"] == 1
+    assert colors_schema["maxItems"] == 256
+    assert colors_schema["items"]["type"] == "array"
+    assert colors_schema["items"]["minItems"] == 3
+    assert colors_schema["items"]["maxItems"] == 3
+    assert colors_schema["items"]["items"] == {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255,
+    }
+    assert strip_schema["required"] == ["colors"]
+
+    for tool_name in ("port_b_ws2812_refresh", "port_b_ws2812_clear"):
+        assert tools_by_name[tool_name].inputSchema == {
+            "type": "object",
+            "properties": {},
+        }
+
+
+def _make_port_b_ws2812_fake_gateway(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, tool_name, arguments):
+            calls.append((tool_name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"ok": True}),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    return calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("gateway_name", "request_args", "firmware_name", "firmware_args"),
+    [
+        (
+            "port_b_ws2812_init",
+            {"led_count": 18},
+            "self.port_b.ws2812.init",
+            {"led_count": 18},
+        ),
+        (
+            "port_b_ws2812_set_pixel",
+            {"index": 2, "r": 10, "g": 20, "b": 30, "refresh": True},
+            "self.port_b.ws2812.set_pixel",
+            {"index": 2, "r": 10, "g": 20, "b": 30, "refresh": True},
+        ),
+        (
+            "port_b_ws2812_refresh",
+            {},
+            "self.port_b.ws2812.refresh",
+            {},
+        ),
+        (
+            "port_b_ws2812_clear",
+            {},
+            "self.port_b.ws2812.clear",
+            {},
+        ),
+    ],
+)
+async def test_port_b_ws2812_tools_relay_to_firmware(
+    monkeypatch,
+    gateway_name,
+    request_args,
+    firmware_name,
+    firmware_args,
+):
+    calls = _make_port_b_ws2812_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": gateway_name, "arguments": request_args},
+        )
+    )
+
+    assert calls == [(firmware_name, firmware_args)]
+    assert json.loads(result.root.content[0].text) == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_port_b_ws2812_set_strip_relays_colors_as_json_string(monkeypatch):
+    calls = _make_port_b_ws2812_fake_gateway(monkeypatch)
+    server = create_server()
+    colors = [[32, 0, 0], [0, 32, 0], [0, 0, 32]]
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": "port_b_ws2812_set_strip",
+                "arguments": {"colors": colors},
+            },
+        )
+    )
+
+    assert len(calls) == 1
+    name, arguments = calls[0]
+    assert name == "self.port_b.ws2812.set_strip"
+    assert set(arguments.keys()) == {"colors"}
+    assert json.loads(arguments["colors"]) == colors
+    assert json.loads(result.root.content[0].text) == {"ok": True}
+
+
 # ---------------------------------------------------------------------------
 # move_head — Issue #109: schema + handler enforce the M5Stack-recommended
 # pitch operating range (5..85). pitch=0 motion-starts have been observed on


### PR DESCRIPTION
## Summary

Adds the gateway-side MCP wrapping for the five `self.port_b.ws2812.*` firmware tools that landed in PR #223 (firmware-only). Closes #224.

Downstream MCP clients previously got `{"error": "Unknown tool: ..."}` for Port B WS2812 calls because the gateway `tool_map` only carried the pre-#223 mappings. This adds:

| Gateway MCP tool | Firmware tool |
|---|---|
| `port_b_ws2812_init` | `self.port_b.ws2812.init` |
| `port_b_ws2812_set_pixel` | `self.port_b.ws2812.set_pixel` |
| `port_b_ws2812_set_strip` | `self.port_b.ws2812.set_strip` |
| `port_b_ws2812_refresh` | `self.port_b.ws2812.refresh` |
| `port_b_ws2812_clear` | `self.port_b.ws2812.clear` |

- `set_strip.colors` keeps a real `list[list[int]]` schema for LLM clients and is JSON-encoded before forwarding, following the existing `set_leds` precedent (the on-device MCP property layer has no array type).
- Tool descriptions cite Port B / GPIO 9 / 3.3 V CMOS data / level-shifter caveat, consistent with the firmware-side registrations in `firmware/main/boards/stackchan/stackchan.cc`.
- Same pattern as the Port A I2C generic wrapping (#196).

## Validation / Test plan

- `cd gateway && uv run pytest` — 492 passed, 1 skipped (new forwarding + schema tests for the five tools, including the `set_strip` JSON-encode behavior)
- `cd gateway && uv run ruff check .` — clean
- Local codex review: 1 round, no findings
- CHANGELOG `[Unreleased]` Gateway entry added
- Real-device smoke check (Issue AC: `port_b_ws2812_init(18)` followed by `port_b_ws2812_set_strip` with dim red produces visible light on a Port B strip) pending — tracked with the `owner-realdevice-verify` label before merge

## Refs

- Closes #224
- Firmware-side counterpart: #223 (merged; shipped in firmware-v1.9.0)
- Pattern reference: #196 (Port A I2C generic)

Note: the Issue's original "Release implication" section referenced the firmware-v1.9.0 + gateway v0.9.0 pair release, which has since shipped without this change; once merged, this lands in the next gateway release instead.
