### PR TITLE
feat(gateway): expose smoothing_window on stackchan_follow_pose_stream MCP schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- `stackchan_follow_pose_stream` now exposes `smoothing_window` as an
+  MCP tool argument (integer, default 5, range 1..20; 1 = passthrough).
+  Callers whose upstream pose source already applies smoothing can
+  disable the redundant gateway-side moving average. Omitting the
+  argument preserves the previous behaviour. (#309)
+
 ## [0.12.0] - 2026-06-20
 
 ### Gateway

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -403,6 +403,10 @@ async def _handle_follow_pose_stream(
     ):
         return _follow_pose_error("pitch_center_deg must be an integer in 5..85")
 
+    smoothing_window = arguments.get("smoothing_window", 5)
+    if not _is_int_arg(smoothing_window) or not 1 <= smoothing_window <= 20:
+        return _follow_pose_error("smoothing_window must be an integer in 1..20")
+
     downsample_hz = arguments.get("downsample_hz", 20.0)
     if not _is_number_arg(downsample_hz) or not 0 < downsample_hz <= 60:
         return _follow_pose_error("downsample_hz must be a number in (0, 60]")
@@ -429,6 +433,7 @@ async def _handle_follow_pose_stream(
         flip_yaw=flip_yaw,
         flip_pitch=flip_pitch,
         pitch_center_deg=pitch_center_deg,
+        smoothing_window=smoothing_window,
         downsample_hz=float(downsample_hz),
         max_step_deg=float(max_step_deg),
         speed_dps=speed_dps,
@@ -925,6 +930,17 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             "description": (
                                 "Servo pitch (deg) treated as the sensor-pitch=0 "
                                 "anchor. Defaults to the head's neutral pose."
+                            ),
+                        },
+                        "smoothing_window": {
+                            "type": "integer",
+                            "default": 5,
+                            "minimum": 1,
+                            "maximum": 20,
+                            "description": (
+                                "Moving-average window size for incoming sensor "
+                                "frames. 1 = passthrough (disable gateway-side "
+                                "smoothing). Default 5."
                             ),
                         },
                         "downsample_hz": {

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -1110,3 +1110,116 @@ class _FakeNotificationSession:
                 exclude_none=True,
             )
         )
+
+
+def _make_follow_pose_fake_gateway(monkeypatch):
+    """Helper: capture the FollowPoseStreamConfig that reaches start_follow.
+
+    Returns a single-element ``captured`` list; the handler imports
+    start_follow from follow_pose_stream at call time, so patching the
+    module attribute is enough to intercept the config without driving a
+    real WebSocket subscription.
+    """
+    captured: list = []
+
+    class FakeGateway:
+        pass
+
+    async def fake_start_follow(gateway, cfg):
+        captured.append(cfg)
+        return {"running": True}
+
+    import stackchan_mcp.follow_pose_stream as follow_pose_stream
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(follow_pose_stream, "start_follow", fake_start_follow)
+    return captured
+
+
+def _follow_pose_request(**arguments):
+    arguments.setdefault("action", "start")
+    arguments.setdefault("url", "ws://example.test/pose")
+    return CallToolRequest(
+        method="tools/call",
+        params={"name": "stackchan_follow_pose_stream", "arguments": arguments},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("window", [1, 5, 20])
+async def test_follow_pose_smoothing_window_propagates(monkeypatch, window):
+    """Explicit in-range smoothing_window reaches FollowPoseStreamConfig."""
+    captured = _make_follow_pose_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _follow_pose_request(smoothing_window=window)
+    )
+
+    assert len(captured) == 1, (
+        f"start_follow should fire once for smoothing_window={window}; "
+        f"response text={result.root.content[0].text!r}"
+    )
+    assert captured[0].smoothing_window == window
+
+
+@pytest.mark.asyncio
+async def test_follow_pose_smoothing_window_defaults_to_five(monkeypatch):
+    """Omitting smoothing_window reproduces the dataclass default of 5."""
+    captured = _make_follow_pose_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _follow_pose_request()
+    )
+
+    assert len(captured) == 1, (
+        "start_follow should fire once when smoothing_window is omitted; "
+        f"response text={result.root.content[0].text!r}"
+    )
+    assert captured[0].smoothing_window == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("window", [0, 21, -1, 100])
+async def test_follow_pose_smoothing_window_out_of_range_rejected(monkeypatch, window):
+    """Out-of-range smoothing_window is refused without starting a follow."""
+    captured = _make_follow_pose_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _follow_pose_request(smoothing_window=window)
+    )
+
+    assert captured == [], (
+        "Out-of-range smoothing_window must not start a follow. "
+        f"Got captured={captured}, "
+        f"response text={result.root.content[0].text!r}"
+    )
+    response_text = result.root.content[0].text.lower()
+    assert any(
+        keyword in response_text
+        for keyword in ("error", "invalid", "minimum", "maximum", "type")
+    ), f"Expected an error signal in {result.root.content[0].text!r}"
+
+
+@pytest.mark.asyncio
+async def test_follow_pose_smoothing_window_non_integer_rejected(monkeypatch):
+    """A non-integer smoothing_window is refused without starting a follow."""
+    captured = _make_follow_pose_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _follow_pose_request(smoothing_window=3.5)
+    )
+
+    assert captured == [], (
+        "Non-integer smoothing_window must not start a follow. "
+        f"Got captured={captured}, "
+        f"response text={result.root.content[0].text!r}"
+    )
+    response_text = result.root.content[0].text.lower()
+    assert any(
+        keyword in response_text
+        for keyword in ("error", "invalid", "type", "integer")
+    ), f"Expected an error signal in {result.root.content[0].text!r}"


