### PR TITLE
feat(gateway): expose scl_speed_hz on Port A I2C tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ documented-only.
   string field, distinct from `speaker_id` integer and the `voice`
   engine selector) or globally via the `STACKCHAN_EDGE_TTS_DEFAULT_VOICE`
   env var. (#317)
+- Exposed the optional Port A I2C `scl_speed_hz` argument in the gateway
+  schemas for `i2c_read`, `i2c_write`, and `i2c_write_read`, matching the
+  firmware-side 100000..1000000 Hz range so schema-driven MCP clients can
+  discover slower per-transaction I2C clocks. Behaviour is unchanged when
+  omitted. (#321)
 
 ## [0.12.0] - 2026-06-20
 

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1746,7 +1746,12 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "address, then read' patterns, use `i2c_write_read` "
                     "instead. Returns "
                     "{\"ok\": true, \"bytes\": [...]} or "
-                    "{\"ok\": false, \"error\": \"ESP_ERR_TIMEOUT\"} on NACK."
+                    "{\"ok\": false, \"error\": \"ESP_ERR_TIMEOUT\"} on NACK. "
+                    "Optional `scl_speed_hz` (default 400000) sets the I2C "
+                    "clock for this transaction; lower it (e.g. 100000 or "
+                    "200000) for slower Units such as the RCWL-9620 "
+                    "ultrasonic ranger that fail at 400 kHz with "
+                    "ESP_ERR_INVALID_STATE."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1767,6 +1772,19 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             "minimum": 1,
                             "maximum": 256,
                         },
+                        "scl_speed_hz": {
+                            "type": "integer",
+                            "default": 400000,
+                            "description": (
+                                "I2C clock for this transaction. Default "
+                                "400000; lower it (e.g. 100000 or 200000) "
+                                "for slower Units such as the RCWL-9620 "
+                                "ultrasonic ranger that fail at 400 kHz "
+                                "with ESP_ERR_INVALID_STATE."
+                            ),
+                            "minimum": 100000,
+                            "maximum": 1000000,
+                        },
                     },
                     "required": ["addr", "n_bytes"],
                 },
@@ -1778,7 +1796,11 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "on Grove Port A. `bytes` is an array of integers "
                     "(0..255). This tool operates on the external Port A "
                     "bus only; on-board ICs (PMIC, AW9523, touch, etc.) "
-                    "on the internal bus are not reachable."
+                    "on the internal bus are not reachable. Optional "
+                    "`scl_speed_hz` (default 400000) sets the I2C clock for "
+                    "this transaction; lower it (e.g. 100000 or 200000) for "
+                    "slower Units such as the RCWL-9620 ultrasonic ranger "
+                    "that fail at 400 kHz with ESP_ERR_INVALID_STATE."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1802,6 +1824,19 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                                 "maximum": 255,
                             },
                         },
+                        "scl_speed_hz": {
+                            "type": "integer",
+                            "default": 400000,
+                            "description": (
+                                "I2C clock for this transaction. Default "
+                                "400000; lower it (e.g. 100000 or 200000) "
+                                "for slower Units such as the RCWL-9620 "
+                                "ultrasonic ranger that fail at 400 kHz "
+                                "with ESP_ERR_INVALID_STATE."
+                            ),
+                            "minimum": 100000,
+                            "maximum": 1000000,
+                        },
                     },
                     "required": ["addr", "bytes"],
                 },
@@ -1814,7 +1849,11 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "single Repeated Start transaction. Common 'set "
                     "register pointer, then read' idiom: pass "
                     "write_bytes=[reg_addr] to read from a specific "
-                    "register."
+                    "register. Optional `scl_speed_hz` (default 400000) "
+                    "sets the I2C clock for this transaction; lower it "
+                    "(e.g. 100000 or 200000) for slower Units such as the "
+                    "RCWL-9620 ultrasonic ranger that fail at 400 kHz with "
+                    "ESP_ERR_INVALID_STATE."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1846,6 +1885,19 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             "description": "Bytes to read (1..256).",
                             "minimum": 1,
                             "maximum": 256,
