### PR TITLE
feat(gateway): add user defaults TOML config (#311)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ venv/
 # Environment / secrets
 .env
 .env.local
+/user-defaults.toml
 *.local
 AGENTS.local.md
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ documented-only.
 
 ### Gateway
 
+- Added optional user-local `user-defaults.toml` support for gateway-side
+  MCP argument defaults, starting with `stackchan_follow_pose_stream`. Explicit
+  MCP call arguments still take precedence, while absent, empty, or invalid
+  config files fall back to schema defaults. (#311)
 - `stackchan_follow_pose_stream` now exposes `smoothing_window` as an
   MCP tool argument (integer, default 5, range 1..20; 1 = passthrough).
   Callers whose upstream pose source already applies smoothing can

--- a/README.ja.md
+++ b/README.ja.md
@@ -336,6 +336,40 @@ callback 設定を [`docs/remote-access.md`](docs/remote-access.md) にまとめ
 
 詳細は `gateway/README.md` 参照。
 
+### gateway user-defaults TOML ファイル
+
+Python gateway は、ユーザーごとの既定引数を任意で OS 標準の user config
+ディレクトリ配下の TOML ファイルから読み込めます:
+
+- Linux / XDG: `~/.config/stackchan-mcp/user-defaults.toml`
+- macOS: `~/Library/Application Support/stackchan-mcp/user-defaults.toml`
+- Windows: `%APPDATA%\stackchan-mcp\user-defaults.toml`
+
+実際の path は `platformdirs` で解決され、gateway 起動時のログに解決後の
+path が出ます。リポジトリ直下の `user-defaults.toml.example` が
+テンプレートです。
+
+このファイルは MCP schema default の上に重ねる overlay です。ファイルが
+存在しない、または空の場合は schema default が使われます。ファイルに
+書かなかった引数も schema default のままです。MCP tool 呼び出しで明示
+された引数は常にこのファイルより優先されるため、優先順位は
+`明示引数 > user-defaults ファイル > schema default` です。
+
+これは gateway 側 Python の設定です。`gateway_config_get` /
+`gateway_config_set`（PR #293 で追加）が扱う firmware 側 NVS の接続設定とは
+別レイヤーです。そちらはデバイスに保存された WebSocket 接続設定を読み書き
+します。この TOML ファイルは Python gateway が使う MCP 引数の既定値だけを
+変更します。
+
+最小例:
+
+```toml
+[tool.stackchan_follow_pose_stream]
+smoothing_window = 1
+downsample_hz = 60
+max_step_deg = 30
+```
+
 ### 4. オプション: TTS セットアップ (VOICEVOX)
 
 デバイスを喋らせるには、`[tts]` extras をインストールして

--- a/README.md
+++ b/README.md
@@ -401,6 +401,40 @@ If you installed from source via `uv`:
 
 See `gateway/README.md` for details.
 
+### Gateway user-defaults TOML file
+
+The Python gateway can optionally read user-local default argument values from
+a TOML file under the OS-standard user config directory:
+
+- Linux / XDG: `~/.config/stackchan-mcp/user-defaults.toml`
+- macOS: `~/Library/Application Support/stackchan-mcp/user-defaults.toml`
+- Windows: `%APPDATA%\stackchan-mcp\user-defaults.toml`
+
+The exact path is resolved with `platformdirs`, and the gateway logs the
+resolved path at startup. The tracked `user-defaults.toml.example` file at the
+repository root is the template.
+
+The file is an overlay on top of the MCP schema defaults. If the file is absent
+or empty, schema defaults are used. If a key is omitted from the file, that key
+keeps its schema default. Explicit MCP tool-call arguments always take
+precedence over the file, so the order is: explicit argument > user-defaults
+file > schema default.
+
+This is a gateway-side Python setting. It is separate from the firmware-side
+NVS connection settings exposed by `gateway_config_get` / `gateway_config_set`
+(added in PR #293). Those tools read or update the device's saved WebSocket
+connection settings; this TOML file only changes default MCP argument values
+used by the Python gateway.
+
+Minimal example:
+
+```toml
+[tool.stackchan_follow_pose_stream]
+smoothing_window = 1
+downsample_hz = 60
+max_step_deg = 30
+```
+
 ### 4. Optional: TTS setup (VOICEVOX)
 
 To make the device speak, install the `[tts]` extra and run a

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "pydantic>=2",
     "python-dotenv",
     "PyYAML>=6",
+    "platformdirs>=4.0,<5.0",
+    "tomli>=2.0,<3.0; python_version < '3.11'",
     # The stdio server captures the active ServerSession via a subclassed
     # Server.run() loop because the public MCP SDK does not yet expose a
     # stable hook for server-side notifications. That subclass relies on

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -745,6 +745,10 @@ def _configure_gateway_startup() -> None:
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
 
+    from .user_defaults import log_user_defaults_startup
+
+    log_user_defaults_startup()
+
 
 def _acquire_startup_lock(
     *,

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -21,6 +21,7 @@ from mcp.types import Notification, TextContent, Tool
 from . import __version__
 from .gateway import get_gateway
 from .notify_config import NotifyConfig, load_notify_config
+from .user_defaults import resolve_default
 from .stt import listen_and_transcribe
 from .tts import synthesize_and_send
 
@@ -388,34 +389,64 @@ async def _handle_follow_pose_stream(
     if not (url.startswith("ws://") or url.startswith("wss://")):
         return _follow_pose_error("url must start with ws:// or wss://")
 
-    flip_yaw = arguments.get("flip_yaw", 1)
+    tool_name = "stackchan_follow_pose_stream"
+
+    flip_yaw = (
+        arguments["flip_yaw"]
+        if "flip_yaw" in arguments
+        else resolve_default(tool_name, "flip_yaw", 1)
+    )
     if not _is_int_arg(flip_yaw) or flip_yaw not in (-1, 1):
         return _follow_pose_error("flip_yaw must be -1 or 1")
 
-    flip_pitch = arguments.get("flip_pitch", 1)
+    flip_pitch = (
+        arguments["flip_pitch"]
+        if "flip_pitch" in arguments
+        else resolve_default(tool_name, "flip_pitch", 1)
+    )
     if not _is_int_arg(flip_pitch) or flip_pitch not in (-1, 1):
         return _follow_pose_error("flip_pitch must be -1 or 1")
 
-    pitch_center_deg = arguments.get("pitch_center_deg", 45)
+    pitch_center_deg = (
+        arguments["pitch_center_deg"]
+        if "pitch_center_deg" in arguments
+        else resolve_default(tool_name, "pitch_center_deg", 45)
+    )
     if (
         not _is_int_arg(pitch_center_deg)
         or not 5 <= pitch_center_deg <= 85
     ):
         return _follow_pose_error("pitch_center_deg must be an integer in 5..85")
 
-    smoothing_window = arguments.get("smoothing_window", 5)
+    smoothing_window = (
+        arguments["smoothing_window"]
+        if "smoothing_window" in arguments
+        else resolve_default(tool_name, "smoothing_window", 5)
+    )
     if not _is_int_arg(smoothing_window) or not 1 <= smoothing_window <= 20:
         return _follow_pose_error("smoothing_window must be an integer in 1..20")
 
-    downsample_hz = arguments.get("downsample_hz", 20.0)
+    downsample_hz = (
+        arguments["downsample_hz"]
+        if "downsample_hz" in arguments
+        else resolve_default(tool_name, "downsample_hz", 20.0)
+    )
     if not _is_number_arg(downsample_hz) or not 0 < downsample_hz <= 60:
         return _follow_pose_error("downsample_hz must be a number in (0, 60]")
 
-    max_step_deg = arguments.get("max_step_deg", 12.0)
+    max_step_deg = (
+        arguments["max_step_deg"]
+        if "max_step_deg" in arguments
+        else resolve_default(tool_name, "max_step_deg", 12.0)
+    )
     if not _is_number_arg(max_step_deg) or not 0 < max_step_deg <= 30:
         return _follow_pose_error("max_step_deg must be a number in (0, 30]")
 
-    speed_dps = arguments.get("speed_dps", 240)
+    speed_dps = (
+        arguments["speed_dps"]
+        if "speed_dps" in arguments
+        else resolve_default(tool_name, "speed_dps", 240)
+    )
     if not _is_int_arg(speed_dps) or not 1 <= speed_dps <= 240:
         return _follow_pose_error("speed_dps must be an integer in 1..240")
 

--- a/gateway/stackchan_mcp/user_defaults.py
+++ b/gateway/stackchan_mcp/user_defaults.py
@@ -1,0 +1,254 @@
+"""User-local MCP tool default overlays."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import platformdirs
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10.
+    import tomli as tomllib  # type: ignore[no-redef]
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_APP_NAME = "stackchan-mcp"
+_CONFIG_FILENAME = "user-defaults.toml"
+_FOLLOW_POSE_TOOL = "stackchan_follow_pose_stream"
+_SCHEMA_DEFAULTS: dict[str, dict[str, Any]] = {
+    _FOLLOW_POSE_TOOL: {
+        "smoothing_window": 5,
+        "downsample_hz": 20.0,
+        "max_step_deg": 12.0,
+        "speed_dps": 240,
+        "flip_yaw": 1,
+        "flip_pitch": 1,
+        "pitch_center_deg": 45,
+    }
+}
+_USER_DEFAULTS_CACHE: dict[str, dict[str, Any]] | None = None
+
+
+def _config_path() -> Path:
+    return (
+        platformdirs.user_config_path(
+            _CONFIG_APP_NAME, appauthor=False, roaming=True
+        )
+        / _CONFIG_FILENAME
+    ).expanduser().resolve()
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, str):
+        return json.dumps(value)
+    return str(value)
+
+
+def _is_int_value(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number_value(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _is_type_compatible(value: Any, schema_default: Any) -> bool:
+    if isinstance(schema_default, bool):
+        return isinstance(value, bool)
+    if isinstance(schema_default, int):
+        return _is_int_value(value)
+    if isinstance(schema_default, float):
+        return _is_number_value(value)
+    return isinstance(value, type(schema_default))
+
+
+def _is_supported_value(tool_name: str, arg_name: str, value: Any) -> bool:
+    schema_default = _SCHEMA_DEFAULTS[tool_name][arg_name]
+    if not _is_type_compatible(value, schema_default):
+        return False
+    if arg_name in {"flip_yaw", "flip_pitch"}:
+        return value in (-1, 1)
+    if arg_name == "pitch_center_deg":
+        return 5 <= value <= 85
+    if arg_name == "smoothing_window":
+        return 1 <= value <= 20
+    if arg_name == "downsample_hz":
+        return 0 < float(value) <= 60
+    if arg_name == "max_step_deg":
+        return 0 < float(value) <= 30
+    if arg_name == "speed_dps":
+        return 1 <= value <= 240
+    return True
+
+
+def _warn_invalid_value(tool_name: str, arg_name: str, value: Any) -> None:
+    schema_default = _SCHEMA_DEFAULTS[tool_name][arg_name]
+    logger.warning(
+        "[user-defaults] warning: invalid value for tool.%s.%s: %s — "
+        "falling back to schema default (%s)",
+        tool_name,
+        arg_name,
+        _format_value(value),
+        _format_value(schema_default),
+    )
+
+
+def _validate_defaults(raw: Mapping[str, Any], path: Path) -> dict[str, dict[str, Any]]:
+    tool_section = raw.get("tool", {})
+    if tool_section == {}:
+        return {}
+    if not isinstance(tool_section, Mapping):
+        logger.warning(
+            "[user-defaults] warning: invalid tool table in %s — "
+            "using schema defaults",
+            path,
+        )
+        return {}
+
+    defaults: dict[str, dict[str, Any]] = {}
+    for tool_name, raw_tool_defaults in tool_section.items():
+        if tool_name not in _SCHEMA_DEFAULTS:
+            logger.warning(
+                "[user-defaults] warning: unsupported tool defaults section "
+                "tool.%s in %s",
+                tool_name,
+                path,
+            )
+            continue
+        if not isinstance(raw_tool_defaults, Mapping):
+            logger.warning(
+                "[user-defaults] warning: invalid defaults table for tool.%s "
+                "in %s",
+                tool_name,
+                path,
+            )
+            continue
+
+        tool_defaults: dict[str, Any] = {}
+        schema_defaults = _SCHEMA_DEFAULTS[tool_name]
+        for arg_name, value in raw_tool_defaults.items():
+            if arg_name not in schema_defaults:
+                logger.warning(
+                    "[user-defaults] warning: unsupported default "
+                    "tool.%s.%s in %s",
+                    tool_name,
+                    arg_name,
+                    path,
+                )
+                continue
+            if not _is_supported_value(tool_name, arg_name, value):
+                _warn_invalid_value(tool_name, arg_name, value)
+                continue
+            tool_defaults[arg_name] = value
+
+        if tool_defaults:
+            defaults[tool_name] = tool_defaults
+
+    return defaults
+
+
+def _read_user_defaults(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        with path.open("rb") as fp:
+            raw = tomllib.load(fp)
+    except FileNotFoundError:
+        return {}
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning(
+            "[user-defaults] warning: failed to parse %s: %s — "
+            "using schema defaults",
+            path,
+            exc,
+        )
+        return {}
+    except OSError as exc:
+        logger.warning(
+            "[user-defaults] warning: failed to read %s: %s — "
+            "using schema defaults",
+            path,
+            exc,
+        )
+        return {}
+
+    if not raw:
+        return {}
+    return _validate_defaults(raw, path)
+
+
+def load_user_defaults() -> dict[str, dict[str, Any]]:
+    """Load and cache user-local MCP tool default overlays."""
+    global _USER_DEFAULTS_CACHE
+
+    if _USER_DEFAULTS_CACHE is None:
+        try:
+            path = _config_path()
+        except Exception as exc:  # pragma: no cover - platformdirs/path failure.
+            logger.warning(
+                "[user-defaults] warning: failed to resolve config path: %s — "
+                "using schema defaults",
+                exc,
+            )
+            _USER_DEFAULTS_CACHE = {}
+        else:
+            _USER_DEFAULTS_CACHE = _read_user_defaults(path)
+    return _USER_DEFAULTS_CACHE
+
+
+def resolve_default(tool_name: str, arg_name: str, schema_default: Any) -> Any:
+    """Return the configured default for one tool argument, if valid."""
+    tool_defaults = load_user_defaults().get(tool_name)
+    if not tool_defaults or arg_name not in tool_defaults:
+        return schema_default
+
+    value = tool_defaults[arg_name]
+    if not _is_type_compatible(value, schema_default):
+        return schema_default
+    return value
+
+
+def log_user_defaults_startup() -> None:
+    """Emit startup diagnostics for the optional user-defaults file."""
+    global _USER_DEFAULTS_CACHE
+
+    try:
+        path = _config_path()
+    except Exception as exc:  # pragma: no cover - platformdirs/path failure.
+        logger.warning(
+            "[user-defaults] warning: failed to resolve config path: %s — "
+            "using schema defaults",
+            exc,
+        )
+        if _USER_DEFAULTS_CACHE is None:
+            _USER_DEFAULTS_CACHE = {}
+        return
+    defaults = load_user_defaults()
+    if not path.exists():
+        logger.info(
+            "[user-defaults] no config file found at %s — using schema defaults",
+            path,
+        )
+        return
+    if not defaults:
+        logger.info(
+            "[user-defaults] no valid overrides in %s — using schema defaults",
+            path,
+        )
+        return
+
+    logger.info("[user-defaults] loaded from %s", path)
+    for tool_name, tool_defaults in defaults.items():
+        formatted = ", ".join(
+            f"{arg_name}={_format_value(value)}"
+            for arg_name, value in tool_defaults.items()
+        )
+        logger.info("  tool.%s: %s", tool_name, formatted)
+
+
+def _clear_user_defaults_cache_for_tests() -> None:
+    global _USER_DEFAULTS_CACHE
+    _USER_DEFAULTS_CACHE = None

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -26,6 +26,27 @@ from stackchan_mcp.stdio_server import (
 from stackchan_mcp.tts import get_registry
 
 
+@pytest.fixture(autouse=True)
+def _isolate_user_defaults_config(monkeypatch, tmp_path):
+    """Keep stdio tests independent from any real user-defaults file."""
+    import stackchan_mcp.user_defaults as user_defaults
+
+    config_dir = tmp_path / "user-defaults-config"
+
+    def fake_user_config_path(appname: str, **kwargs):
+        assert appname == "stackchan-mcp"
+        return config_dir
+
+    monkeypatch.setattr(
+        user_defaults.platformdirs,
+        "user_config_path",
+        fake_user_config_path,
+    )
+    user_defaults._clear_user_defaults_cache_for_tests()
+    yield
+    user_defaults._clear_user_defaults_cache_for_tests()
+
+
 def test_create_server():
     """Server creation succeeds with correct name."""
     server = create_server()
@@ -1178,6 +1199,45 @@ async def test_follow_pose_smoothing_window_defaults_to_five(monkeypatch):
         f"response text={result.root.content[0].text!r}"
     )
     assert captured[0].smoothing_window == 5
+
+
+@pytest.mark.asyncio
+async def test_follow_pose_explicit_smoothing_window_wins_over_user_default(
+    monkeypatch,
+    tmp_path,
+):
+    """Explicit MCP args override user-defaults TOML values."""
+    import stackchan_mcp.user_defaults as user_defaults
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "user-defaults.toml").write_text(
+        "[tool.stackchan_follow_pose_stream]\n"
+        "smoothing_window = 1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        user_defaults.platformdirs,
+        "user_config_path",
+        lambda appname: config_dir,
+    )
+    user_defaults._clear_user_defaults_cache_for_tests()
+
+    try:
+        captured = _make_follow_pose_fake_gateway(monkeypatch)
+        server = create_server()
+
+        result = await server.request_handlers[CallToolRequest](
+            _follow_pose_request(smoothing_window=20)
+        )
+    finally:
+        user_defaults._clear_user_defaults_cache_for_tests()
+
+    assert len(captured) == 1, (
+        "start_follow should fire once with the explicit argument; "
+        f"response text={result.root.content[0].text!r}"
+    )
+    assert captured[0].smoothing_window == 20
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_user_defaults.py
+++ b/gateway/tests/test_user_defaults.py
@@ -1,0 +1,99 @@
+"""Tests for user-local MCP tool default overlays."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+import stackchan_mcp.user_defaults as user_defaults
+
+
+@pytest.fixture
+def user_defaults_path(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    config_path = config_dir / "user-defaults.toml"
+
+    def fake_user_config_path(appname: str, **kwargs) -> Path:
+        assert appname == "stackchan-mcp"
+        return config_dir
+
+    monkeypatch.setattr(
+        user_defaults.platformdirs,
+        "user_config_path",
+        fake_user_config_path,
+    )
+    user_defaults._clear_user_defaults_cache_for_tests()
+    yield config_path
+    user_defaults._clear_user_defaults_cache_for_tests()
+
+
+def test_resolve_default_returns_schema_default_when_config_absent(user_defaults_path):
+    assert not user_defaults_path.exists()
+
+    assert (
+        user_defaults.resolve_default(
+            "stackchan_follow_pose_stream",
+            "smoothing_window",
+            5,
+        )
+        == 5
+    )
+
+
+def test_resolve_default_returns_schema_default_for_empty_file(user_defaults_path):
+    user_defaults_path.parent.mkdir(parents=True)
+    user_defaults_path.write_text("", encoding="utf-8")
+
+    assert (
+        user_defaults.resolve_default(
+            "stackchan_follow_pose_stream",
+            "smoothing_window",
+            5,
+        )
+        == 5
+    )
+
+
+def test_resolve_default_uses_valid_tool_overlay(user_defaults_path):
+    user_defaults_path.parent.mkdir(parents=True)
+    user_defaults_path.write_text(
+        "[tool.stackchan_follow_pose_stream]\n"
+        "smoothing_window = 1\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        user_defaults.resolve_default(
+            "stackchan_follow_pose_stream",
+            "smoothing_window",
+            5,
+        )
+        == 1
+    )
+
+
+def test_resolve_default_warns_and_falls_back_for_invalid_value(
+    user_defaults_path,
+    caplog,
+):
+    user_defaults_path.parent.mkdir(parents=True)
+    user_defaults_path.write_text(
+        "[tool.stackchan_follow_pose_stream]\n"
+        'smoothing_window = "abc"\n',
+        encoding="utf-8",
+    )
+    caplog.set_level(logging.WARNING, logger="stackchan_mcp.user_defaults")
+
+    assert (
+        user_defaults.resolve_default(
+            "stackchan_follow_pose_stream",
+            "smoothing_window",
+            5,
+        )
+        == 5
+    )
+    assert (
+        "invalid value for tool.stackchan_follow_pose_stream.smoothing_window"
+        in caplog.text
+    )
+    assert "falling back to schema default (5)" in caplog.text

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1390,6 +1390,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2064,9 +2073,11 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "mcp" },
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
@@ -2114,9 +2125,11 @@ requires-dist = [
     { name = "openai", marker = "extra == 'stt-openai'", specifier = ">=1.0" },
     { name = "opuslib", marker = "extra == 'stt'", specifier = ">=3" },
     { name = "opuslib", marker = "extra == 'tts'", specifier = ">=3" },
+    { name = "platformdirs", specifier = ">=4.0,<5.0" },
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv" },
     { name = "pyyaml", specifier = ">=6" },
+    { name = "tomli", marker = "python_version < '3.11'", specifier = ">=2.0,<3.0" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-faster-whisper'" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-openai'" },
     { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-irodori'" },

--- a/user-defaults.toml.example
+++ b/user-defaults.toml.example
@@ -1,0 +1,27 @@
+# stackchan-mcp user-defaults template
+#
+# Copy this file to your user config directory as user-defaults.toml.
+# On typical Linux/XDG setups the path is:
+#   ~/.config/stackchan-mcp/user-defaults.toml
+# The gateway uses platformdirs to resolve the OS-specific user config path
+# on macOS, Linux, and Windows.
+#
+# This file is optional. If it is absent or empty, the gateway uses the MCP
+# schema defaults.
+#
+# Values here overlay schema defaults per argument. Arguments you do not list
+# keep their schema default. Explicit MCP tool-call arguments still win over
+# this file.
+#
+# This file does not replace the firmware-side NVS settings handled by
+# gateway_config_get / gateway_config_set. Those are on-device connection
+# settings. This file only sets user-level Python defaults for MCP arguments.
+
+[tool.stackchan_follow_pose_stream]
+# smoothing_window = 5    # schema default: 5
+# downsample_hz = 20      # schema default: 20
+# max_step_deg = 12       # schema default: 12
+# speed_dps = 240         # schema default: 240
+# flip_yaw = 1            # schema default: 1
+# flip_pitch = 1          # schema default: 1
+# pitch_center_deg = 45   # schema default: 45


### PR DESCRIPTION
## Summary

Add a user-local TOML configuration file (`~/.config/stackchan-mcp/user-defaults.toml` on Linux; `platformdirs` resolves the correct path on macOS / Windows) that lets gateway operators override default argument values for MCP tools. First-cut scope: `stackchan_follow_pose_stream` (7 arguments). Closes #311.

## Behaviour

- Precedence: explicit MCP tool-call argument > overlay value > schema default.
- File absent / empty / invalid → schema defaults are used (regression-free).
- MCP schema literal defaults are unchanged; only the runtime resolution path consults the overlay.
- Gateway logs the resolved config path at startup so operators can confirm what was applied.

## Changes

- New module `gateway/stackchan_mcp/user_defaults.py` (`load_user_defaults()` + `resolve_default()`).
- `gateway/stackchan_mcp/stdio_server.py` — `stackchan_follow_pose_stream` dispatch consults the overlay for 7 args.
- `gateway/stackchan_mcp/cli.py` — startup log lines for resolved-path / not-found / invalid-value cases.
- `gateway/pyproject.toml` + `gateway/uv.lock` — `platformdirs >=4.0,<5.0` (used with `appauthor=False, roaming=True` so the Windows path is `%APPDATA%\stackchan-mcp\...`) and `tomli` as a Python 3.10 fallback for `tomllib`.
- `user-defaults.toml.example` (new, tracked) — repo-root template.
- `.gitignore` — anchor `/user-defaults.toml` so a stray repo-root copy is not committed.
- `README.md` + `README.ja.md` — new section explaining the file with per-OS paths and the layer distinction from the firmware-side NVS `gateway_config_get` / `gateway_config_set` (PR #293).
- `CHANGELOG.md` — `[Unreleased]` Gateway entry.
- Unit tests — 5 cases (absent / empty / valid overlay / invalid value / explicit-arg-wins). Plus an autouse fixture in `test_stdio_server.py` to isolate existing tests from any real user config file on the developer's machine.

## Validation

- `cd gateway && uv run pytest tests/test_user_defaults.py tests/test_stdio_server.py -q` → 85 passed
- `uv run ruff check .` → passed
- `git diff --check` → clean
- Pre-PR codex review → clean

## Out of scope (deferred)

- Dynamic config reload (startup-only read this iteration).
- Extending to other MCP tools (`say` / `set_avatar` / `set_volume` / `set_brightness` / `move_head`) — follow-up PR.
- Per-device config; GUI editor.

## Refs

- Closes #311
- Builds on PR #310 (`smoothing_window` MCP schema exposure on the same tool).
- Distinct from PR #293 (firmware-side NVS connection settings) — different layer; the README sections explain the distinction.