### PR DESCRIPTION
## Summary

`stackchan_follow_pose_stream` carries a `FollowPoseStreamConfig.smoothing_window`
field (moving-average window for incoming sensor frames, default 5) that the
runtime honours but that was not surfaced on the MCP tool schema, so callers
could not override it.

When the upstream pose source already applies its own smoothing (e.g. a
producer-side low-pass filter), the gateway-side moving average becomes a
redundant second stage that adds perceived latency without improving
smoothness. This wires the existing field through to the MCP tool surface:

- Argument validation: `smoothing_window` accepts an integer, defaults to `5`,
  and enforces the `1..20` range via the existing `_is_int_arg` helper and the
  `_follow_pose_error` formatter (same pattern as `pitch_center_deg`). Pass
  `smoothing_window=1` for gateway-side passthrough.
- Constructor wiring: the validated value is passed through to
  `FollowPoseStreamConfig(...)`.
- JSON Schema: a `smoothing_window` integer property (`default: 5`,
  `minimum: 1`, `maximum: 20`) is added alongside the other numeric properties.

The `FollowPoseStreamConfig` dataclass and the runtime smoothing logic are
unchanged; only the MCP tool surface and tests are touched.

## Backward compatibility

No behavioural change for existing callers. The default stays `5`, matching the
current dataclass default, so omitting `smoothing_window` reproduces today's
behaviour exactly.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (601 passed, 1 pre-existing skip)
- [x] gateway: `uv run ruff check .` (clean)
- [ ] firmware: `python ./scripts/release.py stackchan` <!-- N/A: gateway-only change, no firmware touched -->

New unit tests in `gateway/tests/test_stdio_server.py` cover:

- explicit `smoothing_window=1` / `5` / `20` propagate to
  `FollowPoseStreamConfig.smoothing_window`;
- omitting the argument yields the default `5`;
- out-of-range values (`0`, `21`, `-1`, `100`) and a non-integer (`3.5`) are
  rejected without starting a follow.

### Hardware

- [x] Not applicable / hardware not available: gateway-only schema + validation
  change. The argument plumbing is exercised by unit tests; no firmware or
  on-device behaviour changes.

## Breaking changes

None. New optional MCP tool argument with a backward-compatible default.

## Related issues

Closes #309
