### PR TITLE
release: cut pair release firmware-v1.11.0 + v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-13
+
 ### Gateway
 
 - Added `gateway_config_get` and `gateway_config_set` MCP wrappers for the
@@ -53,6 +55,8 @@ documented-only.
 - Harden ownership lock stale detection by recording and verifying the
   owning process start time, preventing recycled PIDs from being treated
   as the original live gateway. (#253)
+
+## [firmware-v1.11.0] - 2026-06-13
 
 ### Firmware
 
@@ -1610,7 +1614,9 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.10.0...v0.11.0
+[firmware-v1.11.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.10.0...firmware-v1.11.0
 [0.10.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.1...v0.10.0
 [firmware-v1.10.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.9.0...firmware-v1.10.0
 [0.9.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.0...v0.9.1

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.10.0"
+version = "0.11.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2059,7 +2059,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Pair release commit for firmware-v1.11.0 + gateway v0.11.0.

- Promote CHANGELOG `[Unreleased]` Gateway entries to `[0.11.0] - 2026-06-13`: Irodori TTS engine (#286), emoji-driven say (#289), Port B ws2812 wrappers (#224), gateway_config wrappers (#292), ownership lock hardening (#253)
- Promote CHANGELOG `[Unreleased]` Firmware entries to `[firmware-v1.11.0] - 2026-06-13`: gateway_config MCP tools (#292), host-test infrastructure (#279), speed_dps clamp (#252)
- Bump `gateway/pyproject.toml` version 0.10.0 → 0.11.0
- Regenerate `gateway/uv.lock` (release commit includes the full three-file set: CHANGELOG + pyproject + uv.lock)
- Update CHANGELOG comparison links

## Release context

- firmware-v1.11.0 tag is already pushed; the firmware-release workflow build is running
- All four feature PRs in this release (#290, #291, #293, #294) passed real-device verification before merge
- Release pre-flight checks completed (no open verification blockers, no new priority bugs in released paths, CHANGELOG matches `git log` for both release ranges)

## Validation

- `cd gateway && uv lock` — resolved cleanly, stackchan-mcp 0.10.0 → 0.11.0
- CHANGELOG check runs in CI