### PR TITLE
release: cut pair release firmware-v1.13.0 + v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,22 +30,7 @@ documented-only.
 
 ## [Unreleased]
 
-### Firmware
-
-- Added an optional `scl_speed_hz` property (default `400000`, range
-  `100000`–`1000000`) to the Port A I2C tools `self.i2c.read`,
-  `self.i2c.write`, and `self.i2c.write_read`, applied to the per-call
-  `i2c_master_bus_add_device` config. This lets slow Units that cannot
-  sustain the hardcoded 400 kHz clock be driven without recompiling the
-  firmware (e.g. the RCWL-9620 ultrasonic ranger, which ACKs a probe but
-  fails the transfer with `ESP_ERR_INVALID_STATE` at 400 kHz and only
-  reads stably at 100 kHz). Behaviour is unchanged when the property is
-  omitted. (#319)
-- Added the NVS-backed `touch.enabled` field, handler guards, and
-  `self.robot.set_touch_sensor_enabled` /
-  `self.robot.get_touch_sensor_enabled` MCP tools so users can disable
-  head-touch detection while stopping both local reactions and
-  `stackchan/event` emission. (#312)
+## [0.13.0] - 2026-07-02
 
 ### Gateway
 
@@ -83,6 +68,25 @@ documented-only.
   firmware-side 100000..1000000 Hz range so schema-driven MCP clients can
   discover slower per-transaction I2C clocks. Behaviour is unchanged when
   omitted. (#321)
+
+## [firmware-v1.13.0] - 2026-07-02
+
+### Firmware
+
+- Added an optional `scl_speed_hz` property (default `400000`, range
+  `100000`–`1000000`) to the Port A I2C tools `self.i2c.read`,
+  `self.i2c.write`, and `self.i2c.write_read`, applied to the per-call
+  `i2c_master_bus_add_device` config. This lets slow Units that cannot
+  sustain the hardcoded 400 kHz clock be driven without recompiling the
+  firmware (e.g. the RCWL-9620 ultrasonic ranger, which ACKs a probe but
+  fails the transfer with `ESP_ERR_INVALID_STATE` at 400 kHz and only
+  reads stably at 100 kHz). Behaviour is unchanged when the property is
+  omitted. (#319)
+- Added the NVS-backed `touch.enabled` field, handler guards, and
+  `self.robot.set_touch_sensor_enabled` /
+  `self.robot.get_touch_sensor_enabled` MCP tools so users can disable
+  head-touch detection while stopping both local reactions and
+  `stackchan/event` emission. (#312)
 
 ## [0.12.0] - 2026-06-20
 
@@ -1724,7 +1728,9 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.12.0...v0.13.0
+[firmware-v1.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.12.0...firmware-v1.13.0
 [0.12.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.11.0...v0.12.0
 [firmware-v1.12.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.11.0...firmware-v1.12.0
 [0.11.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.10.0...v0.11.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.12.0"
+version = "0.13.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2129,11 +2129,11 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv" },
     { name = "pyyaml", specifier = ">=6" },
-    { name = "tomli", marker = "python_version < '3.11'", specifier = ">=2.0,<3.0" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-faster-whisper'" },
     { name = "stackchan-mcp", extras = ["stt"], marker = "extra == 'stt-openai'" },
     { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-irodori'" },
     { name = "stackchan-mcp", extras = ["tts"], marker = "extra == 'tts-voicevox'" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0,<3.0" },
     { name = "websockets", specifier = ">=12" },
     { name = "zeroconf", specifier = ">=0.149" },
 ]


### PR DESCRIPTION
## What

Release commit for the pair release **v0.13.0 (gateway)** + **firmware-v1.13.0**.

- `CHANGELOG.md`: promote `[Unreleased]` into `[0.13.0] - 2026-07-02` (Gateway) and `[firmware-v1.13.0] - 2026-07-02` (Firmware); refresh comparison links
- `gateway/pyproject.toml`: version 0.12.0 → 0.13.0
- `gateway/uv.lock`: regenerated via `uv lock` (version sync)

## Contents

**Gateway v0.13.0**: user-defaults TOML config (#311), touch sensor wrappers (#312), `smoothing_window` exposure (#309), `downsample_hz` schema cap 60 → 20 **BREAKING** (#315), `edge-tts` engine (#317), I2C `scl_speed_hz` schema exposure (#321)

**Firmware v1.13.0**: NVS-backed touch sensor disable + MCP tools (#312), Port A I2C per-transaction `scl_speed_hz` (#319)

## Release plan (after merge)

1. Tag `firmware-v1.13.0` on the merge commit → firmware-release workflow builds and publishes the GitHub Release
2. Tag `v0.13.0` → Trusted Publishing to PyPI + manual GitHub Release
3. Release notes will include a migration note for the **BREAKING** `downsample_hz` cap

## Pre-flight

- 4 checks passed: no open verification / release-blocker issues for the included PRs; no parallel work in flight; no new priority/medium bugs on touched paths; CHANGELOG entries match `git log` 1:1 for both sides
- Release commit includes the 3-file set (CHANGELOG + pyproject + uv.lock) per the v0.10.0 lockfile lesson
