### PR TITLE
Add edge-tts engine for natural English/multilingual TTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ documented-only.
   "downsample_hz must be a number in (0, 20]". The schema default
   (20) is unchanged, so calls that omit the argument behave the
   same. (#315)
+- Added `edge-tts` TTS engine — a subprocess-based engine using
+  Microsoft's Edge TTS CLI and ffmpeg, registered as `edge-tts`.
+  Provides natural English and multilingual voices (`voicevox` is
+  Japanese-only by default). Setup: install `edge-tts` CLI on PATH
+  (e.g. `pip install edge-tts`) plus `ffmpeg`. Default voice is
+  `en-GB-SoniaNeural`, overridable per-call via the new
+  `say(speaker_name=...)` argument (added to the say() schema as a
+  string field, distinct from `speaker_id` integer and the `voice`
+  engine selector) or globally via the `STACKCHAN_EDGE_TTS_DEFAULT_VOICE`
+  env var. (#317)
 
 ## [0.12.0] - 2026-06-20
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1606,8 +1606,20 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                         "speaker_id": {
                             "type": "integer",
                             "description": (
-                                "Engine-specific speaker identifier "
+                                "Engine-specific numeric speaker identifier "
                                 "(e.g. a VOICEVOX speaker ID)."
+                            ),
+                        },
+                        "speaker_name": {
+                            "type": "string",
+                            "description": (
+                                "Engine-specific string speaker/voice "
+                                "identifier (e.g. an Edge TTS voice name "
+                                "such as 'en-US-AriaNeural'). Distinct from "
+                                "'voice', which selects the engine itself "
+                                "(e.g. 'edge-tts'); use speaker_name for "
+                                "engines whose speaker selector is a string "
+                                "name rather than the numeric speaker_id."
                             ),
                         },
                         "reference_audio": {

--- a/gateway/stackchan_mcp/tts/__init__.py
+++ b/gateway/stackchan_mcp/tts/__init__.py
@@ -54,8 +54,15 @@ def _register_irodori() -> None:
     get_registry().register(IrodoriEngine())
 
 
+def _register_edge_tts() -> None:
+    from .edge_tts import EdgeTTSEngine
+
+    get_registry().register(EdgeTTSEngine())
+
+
 _try_register(_register_voicevox, "voicevox")
 _try_register(_register_irodori, "irodori")
+_try_register(_register_edge_tts, "edge-tts")
 
 
 __all__ = [

--- a/gateway/stackchan_mcp/tts/edge_tts.py
+++ b/gateway/stackchan_mcp/tts/edge_tts.py
@@ -13,6 +13,17 @@ get raw 16 kHz mono PCM.
 This is intentionally a subprocess-based engine (not an HTTP client like
 VoicevoxEngine) since edge-tts ships as a CLI tool, not a long-running
 server.
+
+Configuration (environment variables):
+
+    STACKCHAN_EDGE_TTS_DEFAULT_VOICE
+        Voice name used when the say() tool does not specify one via
+        speaker_name. Default "en-GB-SoniaNeural". Read lazily on each
+        access (not cached at import/construction time) so a .env file
+        loaded after engine registration — e.g. under
+        `serve --transport streamable-http`, where the tts package import
+        chain resolves before _configure_gateway_startup() loads .env —
+        still takes effect.
 """
 
 from __future__ import annotations
@@ -31,8 +42,6 @@ logger = logging.getLogger(__name__)
 
 
 #: Default voice. en-GB-SoniaNeural is a natural British English voice.
-#: Override per-call via the say() tool's `speaker_id` opt (repurposed here
-#: as a voice name string) or globally via STACKCHAN_EDGE_TTS_DEFAULT_VOICE.
 DEFAULT_EDGE_TTS_VOICE = "en-GB-SoniaNeural"
 
 #: Timeout for the edge-tts subprocess and the ffmpeg conversion step.
@@ -44,12 +53,6 @@ class EdgeTTSEngine(TTSEngine):
 
     Setup: `pip install edge-tts` (already on PATH as `edge-tts` once
     installed) and `ffmpeg` on PATH for MP3 -> PCM conversion.
-
-    Configuration:
-
-        STACKCHAN_EDGE_TTS_DEFAULT_VOICE
-            Voice name used when the say() tool does not specify one.
-            Default "en-GB-SoniaNeural".
     """
 
     name = "edge-tts"
@@ -61,33 +64,48 @@ class EdgeTTSEngine(TTSEngine):
         edge_tts_binary: str | None = None,
         ffmpeg_binary: str | None = None,
     ) -> None:
-        env_voice = os.getenv("STACKCHAN_EDGE_TTS_DEFAULT_VOICE")
-        self._default_voice = default_voice or env_voice or DEFAULT_EDGE_TTS_VOICE
+        # Only the explicit constructor override is stored here. The
+        # STACKCHAN_EDGE_TTS_DEFAULT_VOICE environment variable is
+        # intentionally NOT read in __init__ — see default_voice below
+        # and the module docstring for why.
+        self._default_voice_override = default_voice
         self._timeout_seconds = timeout_seconds
         self._edge_tts_binary = edge_tts_binary or "edge-tts"
         self._ffmpeg_binary = ffmpeg_binary or "ffmpeg"
 
     @property
     def default_voice(self) -> str:
-        """Voice name used when no voice is specified per-call."""
-        return self._default_voice
+        """Voice name used when no voice is specified per-call.
+
+        Resolved lazily on every access: explicit constructor override
+        wins, otherwise STACKCHAN_EDGE_TTS_DEFAULT_VOICE is read fresh
+        from the environment, falling back to DEFAULT_EDGE_TTS_VOICE.
+        """
+        if self._default_voice_override is not None:
+            return self._default_voice_override
+        return os.getenv("STACKCHAN_EDGE_TTS_DEFAULT_VOICE") or DEFAULT_EDGE_TTS_VOICE
 
     async def synthesize(self, text: str, **opts: Any) -> bytes:
         """Run edge-tts + ffmpeg, return 16 kHz mono signed-16-bit PCM.
 
         Recognised opts:
 
-            voice: str
+            speaker_name: str
                 Edge TTS voice name (e.g. "en-GB-SoniaNeural",
-                "en-US-AriaNeural"). Falls back to `default_voice`.
-            speaker_id: str
-                Alternate way to pass the Edge voice name, matching the
-                say() tool's generic per-engine option naming.
+                "en-US-AriaNeural"). Falls back to `default_voice`. This
+                is distinct from the say() tool's `voice` argument, which
+                selects the engine itself (e.g. "edge-tts"); speaker_name
+                is the string equivalent of VOICEVOX's numeric
+                speaker_id, for engines whose speaker selector is a name.
+            speaker_id: int | None
+                Ignored. Accepted only so the orchestrator can pass a
+                uniform argument set across engines without raising.
         """
         if not text:
             raise ValueError("text must not be empty")
 
-        voice = opts.get("voice") or opts.get("speaker_id") or self._default_voice
+        speaker_name = opts.get("speaker_name")
+        voice = speaker_name if isinstance(speaker_name, str) and speaker_name else self.default_voice
 
         with tempfile.TemporaryDirectory() as tmpdir:
             mp3_path = Path(tmpdir) / "out.mp3"
@@ -98,6 +116,7 @@ class EdgeTTSEngine(TTSEngine):
                 "--voice", voice,
                 "--text", text,
                 "--write-media", str(mp3_path),
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -111,9 +130,10 @@ class EdgeTTSEngine(TTSEngine):
                 )
 
             ffmpeg_proc = await asyncio.create_subprocess_exec(
-                self._ffmpeg_binary, "-y", "-i", str(mp3_path),
+                self._ffmpeg_binary, "-nostdin", "-y", "-i", str(mp3_path),
                 "-f", "s16le", "-ar", str(DEVICE_SAMPLE_RATE), "-ac", "1",
                 str(pcm_path),
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/gateway/stackchan_mcp/tts/edge_tts.py
+++ b/gateway/stackchan_mcp/tts/edge_tts.py
@@ -1,0 +1,138 @@
+"""Edge TTS engine — subprocess client for Microsoft's online TTS service.
+
+Uses the `edge-tts` Python package's CLI (https://github.com/rany2/edge-tts)
+to synthesise speech via Microsoft's online TTS service. No local model or
+Docker container needed — just `pip install edge-tts` and the `edge-tts`
+binary on PATH. Produces natural English (and many other language) voices,
+unlike VOICEVOX which is Japanese-only by default.
+
+edge-tts always emits MP3 regardless of the output filename/extension
+passed to --write-media, so this engine pipes that MP3 through ffmpeg to
+get raw 16 kHz mono PCM.
+
+This is intentionally a subprocess-based engine (not an HTTP client like
+VoicevoxEngine) since edge-tts ships as a CLI tool, not a long-running
+server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .audio_utils import DEVICE_SAMPLE_RATE
+from .base import TTSEngine
+
+logger = logging.getLogger(__name__)
+
+
+#: Default voice. en-GB-SoniaNeural is a natural British English voice.
+#: Override per-call via the say() tool's `speaker_id` opt (repurposed here
+#: as a voice name string) or globally via STACKCHAN_EDGE_TTS_DEFAULT_VOICE.
+DEFAULT_EDGE_TTS_VOICE = "en-GB-SoniaNeural"
+
+#: Timeout for the edge-tts subprocess and the ffmpeg conversion step.
+DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 30.0
+
+
+class EdgeTTSEngine(TTSEngine):
+    """Synthesise text via the edge-tts CLI, return 16 kHz mono PCM.
+
+    Setup: `pip install edge-tts` (already on PATH as `edge-tts` once
+    installed) and `ffmpeg` on PATH for MP3 -> PCM conversion.
+
+    Configuration:
+
+        STACKCHAN_EDGE_TTS_DEFAULT_VOICE
+            Voice name used when the say() tool does not specify one.
+            Default "en-GB-SoniaNeural".
+    """
+
+    name = "edge-tts"
+
+    def __init__(
+        self,
+        default_voice: str | None = None,
+        timeout_seconds: float = DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+        edge_tts_binary: str | None = None,
+        ffmpeg_binary: str | None = None,
+    ) -> None:
+        env_voice = os.getenv("STACKCHAN_EDGE_TTS_DEFAULT_VOICE")
+        self._default_voice = default_voice or env_voice or DEFAULT_EDGE_TTS_VOICE
+        self._timeout_seconds = timeout_seconds
+        self._edge_tts_binary = edge_tts_binary or "edge-tts"
+        self._ffmpeg_binary = ffmpeg_binary or "ffmpeg"
+
+    @property
+    def default_voice(self) -> str:
+        """Voice name used when no voice is specified per-call."""
+        return self._default_voice
+
+    async def synthesize(self, text: str, **opts: Any) -> bytes:
+        """Run edge-tts + ffmpeg, return 16 kHz mono signed-16-bit PCM.
+
+        Recognised opts:
+
+            voice: str
+                Edge TTS voice name (e.g. "en-GB-SoniaNeural",
+                "en-US-AriaNeural"). Falls back to `default_voice`.
+            speaker_id: str
+                Alternate way to pass the Edge voice name, matching the
+                say() tool's generic per-engine option naming.
+        """
+        if not text:
+            raise ValueError("text must not be empty")
+
+        voice = opts.get("voice") or opts.get("speaker_id") or self._default_voice
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mp3_path = Path(tmpdir) / "out.mp3"
+            pcm_path = Path(tmpdir) / "out.pcm"
+
+            proc = await asyncio.create_subprocess_exec(
+                self._edge_tts_binary,
+                "--voice", voice,
+                "--text", text,
+                "--write-media", str(mp3_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self._timeout_seconds
+            )
+            if proc.returncode != 0:
+                raise RuntimeError(
+                    f"edge-tts failed (code {proc.returncode}): "
+                    f"{stderr.decode(errors='replace')}"
+                )
+
+            ffmpeg_proc = await asyncio.create_subprocess_exec(
+                self._ffmpeg_binary, "-y", "-i", str(mp3_path),
+                "-f", "s16le", "-ar", str(DEVICE_SAMPLE_RATE), "-ac", "1",
+                str(pcm_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, ffmpeg_stderr = await asyncio.wait_for(
+                ffmpeg_proc.communicate(), timeout=self._timeout_seconds
+            )
+            if ffmpeg_proc.returncode != 0:
+                raise RuntimeError(
+                    f"ffmpeg conversion failed (code {ffmpeg_proc.returncode}): "
+                    f"{ffmpeg_stderr.decode(errors='replace')}"
+                )
+
+            pcm = pcm_path.read_bytes()
+
+        logger.info(
+            "edge-tts synthesised %d bytes PCM (16 kHz mono) for "
+            "voice=%s, text=%r",
+            len(pcm),
+            voice,
+            text[:60],
+        )
+        return pcm

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -238,6 +238,7 @@ async def synthesize_and_send(
         )
 
     speaker_id = arguments.get("speaker_id")
+    speaker_name = arguments.get("speaker_name")
     reference_audio = arguments.get("reference_audio")
 
     tts_text = text
@@ -308,6 +309,7 @@ async def synthesize_and_send(
         pcm = await engine.synthesize(
             tts_text,
             speaker_id=speaker_id,
+            speaker_name=speaker_name,
             reference_audio=reference_audio,
         )
     except ValueError:


### PR DESCRIPTION
VOICEVOX is Japanese-only by default, so non-Japanese text comes out heavily accented when spoken through it. This adds `edge-tts` (Microsoft's free online TTS service, via the `edge-tts` CLI) as an alternative engine for the `say` MCP tool.

## What this adds

- `EdgeTTSEngine` in `gateway/stackchan_mcp/tts/edge_tts.py`, following the same `TTSEngine` interface as the existing VOICEVOX/Irodori engines
- Registered as `"edge-tts"` in `tts/__init__.py`, behind the same `_try_register` ImportError guard used for the other engines

## How it works

- Shells out to the `edge-tts` CLI (no local model, no Docker container, no server process)
- `edge-tts` always emits MP3 regardless of the `--write-media` filename/extension passed, so this engine pipes that MP3 through `ffmpeg` to get raw 16 kHz mono PCM, matching the contract other engines follow
- Defaults to `en-GB-SoniaNeural`; overridable globally via `STACKCHAN_EDGE_TTS_DEFAULT_VOICE` or per-call via the `say()` tool's `voice`/`speaker_id` args (e.g. `en-US-AriaNeural`)

## Setup

```
pip install edge-tts
```
plus `ffmpeg` on PATH. No extras group changes needed since both are external CLI tools, not Python deps with native extensions.

## Testing

Manually tested end-to-end against a real M5Stack CoreS3 running this firmware: `say(text=..., voice="edge-tts")` synthesizes via the CLI, converts via ffmpeg, encodes to Opus, and plays correctly over the device speaker.