### PR TITLE
feat(firmware/i2c): add optional scl_speed_hz to Port A I2C tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ documented-only.
 
 ### Firmware
 
+- Added an optional `scl_speed_hz` property (default `400000`, range
+  `100000`–`1000000`) to the Port A I2C tools `self.i2c.read`,
+  `self.i2c.write`, and `self.i2c.write_read`, applied to the per-call
+  `i2c_master_bus_add_device` config. This lets slow Units that cannot
+  sustain the hardcoded 400 kHz clock be driven without recompiling the
+  firmware (e.g. the RCWL-9620 ultrasonic ranger, which ACKs a probe but
+  fails the transfer with `ESP_ERR_INVALID_STATE` at 400 kHz and only
+  reads stably at 100 kHz). Behaviour is unchanged when the property is
+  omitted. (#319)
 - Added the NVS-backed `touch.enabled` field, handler guards, and
   `self.robot.set_touch_sensor_enabled` /
   `self.robot.get_touch_sensor_enabled` MCP tools so users can disable

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -6155,10 +6155,15 @@ private:
             "from a prior command). For typical 'write register address, "
             "then read' patterns, use self.i2c.write_read instead. Returns "
             "{\"ok\":true, \"bytes\":[...]} or "
-            "{\"ok\":false, \"error\":\"ESP_ERR_TIMEOUT\"} on NACK.",
+            "{\"ok\":false, \"error\":\"ESP_ERR_TIMEOUT\"} on NACK. Optional "
+            "`scl_speed_hz` (default 400000) sets the I2C clock for this "
+            "transaction; lower it (e.g. 200000) for slower Units such as the "
+            "RCWL-9620 ultrasonic ranger that fail at 400 kHz with "
+            "ESP_ERR_INVALID_STATE.",
             PropertyList({
                 Property("addr", kPropertyTypeInteger, 0x08, 0x77),
-                Property("n_bytes", kPropertyTypeInteger, 1, 256)
+                Property("n_bytes", kPropertyTypeInteger, 1, 256),
+                Property("scl_speed_hz", kPropertyTypeInteger, 400000, 100000, 1000000)
             }),
             [this](const PropertyList& props) -> ReturnValue {
                 cJSON* root = cJSON_CreateObject();
@@ -6168,7 +6173,7 @@ private:
                 i2c_device_config_t cfg = {
                     .dev_addr_length = I2C_ADDR_BIT_LEN_7,
                     .device_address = addr,
-                    .scl_speed_hz = 400000,
+                    .scl_speed_hz = static_cast<uint32_t>(props["scl_speed_hz"].value<int>()),
                 };
                 i2c_master_dev_handle_t dev;
                 esp_err_t err = i2c_master_bus_add_device(port_a_i2c_bus_, &cfg, &dev);
@@ -6214,10 +6219,15 @@ private:
             "external Port A bus only; on-board ICs (PMIC, AW9523, touch, "
             "etc.) on the internal bus are not reachable. Returns "
             "{\"ok\":true} on ACK or "
-            "{\"ok\":false, \"error\":\"ESP_ERR_TIMEOUT\"} on NACK.",
+            "{\"ok\":false, \"error\":\"ESP_ERR_TIMEOUT\"} on NACK. Optional "
+            "`scl_speed_hz` (default 400000) sets the I2C clock for this "
+            "transaction; lower it (e.g. 200000) for slower Units such as the "
+            "RCWL-9620 ultrasonic ranger that fail at 400 kHz with "
+            "ESP_ERR_INVALID_STATE.",
             PropertyList({
                 Property("addr", kPropertyTypeInteger, 0x08, 0x77),
-                i2c_write_bytes_prop
+                i2c_write_bytes_prop,
+                Property("scl_speed_hz", kPropertyTypeInteger, 400000, 100000, 1000000)
             }),
             [this](const PropertyList& props) -> ReturnValue {
                 cJSON* root = cJSON_CreateObject();
@@ -6227,7 +6237,7 @@ private:
                 i2c_device_config_t cfg = {
                     .dev_addr_length = I2C_ADDR_BIT_LEN_7,
                     .device_address = addr,
-                    .scl_speed_hz = 400000,
+                    .scl_speed_hz = static_cast<uint32_t>(props["scl_speed_hz"].value<int>()),
                 };
                 i2c_master_dev_handle_t dev;
                 esp_err_t err = i2c_master_bus_add_device(port_a_i2c_bus_, &cfg, &dev);
@@ -6271,11 +6281,16 @@ private:
             "register pointer, then read' pattern: pass write_bytes=[reg_addr] "
             "to read from a specific register. Returns "
             "{\"ok\":true, \"bytes\":[...]} or "
-            "{\"ok\":false, \"error\":\"...\"} on failure.",
+            "{\"ok\":false, \"error\":\"...\"} on failure. Optional "
+            "`scl_speed_hz` (default 400000) sets the I2C clock for this "
+            "transaction; lower it (e.g. 200000) for slower Units such as the "
+            "RCWL-9620 ultrasonic ranger that fail at 400 kHz with "
+            "ESP_ERR_INVALID_STATE.",
             PropertyList({
                 Property("addr", kPropertyTypeInteger, 0x08, 0x77),
                 i2c_wr_write_bytes_prop,
-                Property("n_bytes", kPropertyTypeInteger, 1, 256)
+                Property("n_bytes", kPropertyTypeInteger, 1, 256),
+                Property("scl_speed_hz", kPropertyTypeInteger, 400000, 100000, 1000000)
             }),
             [this](const PropertyList& props) -> ReturnValue {
                 cJSON* root = cJSON_CreateObject();
@@ -6286,7 +6301,7 @@ private:
                 i2c_device_config_t cfg = {
                     .dev_addr_length = I2C_ADDR_BIT_LEN_7,
                     .device_address = addr,
-                    .scl_speed_hz = 400000,
+                    .scl_speed_hz = static_cast<uint32_t>(props["scl_speed_hz"].value<int>()),
                 };
                 i2c_master_dev_handle_t dev;
                 esp_err_t err = i2c_master_bus_add_device(port_a_i2c_bus_, &cfg, &dev);


### PR DESCRIPTION
## What

Adds an optional `scl_speed_hz` property (default `400000`, range `100000`–`1000000`) to the three generic Port A I2C tools — `self.i2c.read`, `self.i2c.write`, `self.i2c.write_read`. When the property is omitted, behaviour is unchanged (400 kHz).

## Why

The tools currently register the Port A device handle at a hardcoded 400 kHz. Some M5Stack Units cannot sustain that clock. The **RCWL-9620 ultrasonic ranger** (Ultrasonic Distance Unit I2C, addr `0x57`) is a concrete case: it ACKs an `i2c_master_probe` (so `self.i2c.scan` lists it) but the actual transfer fails with `ESP_ERR_INVALID_STATE` at 400 kHz — the same failure mode the on-board PY32 IO expander hits at the wrong clock (see the existing comment near `Py32IoExpander`).

Measured on hardware (RCWL-9620 on Port A via PaHUB):

- `self.i2c.write` (trigger, master-driven) ACKs at 200 kHz
- `self.i2c.read` (measurement, slave-driven) is erratic at 200 kHz and only stable at **100 kHz** (5/5 identical readings)

This matches an independent community report of the same Unit returning garbage / 4500 mm at higher speed, fixed by dropping to 100 kHz: https://community.m5stack.com/topic/4255/ultrasonic-i2c-problems/2

Without a per-transaction clock override there is no way to drive such Units without recompiling the firmware.

## Change

`scl_speed_hz` is read from the property (default 400 kHz) and used for the per-call `i2c_master_bus_add_device` config in all three tools. No behavioural change when the property is omitted.

Built into an ESP-IDF 5.5 / esp32s3 firmware and verified on hardware: the RCWL-9620 reads stably at `scl_speed_hz: 100000`, while the default 400 kHz returns `ESP_ERR_INVALID_STATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