+                        },
+                        "scl_speed_hz": {
+                            "type": "integer",
+                            "default": 400000,
+                            "description": (
+                                "I2C clock for this transaction. Default "
+                                "400000; lower it (e.g. 100000 or 200000) "
+                                "for slower Units such as the RCWL-9620 "
+                                "ultrasonic ranger that fail at 400 kHz "
+                                "with ESP_ERR_INVALID_STATE."
+                            ),
+                            "minimum": 100000,
+                            "maximum": 1000000,
                         },
                     },
                     "required": ["addr", "write_bytes", "n_bytes"],

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -726,6 +726,82 @@ async def test_list_tools_includes_port_b_ws2812_tools_with_schemas():
         }
 
 
+_PORT_A_I2C_TOOL_NAMES = ("i2c_read", "i2c_write", "i2c_write_read")
+
+
+@pytest.mark.asyncio
+async def test_list_tools_port_a_i2c_declares_scl_speed_hz_schema():
+    """Port A I2C wrappers expose the per-transaction clock schema."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tools_by_name = {tool.name: tool for tool in result.root.tools}
+    for tool_name in _PORT_A_I2C_TOOL_NAMES:
+        assert tool_name in tools_by_name, f"{tool_name} tool should be registered"
+        description = tools_by_name[tool_name].description
+        assert "scl_speed_hz" in description
+        assert "400000" in description
+        assert "RCWL-9620" in description
+        assert "ESP_ERR_INVALID_STATE" in description
+
+        schema = tools_by_name[tool_name].inputSchema
+        assert schema["properties"]["scl_speed_hz"] == {
+            "type": "integer",
+            "default": 400000,
+            "description": (
+                "I2C clock for this transaction. Default 400000; lower it "
+                "(e.g. 100000 or 200000) for slower Units such as the "
+                "RCWL-9620 ultrasonic ranger that fail at 400 kHz with "
+                "ESP_ERR_INVALID_STATE."
+            ),
+            "minimum": 100000,
+            "maximum": 1000000,
+        }
+        assert "scl_speed_hz" not in schema["required"]
+
+
+@pytest.mark.asyncio
+async def test_i2c_read_relays_scl_speed_hz_to_firmware(monkeypatch):
+    """i2c_read forwards optional scl_speed_hz unchanged to the ESP32 tool."""
+    calls: list[tuple[str, dict]] = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, tool_name, arguments):
+            calls.append((tool_name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"ok": True, "bytes": [1, 2]}),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+    arguments = {"addr": 0x57, "n_bytes": 2, "scl_speed_hz": 200000}
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "i2c_read", "arguments": arguments},
+        )
+    )
+
+    assert calls == [("self.i2c.read", arguments)]
+    assert json.loads(result.root.content[0].text) == {"ok": True, "bytes": [1, 2]}
+
+
 def _make_port_b_ws2812_fake_gateway(monkeypatch):
     calls: list[tuple[str, dict]] = []
 


### PR DESCRIPTION
## What

Declares the optional `scl_speed_hz` property (integer, default `400000`, range `100000`–`1000000`) on the three gateway I2C tool schemas — `i2c_read`, `i2c_write`, `i2c_write_read` — and extends their descriptions to match the firmware side.

## Why

#319 added per-transaction I2C clock control to the firmware Port A tools so slow Units (e.g. the RCWL-9620 ultrasonic ranger, which fails at 400 kHz with `ESP_ERR_INVALID_STATE`) can be driven without recompiling. The gateway dispatch already passes tool arguments through unchanged, so the property worked end-to-end when sent explicitly — but it was absent from the gateway `inputSchema`, so schema-driven MCP clients (the main consumption path) could not discover it.

Closes #321.

## How

- `gateway/stackchan_mcp/stdio_server.py`: added `scl_speed_hz` to the three I2C tool schemas (optional, not in `required`) and mirrored the firmware description wording
- `gateway/tests/test_stdio_server.py`: schema-presence test for all three tools + a relay pass-through test
- `CHANGELOG.md`: `[Unreleased]` > Gateway entry

## Validation

- `uv run pytest` green (new tests included)
- `uv run ruff check .` clean
- No behavioural change when the property is omitted (the dispatch pass-through is untouched)
