### PR TITLE
feat(firmware,gateway): user-configurable touch sensor disable (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,22 @@ documented-only.
 
 ## [Unreleased]
 
+### Firmware
+
+- Added the NVS-backed `touch.enabled` field, handler guards, and
+  `self.robot.set_touch_sensor_enabled` /
+  `self.robot.get_touch_sensor_enabled` MCP tools so users can disable
+  head-touch detection while stopping both local reactions and
+  `stackchan/event` emission. (#312)
+
 ### Gateway
 
 - Added optional user-local `user-defaults.toml` support for gateway-side
   MCP argument defaults, starting with `stackchan_follow_pose_stream`. Explicit
   MCP call arguments still take precedence, while absent, empty, or invalid
   config files fall back to schema defaults. (#311)
+- Added `set_touch_sensor_enabled` and `get_touch_sensor_enabled` MCP
+  wrappers for the firmware head-touch enable flag. (#312)
 - `stackchan_follow_pose_stream` now exposes `smoothing_window` as an
   MCP tool argument (integer, default 5, range 1..20; 1 = passthrough).
   Callers whose upstream pose source already applies smoothing can

--- a/README.ja.md
+++ b/README.ja.md
@@ -53,6 +53,8 @@
 | `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ)。`pitch` は M5Stack 推奨運用レンジ `5..85` に制限される。ファームウェア側のハードクランプ (`0..88`) を使いたい場合は、firmware-side の `set_head_angles` デバイスツールを利用する | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
+| `get_touch_sensor_enabled` | 頭部タッチ検出が有効かどうかを取得。NVS に保存され、再起動後も維持される | ✅ |
+| `set_touch_sensor_enabled(enabled)` | 頭部タッチ検出を有効/無効化。無効時は firmware 側のローカル動作反応と MCP `stackchan/event` 送信の両方を止め、設定は再起動後も維持される | ✅ |
 | `set_avatar(face)` | アバター表情切替 (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`)、または `off` でアバターを隠し blink も停止して下層の WiFi 設定 / OTA / 設定画面を露出。他 face を指定するとアバター + blink が復帰 | ✅ |
 | `set_blink(state)` | 瞬き ON/OFF | ✅ |
 | `set_mouth(state)` | 口開閉（one-shot、次の呼び出しまで保持） | ✅ |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This repository is a monorepo.
 | `set_brightness(brightness)` | Screen brightness (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | Move the neck (servos). `pitch` is constrained to `5..85` — the M5Stack-recommended operating range. For the wider firmware hard clamp (`0..88`), use the firmware-side `set_head_angles` device tool instead. | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
+| `get_touch_sensor_enabled` | Read whether head-touch detection is enabled. The NVS-backed setting persists across reboot. | ✅ |
+| `set_touch_sensor_enabled(enabled)` | Enable or disable head-touch detection. Disabling stops both the firmware local motion response and MCP `stackchan/event` emission, and persists across reboot. | ✅ |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying WiFi config / OTA / settings screens are visible. Any other face brings the avatar back and restores blink. | ✅ |
 | `set_blink(state)` | Blink on/off | ✅ |
 | `set_mouth(state)` | Mouth open/close (one-shot, held until next call) | ✅ |

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -680,6 +680,7 @@ private:
                                                        // bus hangs.
     static constexpr int SERVO_WOBBLE_AMPLITUDE_DEG = 20;
 
+    std::atomic<bool> touch_sensor_enabled_{true};
     std::unique_ptr<Si12T> si12t_;
     bool si12t_ok_ = false;
     esp_timer_handle_t touch_poll_timer_ = nullptr;
@@ -3876,6 +3877,9 @@ private:
     }
 
     void HandleTap(uint64_t duration_ms) {
+        if (!touch_sensor_enabled_.load(std::memory_order_acquire)) {
+            return;
+        }
         LogTouchEvent("TAP", duration_ms);
         last_event_ = TouchEvent::TAP;
         last_event_us_ = esp_timer_get_time();
@@ -3887,6 +3891,9 @@ private:
     }
 
     void HandleStroke(uint64_t duration_ms) {
+        if (!touch_sensor_enabled_.load(std::memory_order_acquire)) {
+            return;
+        }
         LogTouchEvent("STROKE", duration_ms);
         last_event_ = TouchEvent::STROKE;
         last_event_us_ = esp_timer_get_time();
@@ -3982,6 +3989,13 @@ private:
             }
             cooldown_until_us_ = now_us + (uint64_t)COOLDOWN_MS * 1000ULL;
         }
+    }
+
+    void InitializeTouchSettings() {
+        Settings settings("touch", false);
+        bool enabled = settings.GetBool("enabled", true);
+        touch_sensor_enabled_.store(enabled, std::memory_order_release);
+        ESP_LOGI(TAG, "Touch sensor setting loaded: enabled=%d", enabled ? 1 : 0);
     }
 
     void InitializeSi12tTouch() {
@@ -5218,6 +5232,40 @@ private:
                                         IsGatewayFallbackUrlForced());
                 AddGatewayForcedKeyNote(notes, "token", token_provided, IsGatewayTokenForced());
                 cJSON_AddItemToObject(root, "notes", notes);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.robot.get_touch_sensor_enabled",
+            "Read the NVS-backed head-touch sensor enable flag. When disabled, "
+            "HandleTap / HandleStroke skip both the local motion response and "
+            "the stackchan/event emission.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "enabled",
+                                      touch_sensor_enabled_.load(std::memory_order_acquire));
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.robot.set_touch_sensor_enabled",
+            "Update the NVS-backed head-touch sensor enable flag. Disabling "
+            "takes effect immediately and persists across reboot; subsequent "
+            "HandleTap / HandleStroke calls skip both the local motion "
+            "response and the stackchan/event emission.",
+            PropertyList({Property("enabled", kPropertyTypeBoolean)}),
+            [this](const PropertyList& properties) -> ReturnValue {
+                bool enabled = properties["enabled"].value<bool>();
+                Settings settings("touch", true);
+                settings.SetBool("enabled", enabled);
+                touch_sensor_enabled_.store(enabled, std::memory_order_release);
+
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "ok", true);
+                cJSON_AddBoolToObject(root, "enabled", enabled);
+                cJSON_AddStringToObject(root, "takes_effect", "immediate");
+                cJSON_AddStringToObject(root, "persistence", "nvs");
                 return root;
             });
 
