### PR TITLE
release: cut pair release firmware-v1.12.0 + v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-20
+
 ### Gateway
 
 - Added `stackchan_follow_pose_stream` MCP tool. Subscribes to an
@@ -71,6 +73,8 @@ documented-only.
   from the live head pose before issuing a command. Hardening for
   the related clean ESP32 mid-stream reboot case is tracked
   separately in #307. (#304)
+
+## [firmware-v1.12.0] - 2026-06-20
 
 ### Firmware
 
@@ -1666,7 +1670,9 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.11.0...v0.12.0
+[firmware-v1.12.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.11.0...firmware-v1.12.0
 [0.11.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.10.0...v0.11.0
 [firmware-v1.11.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.10.0...firmware-v1.11.0
 [0.10.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.9.1...v0.10.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.11.0"
+version = "0.12.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2059,7 +2059,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Pair release prep for `v0.12.0` (gateway) + `firmware-v1.12.0` (firmware).

- Promote `CHANGELOG.md` `[Unreleased]` entries:
  - **Gateway → `[0.12.0]`**: `stackchan_follow_pose_stream` MCP tool (#304), dynamic WiFi power-save toggle (#304), lifecycle `asyncio.Lock` + reference holding (#305), disconnect-aware seed / PS retry (#304)
  - **Firmware → `[firmware-v1.12.0]`**: `self.wifi.set_power_save` MCP tool (#304)
- Bump `gateway/pyproject.toml` version `0.11.0` → `0.12.0`
- Regenerate `gateway/uv.lock` so it matches the new pyproject version (prevents the `uv lock --check` gate in `publish.yml` from failing — see `CONTRIBUTING.md` Per-release steps)
- Add new compare links for both tags and bump the `[Unreleased]` URL to `v0.12.0...HEAD`

## Why pair release

The new gateway-side `stackchan_follow_pose_stream` MCP tool calls `self.wifi.set_power_save` on the device at start (force `none`) and at stop (restore the previously observed mode). Without the firmware-side counterpart MCP tool the gateway-side power-save control becomes a no-op, and the ~800 ms TCP send jitter caused by the IEEE 802.11 DTIM beacon cycle reappears under tight `set_head_angles` loops. The two have to ship together.

## Test plan

- [x] `gateway/uv.lock` regenerated with `cd gateway && uv lock`
- [x] `git diff --staged` is clean of personal config, internal hostnames / IPs, and tone-separation leaks
- [ ] CI on this release branch is green (behavior-neutral change set: CHANGELOG + version + lockfile only)
- [ ] On merge: tag `firmware-v1.12.0` first → `firmware-release.yml` build + GitHub Release notes → then tag `v0.12.0` → Trusted Publishing → PyPI verify → GitHub Release notes (pair-release ordering, per `CONTRIBUTING.md`)

## Pre-flight checks status

- Verify / blocker Issue traverse: #304 closed (auto-close via #306), #305 closed (lock + reference holding fix landed in #306), #307 open as priority / low follow-up — no release blocker
- Parallel maintainer sessions: none
- Open `priority/medium` bug list: 7 existing items, none touching the paths shipped in this release
- CHANGELOG `[Unreleased]` ↔ `v0.11.0..main` (1 squash commit `4405c9e`): fully covered

Refs #304, #305 (closed), #307 (follow-up).
