### PR TITLE
feat(gateway): lower follow_pose downsample_hz cap to 20 (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ documented-only.
   Callers whose upstream pose source already applies smoothing can
   disable the redundant gateway-side moving average. Omitting the
   argument preserves the previous behaviour. (#309)
+- Lowered `stackchan_follow_pose_stream.downsample_hz` schema maximum
+  from 60 to 20 to match the SCS0009 servo's observed sustained
+  `WritePos` rate. Continuous command rates above ~20 Hz triggered
+  UART hangs during real-device dogfood. **BREAKING**: callers that
+  previously set values above 20 will now be rejected with
+  "downsample_hz must be a number in (0, 20]". The schema default
+  (20) is unchanged, so calls that omit the argument behave the
+  same. (#315)
 
 ## [0.12.0] - 2026-06-20
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -368,7 +368,7 @@ path が出ます。リポジトリ直下の `user-defaults.toml.example` が
 ```toml
 [tool.stackchan_follow_pose_stream]
 smoothing_window = 1
-downsample_hz = 60
+downsample_hz = 20
 max_step_deg = 30
 ```
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Minimal example:
 ```toml
 [tool.stackchan_follow_pose_stream]
 smoothing_window = 1
-downsample_hz = 60
+downsample_hz = 20
 max_step_deg = 30
 ```
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -431,8 +431,8 @@ async def _handle_follow_pose_stream(
         if "downsample_hz" in arguments
         else resolve_default(tool_name, "downsample_hz", 20.0)
     )
-    if not _is_number_arg(downsample_hz) or not 0 < downsample_hz <= 60:
-        return _follow_pose_error("downsample_hz must be a number in (0, 60]")
+    if not _is_number_arg(downsample_hz) or not 0 < downsample_hz <= 20:
+        return _follow_pose_error("downsample_hz must be a number in (0, 20]")
 
     max_step_deg = (
         arguments["max_step_deg"]
@@ -986,11 +986,14 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             "type": "number",
                             "default": 20,
                             "exclusiveMinimum": 0,
-                            "maximum": 60,
+                            "maximum": 20,
                             "description": (
                                 "Cap servo command rate. Recent frames are "
                                 "smoothed; commands are issued at most this "
-                                "frequently."
+                                "frequently. Capped at 20 to match the "
+                                "SCS0009 servo's observed sustained WritePos "
+                                "rate; higher continuous rates can trigger "
+                                "UART hang."
                             ),
                         },
                         "max_step_deg": {

--- a/gateway/stackchan_mcp/user_defaults.py
+++ b/gateway/stackchan_mcp/user_defaults.py
@@ -78,7 +78,7 @@ def _is_supported_value(tool_name: str, arg_name: str, value: Any) -> bool:
     if arg_name == "smoothing_window":
         return 1 <= value <= 20
     if arg_name == "downsample_hz":
-        return 0 < float(value) <= 60
+        return 0 < float(value) <= 20
     if arg_name == "max_step_deg":
         return 0 < float(value) <= 30
     if arg_name == "speed_dps":


### PR DESCRIPTION
## Summary

Lower `stackchan_follow_pose_stream.downsample_hz` schema cap from 60 to 20 to match the SCS0009 servo's observed sustained `WritePos` rate.

During real-device dogfood (2026-06-21), the SCS0009 servo bus exhibited UART hang (`ReadPos` returning `yaw_raw=-1` / `pitch_raw=-1` across 3 retries) when `stackchan_follow_pose_stream` relayed frames at a sustained ~31 Hz from an upstream WebSocket source. The hang was eliminated by lowering the cap to 20, matching both the schema default and the SCS0009's observed sustained rate.

## Changes

- `gateway/stackchan_mcp/stdio_server.py`:
  - Validation guard: `0 < downsample_hz <= 60` → `<= 20`; error message updated to `(0, 20]`.
  - Schema definition: `"maximum": 60` → `20`; description updated to mention the SCS0009 sustained rate context.
- `gateway/stackchan_mcp/user_defaults.py`:
  - `_is_supported_value` cap for `downsample_hz`: 60 → 20. Keeps the user-defaults validation aligned with the new schema cap so invalid local values fall back to the schema default rather than failing at runtime (caught by codex review Round 1).
- `README.md` / `README.ja.md`:
  - Minimal `user-defaults.toml` example updated: `downsample_hz = 60` → `20`.
- `CHANGELOG.md`:
  - `[Unreleased]` Gateway entry added with BREAKING note.

## BREAKING change

- Callers that previously set `downsample_hz` above 20 will now be rejected with `downsample_hz must be a number in (0, 20]`.
- `user-defaults.toml` entries with `downsample_hz` in (20, 60] will be rejected by the validation gate, log a warning, and fall back to the schema default (20).
- The schema default (20) is unchanged, so callers that omit the argument behave the same.

## Validation

- Pre-PR codex review: Round 1 → 1 finding (P2: user_defaults cap mismatch with new schema cap) → fixed → Round 2 0 finding clean.
- Tests: no existing test asserts `downsample_hz` >= 21 (`test_consume_downsamples` uses `downsample_hz=10`, well within the new cap), so no test changes were required.
- Real-device dogfood: a ~7-minute run at `downsample_hz=20` succeeded with no UART hang, vs. a ~2-minute hang at `downsample_hz=60` under the same upstream source.

Closes #315