@@ -6554,6 +6602,7 @@ public:
         GetBacklight()->RestoreBrightness();
         InitializeIOExpander();
         InitializeServo();
+        InitializeTouchSettings();
         InitializeSi12tTouch();
         I2cDetect();
         // Avatar auto-display disabled: WiFi config UI needs to be visible.

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -646,6 +646,14 @@ async def _dispatch_mcp_tool(
             "self.gateway_config.set",
             arguments,
         ),
+        "get_touch_sensor_enabled": (
+            "self.robot.get_touch_sensor_enabled",
+            {},
+        ),
+        "set_touch_sensor_enabled": (
+            "self.robot.set_touch_sensor_enabled",
+            arguments,
+        ),
         "set_avatar": (
             "self.display.set_avatar",
             arguments,
@@ -1107,6 +1115,38 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             ),
                         },
                     },
+                },
+            ),
+            Tool(
+                name="get_touch_sensor_enabled",
+                description=(
+                    "Read the device's NVS-backed head-touch sensor enable "
+                    "flag. When disabled, the firmware stops both the local "
+                    "motion response and the MCP stackchan/event emission; "
+                    "the setting persists across reboot."
+                ),
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="set_touch_sensor_enabled",
+                description=(
+                    "Enable or disable the device's head-touch sensor at "
+                    "runtime. The NVS-backed setting persists across reboot. "
+                    "Disabling stops both the firmware local motion response "
+                    "and the MCP stackchan/event emission."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": (
+                                "True to enable tap/stroke detection; false "
+                                "to disable local reactions and event emission."
+                            ),
+                        },
+                    },
+                    "required": ["enabled"],
                 },
             ),
             Tool(

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -227,6 +227,125 @@ async def test_gateway_config_set_relays_optional_strings(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_tools_includes_touch_sensor_tools():
+    """Touch sensor enable/disable tools are exposed with expected schemas."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tools = {tool.name: tool for tool in result.root.tools}
+    assert "get_touch_sensor_enabled" in tools
+    assert "set_touch_sensor_enabled" in tools
+
+    get_tool = tools["get_touch_sensor_enabled"]
+    assert get_tool.inputSchema == {"type": "object", "properties": {}}
+    assert "NVS" in get_tool.description
+    assert "local motion response" in get_tool.description
+    assert "stackchan/event" in get_tool.description
+
+    set_tool = tools["set_touch_sensor_enabled"]
+    assert set_tool.inputSchema == {
+        "type": "object",
+        "properties": {
+            "enabled": {
+                "type": "boolean",
+                "description": (
+                    "True to enable tap/stroke detection; false to disable "
+                    "local reactions and event emission."
+                ),
+            },
+        },
+        "required": ["enabled"],
+    }
+    assert "persists across reboot" in set_tool.description
+    assert "local motion response" in set_tool.description
+    assert "stackchan/event" in set_tool.description
+
+
+@pytest.mark.asyncio
+async def test_set_touch_sensor_enabled_relays_to_esp32(monkeypatch):
+    """set_touch_sensor_enabled maps to the firmware robot tool."""
+    calls = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "ok": True,
+                                "enabled": arguments["enabled"],
+                                "takes_effect": "immediate",
+                            }
+                        ),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    arguments = {"enabled": False}
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "set_touch_sensor_enabled", "arguments": arguments},
+        )
+    )
+
+    assert calls == [("self.robot.set_touch_sensor_enabled", arguments)]
+    payload = json.loads(result.root.content[0].text)
+    assert payload["ok"] is True
+    assert payload["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_touch_sensor_enabled_relays_to_esp32(monkeypatch):
+    """get_touch_sensor_enabled maps to the firmware robot tool."""
+    calls = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"enabled": False}),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "get_touch_sensor_enabled", "arguments": {}},
+        )
+    )
+
+    assert calls == [("self.robot.get_touch_sensor_enabled", {})]
+    assert json.loads(result.root.content[0].text) == {"enabled": False}
+
+
+@pytest.mark.asyncio
 async def test_list_tools_includes_set_mouth_sequence():
     """set_mouth_sequence is exposed to MCP clients with an array schema."""
     server = create_server()


### PR DESCRIPTION
## Summary

Add a user-configurable touch sensor disable flag that stops both the firmware-side local motion response and the MCP `stackchan/event` emission, addressing community user reports of touch sensor false positives without a current path to disable. Persists across reboot via NVS; runtime toggleable via two new MCP tools. Closes #312.

## Behaviour

- **Default `true`** → identical to current behaviour (no regression on existing devices).
- **`set_touch_sensor_enabled(false)`** → `HandleTap` / `HandleStroke` skip both motion response (head wobble / avatar reaction) and MCP `stackchan/event` emission on the next read cycle.
- **`set_touch_sensor_enabled(false)`** → reboot → `get_touch_sensor_enabled()` returns `false`; behaviour remains disabled across power cycles.
- **`set_touch_sensor_enabled(true)`** → restores the original behaviour at runtime.
- The runtime atomic flag mirrors the NVS value after boot or any successful set, so reads are race-free and free of NVS access on hot paths.

## Changes

- **Firmware (`firmware/main/boards/stackchan/stackchan.cc`)**:
  - New NVS namespace `touch`, key `enabled` (bool, default `true`).
  - At boot init, read NVS → load into `std::atomic<bool> touch_sensor_enabled_`.
  - Early-return guard at the entry of `HandleTap` / `HandleStroke` short-circuits both the local motion response and the MCP `stackchan/event` emission.
  - New firmware MCP tools: `self.robot.set_touch_sensor_enabled(enabled: bool)` (updates NVS + atomic flag immediately) and `self.robot.get_touch_sensor_enabled()` (returns current flag).
- **Gateway (`gateway/stackchan_mcp/stdio_server.py`)**:
  - Two new MCP tool wrappers `set_touch_sensor_enabled` / `get_touch_sensor_enabled` forwarding to the firmware tools, mirroring the pattern established by PR #293 (`gateway_config_get` / `gateway_config_set`).
  - Schema for `set_touch_sensor_enabled` requires `{enabled: boolean}`; `get_touch_sensor_enabled` takes no arguments.
- **Tests (`gateway/tests/test_stdio_server.py`)**:
  - New tests covering schema exposure + relay-to-firmware fidelity for both tools, modelled on the existing `gateway_config_get/set` tests.
- **Docs**:
  - `README.md` (EN) + `README.ja.md` (JP): new rows in the tools table for both tools (dual-language sync, same commit).
  - `CHANGELOG.md`: `[Unreleased]` Firmware + Gateway entries with `(#312)` reference.

## Validation

- `uv run --offline --no-sync pytest gateway/tests/test_stdio_server.py` → 83 passed
- `uv run --offline --no-sync ruff check .` → passed
- `git diff --check` → clean
- GPL-3.0 SCServo_lib 8 files → untouched
- Pre-PR codex review → clean (1 round, 0 findings)
- Firmware build verify (`docker run espressif/idf:v5.5.2 release.py stackchan`) → built `xiaozhi.bin` and `merged-binary.bin` successfully

## Backward compatibility

Default `true` on a fresh device preserves all existing tap / stroke behaviour. Existing test suite passes unchanged. The runtime resolution path adds a single atomic load before each touch handler entry; the schema literal defaults and existing MCP tools are untouched.

## Out of scope (deferred)

- Touch sensor sensitivity threshold tuning — separate follow-up Issue candidate.
- Touch detection algorithm refinement — separate follow-up.
- Per-event (tap vs stroke) selective disable — this flag is a single on/off for all touch events.

## Refs

- Closes #312
- Builds on PR #262 / #263 (Phase 1 touch event implementation).
- Mirrors PR #293 (`gateway_config_get` / `gateway_config_set` NVS-backed firmware MCP tool wrap pattern) at the gateway layer.
- Related but distinct: Issue #103 (Si12T spurious touch trigger during boot calibration window). This Issue provides a user-level workaround that disables all touch events; detection-algorithm robustness for the boot window is tracked separately under #103.
