### PR TITLE
fix(ownership): scope the gateway ownership lock per WS port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ documented-only.
 - Fail in-flight `load_avatar_set` calls with `disconnected` immediately
   when the ESP32 connection drops, instead of waiting for the avatar
   load timeout. (#228)
+- Scoped the gateway ownership lock per WS port (`owner-<ws_port>.lock`
+  instead of the machine-global `owner.lock`), so one gateway per device
+  can run on separate WS ports on the same host without the second
+  gateway being rejected at startup. Single-instance use is unaffected
+  (the default lock is simply named `owner-8765.lock`) and a duplicate
+  start on the same port is still rejected; `--check` reads the per-port
+  lock. (#320)
 
 ## [0.13.0] - 2026-07-02
 

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -774,7 +774,9 @@ def _ws_port_lock_path():
     from .ownership import LOCK_DIR
 
     ws_port, _ = _resolve_ws_port()
-    return LOCK_DIR / (f"owner-{ws_port}.lock" if ws_port else "owner.lock")
+    return LOCK_DIR / (
+        f"owner-{ws_port}.lock" if ws_port is not None else "owner.lock"
+    )
 
 
 def _acquire_startup_lock(

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -438,9 +438,20 @@ def _run_ownership_check() -> int:
     """Print the current ownership lock status and exit cleanly."""
     from .ownership import is_pid_alive, read_lock
 
-    info = read_lock()
+    # Load ``.env`` first so that a WS_PORT / PORT defined only there resolves
+    # the same per-port lock the running gateway claims. Startup loads ``.env``
+    # before ``_acquire_startup_lock`` (via ``_run_stdio_gateway`` /
+    # ``_run_streamable_http_placeholder``), so ``--check`` must match it —
+    # otherwise a gateway owning ``owner-18765.lock`` would be inspected against
+    # the default ``owner-8765.lock`` and wrongly reported ready. Mirrors how
+    # ``--preflight`` loads ``.env`` inside ``_run_preflight``.
+    _load_dotenv()
+    # Inspect the per-WS_PORT lock this gateway would claim (not the legacy
+    # machine-global owner.lock), so the preflight reflects the actual port.
+    lock_path = _ws_port_lock_path()
+    info = read_lock(lock_path)
     if info is None:
-        print("no current owner")
+        print(f"no current owner (lock: {lock_path.name})")
         print("ownership preflight: ready")
         print("Result: ready. Exit 0.")
     elif is_pid_alive(info["pid"]):
@@ -750,6 +761,22 @@ def _configure_gateway_startup() -> None:
     log_user_defaults_startup()
 
 
+def _ws_port_lock_path():
+    """Per-WS_PORT ownership lock path.
+
+    複数機体対応: ownership lock を machine-global な ``owner.lock`` でなく
+    WS_PORT 単位に scope する。 lock は「同一 device を 2 つの gateway が
+    奪い合わない」 ための機構だが、 1 device = 1 gateway = 1 WS ポートで
+    複数機体を同時に動かす構成では global lock が 2 台目以降を誤って弾く。
+    ポート単位なら N gateway が共存でき、 同一ポート二重起動は従来通り弾ける。
+    WS_PORT 未解決時は従来の global パスにフォールバック。
+    """
+    from .ownership import LOCK_DIR
+
+    ws_port, _ = _resolve_ws_port()
+    return LOCK_DIR / (f"owner-{ws_port}.lock" if ws_port else "owner.lock")
+
+
 def _acquire_startup_lock(
     *,
     mode: "LockMode" = _STDIO_TRANSPORT,
@@ -764,13 +791,16 @@ def _acquire_startup_lock(
         release_lock_if_owner,
     )
 
+    lock_path = _ws_port_lock_path()
+
     owner_id = generate_owner_id()
     try:
         if mode == _STDIO_TRANSPORT and http_endpoint is None and started_by is None:
-            info = acquire_lock(owner_id)
+            info = acquire_lock(owner_id, path=lock_path)
         else:
             info = acquire_lock(
                 owner_id,
+                path=lock_path,
                 mode=mode,
                 http_endpoint=http_endpoint,
                 started_by=started_by,
@@ -782,12 +812,13 @@ def _acquire_startup_lock(
     try:
         print(
             "stackchan-mcp: acquired ownership lock "
-            f"(owner_id={info['owner_id']}, pid={info['pid']})",
+            f"(owner_id={info['owner_id']}, pid={info['pid']}, "
+            f"lock={lock_path.name})",
             file=sys.stderr,
         )
-        atexit.register(release_lock_if_owner, info)
+        atexit.register(release_lock_if_owner, info, lock_path)
     except BaseException:
-        release_lock_if_owner(info)
+        release_lock_if_owner(info, lock_path)
         raise
 
     return info
@@ -810,7 +841,7 @@ def _run_stdio_gateway(*, advertise_mdns: bool = True) -> None:
         except KeyboardInterrupt:
             pass
     finally:
-        release_lock_if_owner(info)
+        release_lock_if_owner(info, _ws_port_lock_path())
 
 
 def _resolve_mcp_http_endpoint() -> tuple[str, int]:
@@ -920,7 +951,7 @@ def _run_streamable_http_placeholder(*, advertise_mdns: bool = True) -> None:
             pass
     finally:
         if info is not None:
-            release_lock_if_owner(info)
+            release_lock_if_owner(info, _ws_port_lock_path())
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -189,7 +189,7 @@ def test_main_default_advertises_mdns(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
     monkeypatch.setattr(cli, "_ensure_libopus_findable", lambda: None)
     monkeypatch.setattr(cli, "_run", fake_run)
-    monkeypatch.setattr(ownership, "release_lock_if_owner", lambda info: True)
+    monkeypatch.setattr(ownership, "release_lock_if_owner", lambda info, path=None: True)
 
     main([])
 
@@ -210,7 +210,7 @@ def test_main_no_mdns_disables_advertisement(
     monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
     monkeypatch.setattr(cli, "_ensure_libopus_findable", lambda: None)
     monkeypatch.setattr(cli, "_run", fake_run)
-    monkeypatch.setattr(ownership, "release_lock_if_owner", lambda info: True)
+    monkeypatch.setattr(ownership, "release_lock_if_owner", lambda info, path=None: True)
 
     main(["--no-mdns"])
 
@@ -385,7 +385,9 @@ def test_streamable_http_releases_lock_after_daemon_exit(
     monkeypatch.setattr(cli, "_configure_gateway_startup", lambda: None)
     monkeypatch.setattr(cli, "_acquire_startup_lock", fake_acquire)
     monkeypatch.setattr(cli, "_run_streamable_http_daemon", fake_daemon)
-    monkeypatch.setattr(ownership, "release_lock_if_owner", released.append)
+    monkeypatch.setattr(
+        ownership, "release_lock_if_owner", lambda info, path=None: released.append(info)
+    )
     monkeypatch.delenv("MCP_HTTP_HOST", raising=False)
     monkeypatch.delenv("MCP_HTTP_PORT", raising=False)
     monkeypatch.delenv("STACKCHAN_TOKEN", raising=False)
@@ -752,7 +754,7 @@ def test_main_check_flag_runs_ownership_check_and_exits(
 
     _isolate_preflight_env(monkeypatch, tmp_path)
     monkeypatch.setattr(cli, "_run_preflight", lambda: 99)
-    monkeypatch.setattr(ownership, "read_lock", lambda: None)
+    monkeypatch.setattr(ownership, "read_lock", lambda path=None: None)
 
     with pytest.raises(SystemExit) as exc:
         main(["--check"])
@@ -760,6 +762,38 @@ def test_main_check_flag_runs_ownership_check_and_exits(
     out = capsys.readouterr().out
     assert "ownership preflight" in out
     assert "Result: ready" in out
+
+
+def test_main_check_flag_inspects_per_ws_port_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``--check`` inspects the lock for the configured WS_PORT.
+
+    Guards against the ``--check`` preflight reading the default
+    ``owner-8765.lock`` while a gateway configured for another port owns
+    ``owner-<port>.lock``. ``_run_ownership_check`` loads ``.env`` before
+    deriving the lock path, mirroring the startup order, so a WS_PORT set in
+    the environment (or ``.env``) is reflected here.
+    """
+    from stackchan_mcp import ownership
+
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("WS_PORT", "18765")
+    seen: list[Path] = []
+
+    def fake_read_lock(path: Path | None = None) -> None:
+        seen.append(path)
+        return None
+
+    monkeypatch.setattr(ownership, "read_lock", fake_read_lock)
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--check"])
+    assert exc.value.code == 0
+    assert seen and seen[0] is not None and seen[0].name == "owner-18765.lock"
+    assert "owner-18765.lock" in capsys.readouterr().out
 
 
 def test_main_preflight_flag_runs_preflight_and_exits(

--- a/gateway/tests/test_cli.py
+++ b/gateway/tests/test_cli.py
@@ -325,7 +325,11 @@ def test_main_check_flag_remains_side_effect_free_with_no_mdns(
     async def fail_run(*, advertise_mdns: bool = True) -> None:
         raise AssertionError("--check must not start the gateway")
 
-    monkeypatch.setattr(cli, "_run_preflight", lambda: 0)
+    # ``--check`` runs ``_run_ownership_check()``, which calls ``_load_dotenv()``.
+    # Without stubbing it, the developer's real ``gateway/.env`` is loaded into
+    # ``os.environ`` outside monkeypatch's tracking and never restored, polluting
+    # later tests (e.g. a ``STACKCHAN_TOKEN`` there breaks the WS-server suite).
+    monkeypatch.setattr(cli, "_load_dotenv", lambda: None)
     monkeypatch.setattr(cli, "_run", fail_run)
 
     with pytest.raises(SystemExit) as exc:
@@ -794,6 +798,35 @@ def test_main_check_flag_inspects_per_ws_port_lock(
     assert exc.value.code == 0
     assert seen and seen[0] is not None and seen[0].name == "owner-18765.lock"
     assert "owner-18765.lock" in capsys.readouterr().out
+
+
+def test_main_check_flag_scopes_lock_for_ephemeral_ws_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``WS_PORT=0`` scopes the lock to ``owner-0.lock``, not the legacy path.
+
+    Preflight treats ``0`` as a valid (OS-assigned ephemeral) port, so the
+    ownership lock must stay per-port for it too. A truthiness check would send
+    ``0`` to the machine-global ``owner.lock`` and diverge from startup.
+    """
+    from stackchan_mcp import ownership
+
+    _isolate_preflight_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("WS_PORT", "0")
+    seen: list[Path] = []
+
+    def fake_read_lock(path: Path | None = None) -> None:
+        seen.append(path)
+        return None
+
+    monkeypatch.setattr(ownership, "read_lock", fake_read_lock)
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--check"])
+    assert exc.value.code == 0
+    assert seen and seen[0] is not None and seen[0].name == "owner-0.lock"
 
 
 def test_main_preflight_flag_runs_preflight_and_exits(


### PR DESCRIPTION
## What
Scope the gateway's ownership lock per WS port instead of a single machine-global `owner.lock` (path becomes `owner-<ws_port>.lock`, falling back to `owner.lock` when the WS port can't be resolved).

## Why
The lock guards against two processes fighting over the same device (`ownership.py`: `LOCK_PATH = LOCK_DIR / "owner.lock"`). The real invariant is **one gateway owns one device**; a machine-global lock over-encodes that as **one gateway per machine**. Running one gateway per device on separate WS ports on the same host makes the global lock wrongly reject the second gateway — it dies with `OwnershipError`, surfacing as `unhandled errors in a TaskGroup`. Scoping to the WS port restores the intended invariant: N gateways coexist as long as each owns a distinct port/device, while a duplicate start on the *same* port is still rejected.

## How
- `_ws_port_lock_path()` resolves to `owner-<ws_port>.lock` via existing `_resolve_ws_port()`, falling back to `owner.lock` when unresolved.
- `_acquire_startup_lock` passes `path=` to `acquire_lock` (stdio + streamable-http); release paths (atexit, stdio/http finally) use the same per-port path.
- `--check` reads the per-port lock, reflecting the port it would actually claim.
- `ownership.py` is unchanged — its functions already accept a `path` argument.

## Compatibility (single-device users unaffected)
A default user just sees `owner.lock` → `owner-8765.lock`; single-instance use and same-port double-start rejection are unchanged. The old `owner.lock` becomes a harmless orphan on upgrade.

## Verified on hardware
Two Stack-chan devices on one host (ports 18765 / 8767) start concurrently, each taking its own `owner-18765.lock` / `owner-8767.lock`; both independently controllable (head movement, speech, LEDs).

## Discussion
Happy to adjust the granularity — WS port is a proxy for "one gateway = one endpoint"; scoping by device identity (MAC / Device-Id) may fit better under a multi-device roadmap. Also open to adding cleanup for the orphaned legacy lock.