### PR TITLE
feat(gateway): emoji-driven expression in say text — single-call speech + face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ documented-only.
 
 ### Gateway
 
+- Add emoji-driven expression handling to `say`: a supported emoji
+  switches the avatar face in the same MCP call, Irodori receives emoji
+  verbatim for voice style, and non-emoji-aware engines strip emoji before
+  synthesis. Emoji-only text changes the face and reports speech skipped
+  after stripping. (#289)
 - Add the Irodori TTS engine as a second selectable synthesis engine
   alongside VOICEVOX. It calls an external MP3 synthesis service (decoded
   to PCM via the new `tts-irodori` extra) and reuses the existing

--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@
 | `set_all_leds(r, g, b)` | ベース部の RGB LED 12 個すべてを同じ色に設定 | ✅ |
 | `set_leds(colors)` | `[[r,g,b], ...]` 配列で先頭 N 個を一括設定（I2C 1 回のバースト送信、アニメーション等向け）。指定外の LED は前の色を保持 | ✅ |
 | `clear_leds` | ベース部の RGB LED 12 個すべて消灯 | ✅ |
-| `say(text, voice?, speaker_id?, reference_audio?)` | gateway 側 TTS でデバイススピーカーから喋らせる。デフォルトエンジンは **VOICEVOX**（別 HTTP サービスとして起動 — [TTS セットアップ](#4-オプション-tts-セットアップ-voicevox) 参照）。`[tts]` extras が必要 | ✅ |
+| `say(text, voice?, speaker_id?, reference_audio?)` | gateway 側 TTS でデバイススピーカーから喋らせる。本文内の対応 emoji で、同じ呼び出し内にアバター表情も切り替え可能。デフォルトエンジンは **VOICEVOX**（別 HTTP サービスとして起動 — [TTS セットアップ](#4-オプション-tts-セットアップ-voicevox) 参照）。`[tts]` extras が必要 | ✅ |
 | `listen(duration_ms?, engine?, language?, model?, motion?, look_up_pitch?)` | デバイスマイクから短い発話をキャプチャし、gateway 側 STT で文字起こし。デフォルトエンジンは **faster-whisper**（ローカル動作・MIT — [STT セットアップ](#5-オプション-stt-セットアップ-faster-whisper) 参照）。任意の `motion` feedback で、キャプチャ中に `thinking` face を出したり、頭を上向きに傾けたりできます。`[stt-faster-whisper]`（または `[stt-openai]`）extras と、`listen` ワイヤタイプを受け付けるファームウェアが必要 | ✅ |
 
 詳細スキーマは `gateway/README.md` 参照。
@@ -383,12 +383,22 @@ gateway は VOICEVOX に POST → 返ってきた WAV をデコード →
 TTS フレームワークはエンジン非依存なので、他のエンジンも同じ
 `say` API の裏に差し込めます — 下記の Irodori エンジンを参照。
 
+`say` の本文には対応する表情 emoji も入れられます: happy
+(😊 😄 😀 😁 🙂 😆 🥰 😍 😋 🤗), sad (😢 😭 😞 😔 ☹️ 🙁 😿),
+surprised (😲 😮 😯 😱 🤯), embarrassed (😳 😅 🫣), thinking
+(🤔 🧐 💭)。最初に見つかった対応 emoji が、同じ MCP 呼び出し内で
+発話前にアバター表情を切り替えます。未対応 emoji は表情を変えません。
+VOICEVOX など emoji-style 非対応エンジンでは、合成前にすべての emoji を
+取り除きます。取り除いた結果が空文字列になる場合は、表情変更だけを試み、
+発話は skipped として返します。
+
 #### 別エンジン: Irodori
 
 Irodori は MP3 を返す外部合成サービスを呼ぶ 2 つ目の TTS
 エンジンです。VOICEVOX と同じ `say` パイプラインに乗り（MP3 を
 16 kHz mono PCM にデコードしてから Opus にエンコード）、入力
-テキストに含まれる絵文字を声質スタイルの指示として解釈します。
+テキストに含まれる emoji をそのまま受け取って voice-style cue として
+扱えます。
 
 **デフォルトのエンドポイントはありません** — 合成バックエンドは
 ホスト型サービスであり、URL をハードコードすると全インストールが

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This repository is a monorepo.
 | `set_all_leds(r, g, b)` | Set all 12 base RGB LEDs to the same color | ✅ |
 | `set_leds(colors)` | Batch-set the first N LEDs from a `[[r,g,b], ...]` array in a single I2C burst (use this for animations / multi-color patterns); trailing LEDs keep their previous color | ✅ |
 | `clear_leds` | Turn all 12 base RGB LEDs off | ✅ |
-| `say(text, voice?, speaker_id?, reference_audio?)` | Speak text on the device speaker via gateway-side TTS. Default engine: **VOICEVOX** (runs as a separate HTTP service — see [TTS setup](#optional-tts-setup-voicevox)). Requires the `[tts]` extra. | ✅ |
+| `say(text, voice?, speaker_id?, reference_audio?)` | Speak text on the device speaker via gateway-side TTS. A supported expression emoji in the text can switch the avatar face in the same call. Default engine: **VOICEVOX** (runs as a separate HTTP service — see [TTS setup](#optional-tts-setup-voicevox)). Requires the `[tts]` extra. | ✅ |
 | `listen(duration_ms?, engine?, language?, model?, motion?, look_up_pitch?)` | Capture a short utterance from the device microphone and transcribe it via gateway-side STT. Default engine: **faster-whisper** (local, MIT) — see [STT setup](#optional-stt-setup-faster-whisper). Optional `motion` feedback can show the `thinking` face or tilt the head up during capture. Requires the `[stt-faster-whisper]` (or `[stt-openai]`) extra and a firmware update with the inbound `listen` wire type. | ✅ |
 
 See `gateway/README.md` for full schemas.
@@ -435,12 +435,22 @@ existing audio decoder pipeline already accepts these frames. The
 TTS framework is engine-agnostic, so additional engines plug in behind
 the same `say` API — see the Irodori engine below.
 
+`say` also accepts supported expression emoji in the text: happy
+(😊 😄 😀 😁 🙂 😆 🥰 😍 😋 🤗), sad (😢 😭 😞 😔 ☹️ 🙁 😿),
+surprised (😲 😮 😯 😱 🤯), embarrassed (😳 😅 🫣), and thinking
+(🤔 🧐 💭). The first mapped emoji changes the avatar face in the same
+MCP call before speech; unmapped emoji do not change the face. VOICEVOX
+and other engines without emoji-style support strip all emoji before
+synthesis. If stripping leaves empty text, the face change is attempted
+and speech is skipped.
+
 #### Alternative engine: Irodori
 
 Irodori is a second TTS engine that calls an external synthesis service
 returning MP3. It plugs into the same `say` pipeline as VOICEVOX (MP3 is
-decoded to 16 kHz mono PCM, then encoded to Opus), and it interprets
-emoji embedded in the input text as a voice-style cue.
+decoded to 16 kHz mono PCM, then encoded to Opus), and it receives
+emoji embedded in the input text verbatim so they can act as voice-style
+cues.
 
 There is **no default endpoint** — the synthesis backend is a hosted
 service, and shipping a hard-coded URL would point every install at

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1033,15 +1033,20 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                 name="say",
                 description=(
                     "Speak the given text on the device speaker via gateway-side "
-                    "TTS (Phase 4, Issue #70). The gateway synthesises audio, "
-                    "encodes it to Opus, and pushes frames over the existing "
-                    "WebSocket — the device firmware does not change. Engine is "
-                    "selectable via 'voice' (default 'voicevox'). "
-                    "NOTE: this build ships the framework only; concrete engines "
-                    "(VOICEVOX, Irodori) land in follow-up PRs and require the "
-                    "matching optional extra (e.g. "
-                    "'pip install stackchan-mcp[tts-voicevox]'). Calling this tool "
-                    "before an engine is registered returns a clear error."
+                    "TTS. The gateway synthesises audio, encodes it to Opus, "
+                    "and pushes frames over the existing WebSocket; the device "
+                    "firmware does not change. Engine is selectable via 'voice' "
+                    "(default 'voicevox'). If the text contains a supported "
+                    "expression emoji, say first switches the avatar face in the "
+                    "same call: happy (😊 😄 😀 😁 🙂 😆 🥰 😍 😋 🤗), "
+                    "sad (😢 😭 😞 😔 ☹️ 🙁 😿), surprised (😲 😮 😯 😱 🤯), "
+                    "embarrassed (😳 😅 🫣), thinking (🤔 🧐 💭). The first "
+                    "mapped emoji wins; unmapped emoji do not change the face, "
+                    "and emoji never select 'off'. Irodori keeps emoji in the "
+                    "TTS input so they can act as voice-style cues. Engines "
+                    "without emoji-style support, including VOICEVOX, strip all "
+                    "emoji before synthesis; if stripping leaves empty text, the "
+                    "face change is still attempted and speech is skipped."
                 ),
                 inputSchema={
                     "type": "object",

--- a/gateway/stackchan_mcp/tts/base.py
+++ b/gateway/stackchan_mcp/tts/base.py
@@ -29,6 +29,11 @@ class TTSEngine(ABC):
     #: Concrete subclasses must override with a non-empty string.
     name: str = ""
 
+    #: Whether the engine natively interprets emoji as voice-style cues.
+    #: Engines that leave this false receive emoji-stripped text from
+    #: the orchestrator.
+    supports_emoji_style: bool = False
+
     @abstractmethod
     async def synthesize(self, text: str, **opts: Any) -> bytes:
         """Synthesise ``text`` into 16 kHz mono PCM (signed 16-bit LE).

--- a/gateway/stackchan_mcp/tts/emoji_expression.py
+++ b/gateway/stackchan_mcp/tts/emoji_expression.py
@@ -1,0 +1,80 @@
+"""Emoji-driven avatar expression helpers for ``say`` text."""
+
+from __future__ import annotations
+
+import re
+
+
+EMOJI_FACE_GROUPS: dict[str, tuple[str, ...]] = {
+    "happy": ("😊", "😄", "😀", "😁", "🙂", "😆", "🥰", "😍", "😋", "🤗"),
+    "sad": ("😢", "😭", "😞", "😔", "☹️", "🙁", "😿"),
+    "surprised": ("😲", "😮", "😯", "😱", "🤯"),
+    "embarrassed": ("😳", "😅", "🫣"),
+    "thinking": ("🤔", "🧐", "💭"),
+}
+
+_EMOJI_TO_FACE: dict[str, str] = {
+    emoji: face
+    for face, emojis in EMOJI_FACE_GROUPS.items()
+    for emoji in emojis
+}
+_MAPPED_EMOJIS = tuple(
+    sorted(_EMOJI_TO_FACE, key=lambda emoji: len(emoji), reverse=True)
+)
+
+_EMOJI_BASE = (
+    "["
+    "\u00a9\u00ae"
+    "\u2600-\u27bf"
+    "\U0001f000-\U0001faff"
+    "]"
+)
+_EMOJI_MODIFIER = "[\ufe0f\U0001f3fb-\U0001f3ff]*"
+_EMOJI_SEQUENCE_RE = re.compile(
+    f"(?:[0-9#*]\ufe0f?\u20e3|"
+    f"{_EMOJI_BASE}{_EMOJI_MODIFIER}"
+    f"(?:\u200d{_EMOJI_BASE}{_EMOJI_MODIFIER})*)"
+)
+_EMOJI_RESIDUE_RE = re.compile("[\ufe0f\u200d\U0001f3fb-\U0001f3ff\u20e3]")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def detect_emoji_face(text: str) -> str | None:
+    """Return the face mapped from the first supported emoji in ``text``."""
+    best_index: int | None = None
+    best_emoji: str | None = None
+
+    for emoji in _MAPPED_EMOJIS:
+        index = text.find(emoji)
+        if index < 0:
+            continue
+        if (
+            best_index is None
+            or index < best_index
+            or (
+                index == best_index
+                and best_emoji is not None
+                and len(emoji) > len(best_emoji)
+            )
+        ):
+            best_index = index
+            best_emoji = emoji
+
+    if best_emoji is None:
+        return None
+    return _EMOJI_TO_FACE[best_emoji]
+
+
+def contains_emoji(text: str) -> bool:
+    """Return whether ``text`` contains any Unicode emoji-like sequence."""
+    return _EMOJI_SEQUENCE_RE.search(text) is not None
+
+
+def strip_emoji_for_plain_tts(text: str) -> str:
+    """Remove emoji for engines that do not interpret them as style cues."""
+    if not contains_emoji(text):
+        return text
+
+    stripped = _EMOJI_SEQUENCE_RE.sub("", text)
+    stripped = _EMOJI_RESIDUE_RE.sub("", stripped)
+    return _WHITESPACE_RE.sub(" ", stripped).strip()

--- a/gateway/stackchan_mcp/tts/emoji_expression.py
+++ b/gateway/stackchan_mcp/tts/emoji_expression.py
@@ -75,6 +75,6 @@ def strip_emoji_for_plain_tts(text: str) -> str:
     if not contains_emoji(text):
         return text
 
-    stripped = _EMOJI_SEQUENCE_RE.sub("", text)
-    stripped = _EMOJI_RESIDUE_RE.sub("", stripped)
+    stripped = _EMOJI_SEQUENCE_RE.sub(" ", text)
+    stripped = _EMOJI_RESIDUE_RE.sub(" ", stripped)
     return _WHITESPACE_RE.sub(" ", stripped).strip()

--- a/gateway/stackchan_mcp/tts/irodori.py
+++ b/gateway/stackchan_mcp/tts/irodori.py
@@ -121,6 +121,7 @@ class IrodoriEngine(TTSEngine):
     """
 
     name = "irodori"
+    supports_emoji_style = True
 
     def __init__(
         self,

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -237,24 +237,6 @@ async def synthesize_and_send(
             "No ESP32 device connected; cannot deliver synthesised audio."
         )
 
-    # WebSocket protocol version gate. The firmware decodes raw Opus
-    # binary frames only on protocol v1; v2/v3 wrap each binary message
-    # in a BinaryProtocol header that this gateway does not yet emit.
-    # Streaming raw frames to a v2/v3 device makes the firmware parse
-    # Opus bytes as header fields, so the audio never plays — yet
-    # without this check ``say()`` would still report success. Fail
-    # fast with a clear, actionable error instead. BinaryProtocol
-    # header wrapping is tracked as a follow-up to Issue #70.
-    connection = getattr(gateway.esp32, "connection", None)
-    proto_version = getattr(connection, "protocol_version", 1)
-    if proto_version != 1:
-        raise RuntimeError(
-            f"TTS requires WebSocket protocol v1, but the connected "
-            f"device negotiated v{proto_version}. Rebuild the firmware "
-            "with v1 (the default for this repository) — v2/v3 "
-            "BinaryProtocol header wrapping is not yet supported."
-        )
-
     speaker_id = arguments.get("speaker_id")
     reference_audio = arguments.get("reference_audio")
 
@@ -298,6 +280,24 @@ async def synthesize_and_send(
         if text_stripped:
             result["tts_text"] = tts_text
         return result
+
+    # WebSocket protocol version gate. The firmware decodes raw Opus
+    # binary frames only on protocol v1; v2/v3 wrap each binary message
+    # in a BinaryProtocol header that this gateway does not yet emit.
+    # Streaming raw frames to a v2/v3 device makes the firmware parse
+    # Opus bytes as header fields, so the audio never plays — yet
+    # without this check ``say()`` would still report success. Fail
+    # fast with a clear, actionable error instead. BinaryProtocol
+    # header wrapping is tracked as a follow-up to Issue #70.
+    connection = getattr(gateway.esp32, "connection", None)
+    proto_version = getattr(connection, "protocol_version", 1)
+    if proto_version != 1:
+        raise RuntimeError(
+            f"TTS requires WebSocket protocol v1, but the connected "
+            f"device negotiated v{proto_version}. Rebuild the firmware "
+            "with v1 (the default for this repository) — v2/v3 "
+            "BinaryProtocol header wrapping is not yet supported."
+        )
 
     # Engine failures (HTTP errors from VOICEVOX, malformed WAV from
     # the synthesiser, etc.) are translated to RuntimeError so the

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
@@ -91,6 +91,17 @@ async def _try_set_avatar_face(
         return False, str(message)
 
     return True, None
+
+
+async def _try_set_avatar_face_with_tts_lock(
+    gateway: "Gateway",
+    face: str,
+) -> tuple[bool, str | None]:
+    tts_lock = getattr(gateway.esp32, "tts_lock", None)
+    lock_ctx = tts_lock if tts_lock is not None else nullcontext()
+
+    async with lock_ctx:
+        return await _try_set_avatar_face(gateway, face)
 
 
 async def synthesize_and_send(
@@ -205,11 +216,6 @@ async def synthesize_and_send(
     speaker_id = arguments.get("speaker_id")
     reference_audio = arguments.get("reference_audio")
 
-    face_dispatched = False
-    face_error: str | None = None
-    if face is not None:
-        face_dispatched, face_error = await _try_set_avatar_face(gateway, face)
-
     tts_text = text
     text_stripped = False
     if not getattr(engine, "supports_emoji_style", False):
@@ -217,7 +223,15 @@ async def synthesize_and_send(
         text_stripped = stripped_text != text
         tts_text = stripped_text
 
+    face_dispatched = False
+    face_error: str | None = None
+
     if not tts_text.strip():
+        if face is not None:
+            face_dispatched, face_error = await _try_set_avatar_face_with_tts_lock(
+                gateway,
+                face,
+            )
         logger.info(
             "say(): engine=%s speaker=%s speech skipped: text empty after "
             "emoji strip",
@@ -269,6 +283,14 @@ async def synthesize_and_send(
             f"Engine '{voice}' produced no PCM data for the given text."
         )
 
+    async def dispatch_face_before_first_frame() -> None:
+        nonlocal face_dispatched, face_error
+        if face is not None:
+            face_dispatched, face_error = await _try_set_avatar_face(
+                gateway,
+                face,
+            )
+
     # Hand the PCM off to the shared encode-and-push path. Engines that
     # have already resampled to DEVICE_SAMPLE_RATE (the documented
     # TTSEngine contract) need no further conversion here.
@@ -276,6 +298,9 @@ async def synthesize_and_send(
         gateway,
         pcm,
         source_label=f"engine:{voice}",
+        before_first_frame=(
+            dispatch_face_before_first_frame if face is not None else None
+        ),
     )
 
     logger.info(
@@ -311,6 +336,7 @@ async def send_pcm_audio(
     *,
     source_rate: int = DEVICE_SAMPLE_RATE,
     source_label: str = "external",
+    before_first_frame: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Encode mono PCM and push as Opus frames to the connected device.
 
@@ -334,6 +360,8 @@ async def send_pcm_audio(
         source_label: Label that appears in the orchestrator log line so
             external callers can be traced separately from engine-driven
             synthesis (e.g. ``"voice-tts"``, ``"sfx:notification"``).
+        before_first_frame: Internal hook for ``say()`` side effects that
+            must be serialized with speech delivery.
 
     Returns:
         Dict describing the push: ``source``, ``frame_count``,
@@ -446,6 +474,9 @@ async def send_pcm_audio(
         loop = asyncio.get_event_loop()
 
         try:
+            if before_first_frame is not None:
+                await before_first_frame()
+
             next_send_time = loop.time()
             for frame in opus_frames:
                 now = loop.time()

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -31,6 +31,7 @@ from .audio_utils import (
     resample_pcm16_linear,
 )
 from .base import EngineRegistry, get_registry
+from .emoji_expression import detect_emoji_face, strip_emoji_for_plain_tts
 
 if TYPE_CHECKING:
     from ..gateway import Gateway
@@ -72,6 +73,26 @@ def _resolve_default_engine() -> str:
     return DEFAULT_VOICE
 
 
+async def _try_set_avatar_face(
+    gateway: "Gateway",
+    face: str,
+) -> tuple[bool, str | None]:
+    try:
+        _result, error = await gateway.esp32.call_tool(
+            "self.display.set_avatar", {"face": face}
+        )
+    except Exception as exc:
+        logger.warning("say(): set_avatar(%s) failed: %s", face, exc)
+        return False, str(exc)
+
+    if error:
+        message = error.get("message", error) if isinstance(error, dict) else error
+        logger.warning("say(): set_avatar(%s) failed: %s", face, message)
+        return False, str(message)
+
+    return True, None
+
+
 async def synthesize_and_send(
     arguments: dict[str, Any],
     *,
@@ -105,7 +126,8 @@ async def synthesize_and_send(
     Returns:
         Dict describing the synthesis: ``engine``, ``text``,
         ``speaker_id``, ``frame_count``, ``sample_rate``,
-        ``frame_duration_ms``, ``duration_ms``.
+        ``frame_duration_ms``, ``duration_ms``, plus emoji-expression
+        metadata such as ``face`` and ``text_stripped``.
 
     Raises:
         ValueError: if ``text`` is missing / empty / non-string.
@@ -122,6 +144,8 @@ async def synthesize_and_send(
     text = arguments.get("text", "")
     if not isinstance(text, str) or not text.strip():
         raise ValueError("'text' is required and must be a non-empty string")
+
+    face = detect_emoji_face(text)
 
     # An explicit, non-empty ``voice`` argument always wins. Otherwise the
     # default engine is resolved from STACKCHAN_TTS_ENGINE (falling back to
@@ -181,6 +205,44 @@ async def synthesize_and_send(
     speaker_id = arguments.get("speaker_id")
     reference_audio = arguments.get("reference_audio")
 
+    face_dispatched = False
+    face_error: str | None = None
+    if face is not None:
+        face_dispatched, face_error = await _try_set_avatar_face(gateway, face)
+
+    tts_text = text
+    text_stripped = False
+    if not getattr(engine, "supports_emoji_style", False):
+        stripped_text = strip_emoji_for_plain_tts(text)
+        text_stripped = stripped_text != text
+        tts_text = stripped_text
+
+    if not tts_text.strip():
+        logger.info(
+            "say(): engine=%s speaker=%s speech skipped: text empty after "
+            "emoji strip",
+            voice,
+            speaker_id if speaker_id is not None else "default",
+        )
+        result = {
+            "engine": voice,
+            "text": text,
+            "speaker_id": speaker_id,
+            "frame_count": 0,
+            "sample_rate": DEVICE_SAMPLE_RATE,
+            "frame_duration_ms": DEVICE_FRAME_DURATION_MS,
+            "duration_ms": 0,
+            "face": face,
+            "face_dispatched": face_dispatched,
+            "face_error": face_error,
+            "text_stripped": text_stripped,
+            "spoke": False,
+            "reason": "text empty after emoji strip",
+        }
+        if text_stripped:
+            result["tts_text"] = tts_text
+        return result
+
     # Engine failures (HTTP errors from VOICEVOX, malformed WAV from
     # the synthesiser, etc.) are translated to RuntimeError so the
     # MCP layer's narrow exception filter still produces clean error
@@ -188,7 +250,7 @@ async def synthesize_and_send(
     # arguments stay separable from operational degradation.
     try:
         pcm = await engine.synthesize(
-            text,
+            tts_text,
             speaker_id=speaker_id,
             reference_audio=reference_audio,
         )
@@ -224,7 +286,7 @@ async def synthesize_and_send(
         result["duration_ms"],
     )
 
-    return {
+    response = {
         "engine": voice,
         "text": text,
         "speaker_id": speaker_id,
@@ -232,7 +294,15 @@ async def synthesize_and_send(
         "sample_rate": result["sample_rate"],
         "frame_duration_ms": result["frame_duration_ms"],
         "duration_ms": result["duration_ms"],
+        "face": face,
+        "face_dispatched": face_dispatched,
+        "face_error": face_error,
+        "text_stripped": text_stripped,
+        "spoke": True,
     }
+    if text_stripped:
+        response["tts_text"] = tts_text
+    return response
 
 
 async def send_pcm_audio(

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -17,6 +17,7 @@ synthesising audio with no destination.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -59,6 +60,39 @@ DEFAULT_VOICE = "voicevox"
 TTS_ENGINE_ENV_VAR = "STACKCHAN_TTS_ENGINE"
 
 
+def _extract_set_avatar_payload(result: Any) -> dict[str, Any] | None:
+    payload = result
+    if isinstance(result, dict) and "content" in result:
+        content = result.get("content") or []
+        if isinstance(content, list) and content:
+            text = (
+                content[0].get("text")
+                if isinstance(content[0], dict)
+                else None
+            )
+            if isinstance(text, str):
+                try:
+                    payload = json.loads(text)
+                except json.JSONDecodeError:
+                    return None
+
+    return payload if isinstance(payload, dict) else None
+
+
+def _set_avatar_payload_error(payload: dict[str, Any]) -> str:
+    raw_error = payload.get("error")
+    if isinstance(raw_error, dict):
+        message = raw_error.get("message")
+        if isinstance(message, str) and message.strip():
+            return message
+    elif isinstance(raw_error, str) and raw_error.strip():
+        return raw_error
+    elif raw_error:
+        return str(raw_error)
+
+    return "set_avatar reported ok=false"
+
+
 def _resolve_default_engine() -> str:
     """Return the default engine name, honouring ``STACKCHAN_TTS_ENGINE``.
 
@@ -78,7 +112,7 @@ async def _try_set_avatar_face(
     face: str,
 ) -> tuple[bool, str | None]:
     try:
-        _result, error = await gateway.esp32.call_tool(
+        result, error = await gateway.esp32.call_tool(
             "self.display.set_avatar", {"face": face}
         )
     except Exception as exc:
@@ -89,6 +123,14 @@ async def _try_set_avatar_face(
         message = error.get("message", error) if isinstance(error, dict) else error
         logger.warning("say(): set_avatar(%s) failed: %s", face, message)
         return False, str(message)
+
+    payload = _extract_set_avatar_payload(result)
+    if payload is not None and payload.get("ok") is False:
+        message = _set_avatar_payload_error(payload)
+        logger.warning(
+            "say(): set_avatar(%s) reported ok=false: %s", face, message
+        )
+        return False, message
 
     return True, None
 

--- a/gateway/tests/test_emoji_expression.py
+++ b/gateway/tests/test_emoji_expression.py
@@ -31,6 +31,10 @@ def test_strip_emoji_for_plain_tts_removes_all_emoji_and_collapses_spaces():
     assert strip_emoji_for_plain_tts(text) == "やったね rocket thinking"
 
 
+def test_strip_emoji_for_plain_tts_preserves_word_boundaries():
+    assert strip_emoji_for_plain_tts("hello😊world") == "hello world"
+
+
 def test_strip_emoji_for_plain_tts_keeps_no_emoji_text_exactly():
     text = "hello   world"
     assert strip_emoji_for_plain_tts(text) == text

--- a/gateway/tests/test_emoji_expression.py
+++ b/gateway/tests/test_emoji_expression.py
@@ -1,0 +1,40 @@
+"""Tests for emoji-driven expression helpers."""
+
+from __future__ import annotations
+
+from stackchan_mcp.tts.emoji_expression import (
+    detect_emoji_face,
+    strip_emoji_for_plain_tts,
+)
+
+
+def test_detect_emoji_face_uses_first_supported_emoji():
+    assert detect_emoji_face("先に sad 😢 あと happy 😊") == "sad"
+    assert detect_emoji_face("先に thinking 🤔 あと happy 😊") == "thinking"
+
+
+def test_detect_emoji_face_ignores_unmapped_emoji_before_mapped_one():
+    assert detect_emoji_face("rocket 🚀 then happy 😊") == "happy"
+
+
+def test_detect_emoji_face_returns_none_for_unmapped_or_plain_text():
+    assert detect_emoji_face("plain text") is None
+    assert detect_emoji_face("rocket 🚀") is None
+
+
+def test_detect_emoji_face_supports_variation_selector_sequence():
+    assert detect_emoji_face("かなしい ☹️") == "sad"
+
+
+def test_strip_emoji_for_plain_tts_removes_all_emoji_and_collapses_spaces():
+    text = "やったね 😊  rocket 🚀  thinking 🤔"
+    assert strip_emoji_for_plain_tts(text) == "やったね rocket thinking"
+
+
+def test_strip_emoji_for_plain_tts_keeps_no_emoji_text_exactly():
+    text = "hello   world"
+    assert strip_emoji_for_plain_tts(text) == text
+
+
+def test_strip_emoji_for_plain_tts_removes_joined_sequences():
+    assert strip_emoji_for_plain_tts("work 🧑‍💻 done") == "work done"

--- a/gateway/tests/test_irodori.py
+++ b/gateway/tests/test_irodori.py
@@ -38,6 +38,11 @@ def _fake_pcm_16k(n_samples: int = 480) -> bytes:
     return samples.tobytes()
 
 
+def test_irodori_engine_declares_emoji_style_support():
+    engine = IrodoriEngine(url=_SYNTH_URL)
+    assert engine.supports_emoji_style is True
+
+
 def _patch_decode(monkeypatch, *, sample_rate: int = 16000, pcm: bytes | None = None):
     """Replace the MP3 decode boundary with a deterministic fake.
 

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -27,11 +27,19 @@ class _PCMEngine(TTSEngine):
         return self._pcm
 
 
+class _EmojiStylePCMEngine(_PCMEngine):
+    supports_emoji_style = True
+
+
 class _FakeESP32:
-    def __init__(self, *, connected: bool = True) -> None:
+    def __init__(
+        self, *, connected: bool = True, avatar_error: str | None = None
+    ) -> None:
         self.device_connected = connected
         self.frames: list[bytes] = []
         self.tts_states: list[str] = []
+        self.tool_calls: list[tuple[str, dict[str, Any]]] = []
+        self.avatar_error = avatar_error
         # Records the relative order in which audio frames and TTS state
         # notifications were dispatched, so tests can assert that
         # ``start`` precedes any frame and ``stop`` trails them.
@@ -41,6 +49,17 @@ class _FakeESP32:
         # same way under tests as in production. The lock is created
         # per-fake so each test runs against a fresh instance.
         self.tts_lock = asyncio.Lock()
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, str] | None]:
+        self.tool_calls.append((name, dict(arguments)))
+        self.events.append(("tool", (name, dict(arguments))))
+        if name == "self.display.set_avatar":
+            if self.avatar_error is not None:
+                return {}, {"message": self.avatar_error}
+            return {"ok": True}, None
+        raise AssertionError(f"unexpected tool call: {name}")
 
     async def send_audio_frame(self, frame: bytes) -> None:
         self.frames.append(frame)
@@ -143,6 +162,145 @@ async def test_pipeline_passes_reference_audio_through(fake_encode):
     )
 
     assert engine.calls[0][1]["reference_audio"] == "/tmp/sample.wav"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_no_emoji_keeps_text_and_skips_face_dispatch(fake_encode):
+    """Plain text follows the existing say path without avatar side effects."""
+    text = "hello   world"
+    engine = _PCMEngine(b"\x00\x00" * 960)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": text, "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert engine.calls[0][0] == text
+    assert esp32.tool_calls == []
+    assert result["text"] == text
+    assert result["face"] is None
+    assert result["face_dispatched"] is False
+    assert result["face_error"] is None
+    assert result["text_stripped"] is False
+    assert result["spoke"] is True
+    assert "tts_text" not in result
+
+
+@pytest.mark.asyncio
+async def test_pipeline_dispatches_face_and_strips_plain_engine_text(fake_encode):
+    """VOICEVOX-style engines get emoji-free text after the face change."""
+    pcm = b"\x01\x00" * 960
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "やったね 😊  rocket 🚀", "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    assert esp32.events[0] == (
+        "tool",
+        ("self.display.set_avatar", {"face": "happy"}),
+    )
+    assert engine.calls[0][0] == "やったね rocket"
+    assert result["face"] == "happy"
+    assert result["face_dispatched"] is True
+    assert result["face_error"] is None
+    assert result["text_stripped"] is True
+    assert result["tts_text"] == "やったね rocket"
+    assert result["spoke"] is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_emoji_for_emoji_style_engine(fake_encode):
+    """Irodori-style engines receive emoji verbatim for voice styling."""
+    text = "やったね 😊"
+    engine = _EmojiStylePCMEngine(b"\x01\x00" * 960, name="irodori")
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": text, "voice": "irodori"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    assert engine.calls[0][0] == text
+    assert result["face"] == "happy"
+    assert result["text_stripped"] is False
+    assert "tts_text" not in result
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emoji_only_plain_engine_skips_speech(fake_encode):
+    """Emoji-only text can still set a face without calling synthesize."""
+    engine = _PCMEngine(b"\x01\x00" * 960)
+    esp32 = _FakeESP32(connected=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "😊", "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    assert engine.calls == []
+    assert esp32.tts_states == []
+    assert esp32.frames == []
+    assert result["frame_count"] == 0
+    assert result["duration_ms"] == 0
+    assert result["face"] == "happy"
+    assert result["face_dispatched"] is True
+    assert result["text_stripped"] is True
+    assert result["tts_text"] == ""
+    assert result["spoke"] is False
+    assert result["reason"] == "text empty after emoji strip"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_face_dispatch_failure_does_not_abort_speech(fake_encode):
+    """A display-side set_avatar error is reported but speech continues."""
+    engine = _PCMEngine(b"\x01\x00" * 960)
+    esp32 = _FakeESP32(connected=True, avatar_error="display offline")
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "hello 😊", "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    assert engine.calls[0][0] == "hello"
+    assert esp32.tts_states == ["start", "stop"]
+    assert esp32.frames == [b"opus_frame_0"]
+    assert result["face"] == "happy"
+    assert result["face_dispatched"] is False
+    assert result["face_error"] == "display offline"
+    assert result["spoke"] is True
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -31,9 +31,28 @@ class _EmojiStylePCMEngine(_PCMEngine):
     supports_emoji_style = True
 
 
+class _RecordingLock:
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        self._lock = asyncio.Lock()
+        self._events = events
+
+    async def __aenter__(self) -> "_RecordingLock":
+        await self._lock.acquire()
+        self._events.append(("lock", "acquired"))
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        self._events.append(("lock", "released"))
+        self._lock.release()
+
+
 class _FakeESP32:
     def __init__(
-        self, *, connected: bool = True, avatar_error: str | None = None
+        self,
+        *,
+        connected: bool = True,
+        avatar_error: str | None = None,
+        record_lock: bool = False,
     ) -> None:
         self.device_connected = connected
         self.frames: list[bytes] = []
@@ -48,7 +67,9 @@ class _FakeESP32:
         # orchestrator's ``async with gateway.esp32.tts_lock`` works the
         # same way under tests as in production. The lock is created
         # per-fake so each test runs against a fresh instance.
-        self.tts_lock = asyncio.Lock()
+        self.tts_lock = (
+            _RecordingLock(self.events) if record_lock else asyncio.Lock()
+        )
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
@@ -197,7 +218,7 @@ async def test_pipeline_dispatches_face_and_strips_plain_engine_text(fake_encode
     """VOICEVOX-style engines get emoji-free text after the face change."""
     pcm = b"\x01\x00" * 960
     engine = _PCMEngine(pcm)
-    esp32 = _FakeESP32(connected=True)
+    esp32 = _FakeESP32(connected=True, record_lock=True)
     gateway = _FakeGateway(esp32)
 
     reg = EngineRegistry()
@@ -209,11 +230,16 @@ async def test_pipeline_dispatches_face_and_strips_plain_engine_text(fake_encode
         registry=reg,
     )
 
-    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
-    assert esp32.events[0] == (
-        "tool",
-        ("self.display.set_avatar", {"face": "happy"}),
-    )
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call]
+    assert esp32.events == [
+        ("lock", "acquired"),
+        ("tts_state", "start"),
+        ("tool", avatar_call),
+        ("frame", b"opus_frame_0"),
+        ("tts_state", "stop"),
+        ("lock", "released"),
+    ]
     assert engine.calls[0][0] == "やったね rocket"
     assert result["face"] == "happy"
     assert result["face_dispatched"] is True
@@ -251,7 +277,7 @@ async def test_pipeline_keeps_emoji_for_emoji_style_engine(fake_encode):
 async def test_pipeline_emoji_only_plain_engine_skips_speech(fake_encode):
     """Emoji-only text can still set a face without calling synthesize."""
     engine = _PCMEngine(b"\x01\x00" * 960)
-    esp32 = _FakeESP32(connected=True)
+    esp32 = _FakeESP32(connected=True, record_lock=True)
     gateway = _FakeGateway(esp32)
 
     reg = EngineRegistry()
@@ -263,7 +289,13 @@ async def test_pipeline_emoji_only_plain_engine_skips_speech(fake_encode):
         registry=reg,
     )
 
-    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call]
+    assert esp32.events == [
+        ("lock", "acquired"),
+        ("tool", avatar_call),
+        ("lock", "released"),
+    ]
     assert engine.calls == []
     assert esp32.tts_states == []
     assert esp32.frames == []
@@ -361,20 +393,13 @@ async def test_pipeline_blocks_protocol_v2(fake_encode):
 
 @pytest.mark.asyncio
 async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
-    """Concurrent ``say()`` invocations don't interleave on the same device.
+    """Concurrent ``say()`` invocations keep face dispatch with their speech.
 
-    Without the per-device TTS lock, two ``synthesize_and_send`` calls
-    running concurrently would each ``send_tts_state("start")``, race
-    through the ``TTS_START_TRANSITION_DELAY_S`` ``asyncio.sleep`` (the
-    cooperative yield point in this fake), then dump their frames and
-    stop notifications in arbitrary order on the same WebSocket. With
-    the lock, the recorded event stream must show one full
-    ``start → frames → stop`` sequence followed by another, never
-    interleaved — a strictly sequential pattern is what the device
-    relies on to stay in ``kDeviceStateSpeaking`` for one utterance at
-    a time.
+    The TTS lock covers the start notification, emoji-driven avatar update,
+    audio frames, and stop notification. A later emoji face change must not
+    land between an earlier utterance's start and first frame.
     """
-    pcm = b"\x01\x00" * 1440  # ~3 frames of audio
+    pcm = b"\x01\x00" * 1440  # 1.5 -> 2 frames of audio
     engine_a = _PCMEngine(pcm, name="engine_a")
     engine_b = _PCMEngine(pcm, name="engine_b")
     esp32 = _FakeESP32(connected=True)
@@ -386,12 +411,12 @@ async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
 
     await asyncio.gather(
         synthesize_and_send(
-            {"text": "first", "voice": "engine_a"},
+            {"text": "first 😊", "voice": "engine_a"},
             gateway=gateway,
             registry=reg,
         ),
         synthesize_and_send(
-            {"text": "second", "voice": "engine_b"},
+            {"text": "second 😢", "voice": "engine_b"},
             gateway=gateway,
             registry=reg,
         ),
@@ -404,17 +429,24 @@ async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
     stop_indices = [
         i for i, e in enumerate(events) if e == ("tts_state", "stop")
     ]
+    tool_indices = [i for i, e in enumerate(events) if e[0] == "tool"]
+    frame_indices = [i for i, e in enumerate(events) if e[0] == "frame"]
+
     assert len(start_indices) == 2
     assert len(stop_indices) == 2
+    assert len(tool_indices) == 2
+    assert len(frame_indices) == 4
 
-    # The lock guarantees a strictly sequential pattern:
-    #   start_0 < stop_0 < start_1 < stop_1
-    # The second utterance cannot begin until the first one finishes
-    # its stop notification.
     assert (
         start_indices[0]
+        < tool_indices[0]
+        < frame_indices[0]
+        < frame_indices[1]
         < stop_indices[0]
         < start_indices[1]
+        < tool_indices[1]
+        < frame_indices[2]
+        < frame_indices[3]
         < stop_indices[1]
     )
 

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -287,10 +287,16 @@ async def test_pipeline_keeps_emoji_for_emoji_style_engine(fake_encode):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_emoji_only_plain_engine_skips_speech(fake_encode):
+@pytest.mark.parametrize("protocol_version", [1, 2, 3])
+async def test_pipeline_emoji_only_plain_engine_skips_speech_before_protocol_gate(
+    fake_encode, protocol_version
+):
     """Emoji-only text can still set a face without calling synthesize."""
+    from types import SimpleNamespace
+
     engine = _PCMEngine(b"\x01\x00" * 960)
     esp32 = _FakeESP32(connected=True, record_lock=True)
+    esp32.connection = SimpleNamespace(protocol_version=protocol_version)
     gateway = _FakeGateway(esp32)
 
     reg = EngineRegistry()

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 import pytest
@@ -46,12 +47,16 @@ class _RecordingLock:
         self._lock.release()
 
 
+_DEFAULT_AVATAR_RESULT = object()
+
+
 class _FakeESP32:
     def __init__(
         self,
         *,
         connected: bool = True,
         avatar_error: str | None = None,
+        avatar_result: Any = _DEFAULT_AVATAR_RESULT,
         record_lock: bool = False,
     ) -> None:
         self.device_connected = connected
@@ -59,6 +64,7 @@ class _FakeESP32:
         self.tts_states: list[str] = []
         self.tool_calls: list[tuple[str, dict[str, Any]]] = []
         self.avatar_error = avatar_error
+        self.avatar_result = avatar_result
         # Records the relative order in which audio frames and TTS state
         # notifications were dispatched, so tests can assert that
         # ``start`` precedes any frame and ``stop`` trails them.
@@ -79,6 +85,8 @@ class _FakeESP32:
         if name == "self.display.set_avatar":
             if self.avatar_error is not None:
                 return {}, {"message": self.avatar_error}
+            if self.avatar_result is not _DEFAULT_AVATAR_RESULT:
+                return self.avatar_result, None
             return {"ok": True}, None
         raise AssertionError(f"unexpected tool call: {name}")
 
@@ -94,6 +102,11 @@ class _FakeESP32:
 class _FakeGateway:
     def __init__(self, esp32: _FakeESP32) -> None:
         self.esp32 = esp32
+
+
+def _tool_result_payload(payload: dict[str, Any] | str) -> dict[str, Any]:
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    return {"content": [{"type": "text", "text": text}]}
 
 
 @pytest.fixture
@@ -332,6 +345,79 @@ async def test_pipeline_face_dispatch_failure_does_not_abort_speech(fake_encode)
     assert result["face"] == "happy"
     assert result["face_dispatched"] is False
     assert result["face_error"] == "display offline"
+    assert result["spoke"] is True
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ({"ok": False, "error": "unsupported face"}, "unsupported face"),
+        ({"ok": False}, "set_avatar reported ok=false"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_pipeline_face_payload_ok_false_reports_failure(
+    fake_encode, payload, expected_error
+):
+    """A device result payload with ok:false is reported as face failure."""
+    engine = _PCMEngine(b"\x01\x00" * 960)
+    esp32 = _FakeESP32(
+        connected=True,
+        avatar_result=_tool_result_payload(payload),
+    )
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "hello 😊", "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    assert engine.calls[0][0] == "hello"
+    assert esp32.tts_states == ["start", "stop"]
+    assert esp32.frames == [b"opus_frame_0"]
+    assert result["face"] == "happy"
+    assert result["face_dispatched"] is False
+    assert result["face_error"] == expected_error
+    assert result["spoke"] is True
+
+
+@pytest.mark.parametrize(
+    "avatar_result",
+    [
+        {"content": []},
+        _tool_result_payload("not json"),
+        _tool_result_payload({"status": "ignored"}),
+        {"content": [{"type": "text"}]},
+        {"content": {"text": json.dumps({"ok": False})}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_pipeline_face_odd_result_payloads_still_count_as_success(
+    fake_encode, avatar_result
+):
+    """Only an explicit ok:false payload turns face dispatch into failure."""
+    engine = _PCMEngine(b"\x01\x00" * 960)
+    esp32 = _FakeESP32(connected=True, avatar_result=avatar_result)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "hello 😊", "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    assert result["face"] == "happy"
+    assert result["face_dispatched"] is True
+    assert result["face_error"] is None
     assert result["spoke"] is True
 
 

--- a/gateway/tests/test_tts_framework.py
+++ b/gateway/tests/test_tts_framework.py
@@ -93,6 +93,11 @@ def test_default_voice_constant():
     assert DEFAULT_VOICE == "voicevox"
 
 
+def test_tts_engine_defaults_to_no_emoji_style_support():
+    engine = _FakeEngine(name="voicevox")
+    assert engine.supports_emoji_style is False
+
+
 @pytest.mark.asyncio
 async def test_synthesize_and_send_rejects_missing_text():
     """No text -> ValueError before any engine lookup."""


### PR DESCRIPTION
## Summary

Embedding an emoji in the `say` text now changes the avatar face and speaks in a single MCP call, instead of sequencing `set_avatar` + `say`. First step of the bundling direction (one command driving multiple actions) shared with #89 / #73.

Closes #289.

> **Stacked PR**: based on #290 (Irodori TTS engine), because the engine-aware emoji handling depends on the Irodori engine introduced there. Merge #290 first; this PR's base will then be switched to `main` and rebased.

## Changes

- **Emoji → face mapping**: first matching emoji in the text selects one of the avatar faces (happy / sad / surprised / embarrassed / thinking); unmapped emoji leave the face unchanged; `off` is not reachable from emoji
- **Engine-aware text handling** via a declarative `supports_emoji_style` capability flag on `TTSEngine`:
  - Irodori (`True`): text passes through verbatim — the same emoji shapes the voice emotion natively
  - VOICEVOX and other engines (`False`): emoji are stripped before synthesis, never spoken
- **Dispatch order**: face change dispatches immediately before speech delivery; a face-dispatch failure logs and continues (speech is not aborted)
- **Edge**: emoji-only text skips synthesis and reports `spoke: false`, still dispatching the face
- **Backward compatible**: no emoji = current behaviour
- `say` tool description, tests, CHANGELOG, README (EN/JP) updated

## Known limitations

- **Lip-sync display interplay (deferred to real-device verification)**: the round-4 review flagged that the firmware's TTS lip-sync switches mouth-part rendering during speech, which may visually mask the emoji-selected face while speaking and after `tts.stop` depending on the avatar mode. This interaction pre-exists this PR (a manual `set_avatar` + `say` sequence behaves identically) and the right fix involves expression-lifecycle design (when to restore which face). Verifying the actual on-screen behaviour is part of the real-device pass below; a follow-up issue will be filed if confirmed.

## Validation

- [x] Gateway: full `uv run pytest` (537 passed) + `uv run ruff check .` green
- [x] Pre-PR codex review: 4 rounds — R1 P2 (face dispatch outside the TTS lock) fixed; R2 P2 (`ok:false` result payload treated as success) fixed; R3 P2×2 (emoji-only skip ordered after the protocol gate; emoji strip collapsing word boundaries) fixed; R4 finding deferred to real-device verification as described above
- [ ] CI: runs after the base switches to `main` post-#290-merge (stacked PRs do not trigger CI on a non-main base)
- [ ] Real-device verification (pending, tracked by `owner-realdevice-verify`):
  - `say("😊 ...")` changes the face and speaks in one call
  - with Irodori selected, voice emotion follows the emoji; with VOICEVOX the emoji is never spoken
  - face visibility during and after speech (lip-sync interplay — see Known limitations)
  - lip-sync (#85 path) unaffected

## Refs

- #286 / #290 (Irodori TTS engine — base of this stack)
- #89 / #73 (bundling direction)
- #85 (lip-sync, explicitly unaffected)
