### PR TITLE
feat(gateway): auto-show idle avatar after device session init (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Auto-render the idle avatar after a new ESP32 device session finishes
+  initialization and tool discovery, unless `set_avatar` was already sent
+  on that connection. (#77)
+
 ## [0.13.0] - 2026-07-02
 
 ### Gateway

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -43,6 +43,8 @@ RESPONSE_TIMEOUT = 10.0
 ToolCall = tuple[str, dict[str, Any]]
 ToolCallResult = tuple[Any, dict[str, Any] | None]
 
+_SET_AVATAR_TOOL = "self.display.set_avatar"
+
 _TOOL_LANES = {
     "self.robot.": "servo",
     "self.wifi.": "wifi",
@@ -82,6 +84,8 @@ class ESP32Connection:
         self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
         self._connected = True
         self._initialized = False
+        self._tools_discovered = False
+        self._avatar_render_sent = False
         # Phase 4.5 avatar: pending load_avatar_set calls waiting for the
         # device's `avatar_set_loaded` reply. Keyed by expected checksum
         # so that overlapping fetches (different sets) can be discriminated.
@@ -101,6 +105,14 @@ class ESP32Connection:
     @property
     def initialized(self) -> bool:
         return self._initialized
+
+    @property
+    def tools_discovered(self) -> bool:
+        return self._tools_discovered
+
+    @property
+    def avatar_render_sent(self) -> bool:
+        return self._avatar_render_sent
 
     def _next_id(self) -> int:
         self._request_id += 1
@@ -162,6 +174,8 @@ class ESP32Connection:
         """Discover tools available on ESP32."""
         all_tools: list[dict[str, Any]] = []
         cursor = ""
+        self._tools_discovered = False
+        discovered = False
 
         while True:
             params: dict[str, Any] = {"cursor": cursor}
@@ -169,6 +183,7 @@ class ESP32Connection:
 
             if error:
                 logger.error("tools/list failed: %s", error)
+                self.tools = all_tools
                 break
 
             tools = result.get("tools", [])
@@ -176,10 +191,12 @@ class ESP32Connection:
 
             next_cursor = result.get("nextCursor", "")
             if not next_cursor:
+                discovered = True
                 break
             cursor = next_cursor
 
         self.tools = all_tools
+        self._tools_discovered = discovered
         logger.info("Discovered %d tools on ESP32", len(all_tools))
         return all_tools
 
@@ -187,6 +204,8 @@ class ESP32Connection:
         self, name: str, arguments: dict[str, Any]
     ) -> tuple[Any, dict[str, Any] | None]:
         """Call a tool on ESP32."""
+        if name == _SET_AVATAR_TOOL:
+            self._avatar_render_sent = True
         return await self.send_mcp_request(
             "tools/call", {"name": name, "arguments": arguments}
         )
@@ -732,6 +751,10 @@ class ESP32Manager:
             vision_token=self._vision_token,
         ):
             await connection.discover_tools()
+            if not connection.tools_discovered:
+                logger.error("ESP32 tools discovery failed")
+                return
+            await self._auto_render_idle_avatar(connection, device_id)
             logger.info(
                 "ESP32 ready: device=%s tools=%d",
                 device_id,
@@ -739,6 +762,37 @@ class ESP32Manager:
             )
         else:
             logger.error("ESP32 MCP initialization failed")
+
+    async def _auto_render_idle_avatar(
+        self, connection: ESP32Connection, device_id: str
+    ) -> None:
+        """Best-effort idle avatar render after a fresh device session init."""
+        if connection.avatar_render_sent:
+            return
+
+        logger.info(
+            "auto-rendering idle avatar (no explicit set_avatar yet): device=%s",
+            device_id,
+        )
+        try:
+            _result, error = await connection.call_tool(
+                _SET_AVATAR_TOOL,
+                {"face": "idle"},
+            )
+        except Exception as exc:
+            logger.warning(
+                "auto-rendering idle avatar failed: device=%s error=%s",
+                device_id,
+                exc,
+            )
+            return
+
+        if error:
+            logger.warning(
+                "auto-rendering idle avatar failed: device=%s error=%s",
+                device_id,
+                error,
+            )
 
     async def _emit_stackchan_event(self, payload: dict[str, Any]) -> None:
         """Forward a firmware-originated stackchan event to the MCP client."""

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import gc
 import json
+import logging
 
 import pytest
 import pytest_asyncio
@@ -131,6 +132,13 @@ async def test_esp32_hello_handshake(manager):
             },
         }
         await ws.send(json.dumps(tools_resp))
+
+        auto_msg = await _expect_auto_idle_avatar(ws)
+        await _send_mcp_response(
+            ws,
+            auto_msg,
+            result={"content": [{"type": "text", "text": "true"}], "isError": False},
+        )
 
         # Wait for manager to process
         await asyncio.sleep(0.2)
@@ -316,6 +324,190 @@ async def test_connection_removes_pending_request_when_call_is_cancelled():
         await task
 
     assert conn._pending == {}
+
+
+# ---------------------------------------------------------------------------
+# Auto idle avatar render after session initialization (Issue #77)
+# ---------------------------------------------------------------------------
+
+
+class _InitDeviceConnection:
+    """Fake connection for exercising ESP32Manager._init_device."""
+
+    def __init__(
+        self,
+        *,
+        avatar_render_sent: bool = False,
+        discover_ok: bool = True,
+        auto_error: dict | None = None,
+        auto_exception: Exception | None = None,
+    ) -> None:
+        self.tools: list[dict] = []
+        self.tools_discovered = False
+        self.avatar_render_sent = avatar_render_sent
+        self.discover_ok = discover_ok
+        self.auto_error = auto_error
+        self.auto_exception = auto_exception
+        self.initialize_calls = 0
+        self.discover_calls = 0
+        self.call_tool_calls: list[tuple[str, dict]] = []
+
+    async def initialize(self, *, vision_url: str = "", vision_token: str = "") -> bool:
+        self.initialize_calls += 1
+        return True
+
+    async def discover_tools(self) -> list[dict]:
+        self.discover_calls += 1
+        if not self.discover_ok:
+            self.tools = []
+            self.tools_discovered = False
+            return self.tools
+
+        self.tools = [
+            {
+                "name": "self.display.set_avatar",
+                "description": "Set avatar",
+                "inputSchema": {"type": "object"},
+            }
+        ]
+        self.tools_discovered = True
+        return self.tools
+
+    async def call_tool(self, name: str, arguments: dict):
+        self.call_tool_calls.append((name, arguments))
+        if name == "self.display.set_avatar":
+            self.avatar_render_sent = True
+        if self.auto_exception is not None:
+            raise self.auto_exception
+        return {"content": [{"type": "text", "text": "true"}]}, self.auto_error
+
+
+class _AutoMcpWebSocket:
+    """Fake WebSocket that responds to gateway MCP requests immediately."""
+
+    def __init__(self) -> None:
+        self.connection: ESP32Connection | None = None
+        self.sent: list[str] = []
+        self.tool_calls: list[tuple[str, dict]] = []
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+        message = json.loads(data)
+        payload = message["payload"]
+        method = payload["method"]
+
+        if method == "initialize":
+            result = {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "test-device", "version": "1.0.0"},
+            }
+        elif method == "tools/list":
+            result = {
+                "tools": [
+                    {
+                        "name": "self.display.set_avatar",
+                        "description": "Set avatar",
+                        "inputSchema": {"type": "object"},
+                    }
+                ],
+                "nextCursor": "",
+            }
+        elif method == "tools/call":
+            params = payload["params"]
+            self.tool_calls.append((params["name"], params["arguments"]))
+            result = {"content": [{"type": "text", "text": "true"}], "isError": False}
+        else:
+            raise AssertionError(f"unexpected MCP method: {method}")
+
+        assert self.connection is not None
+        self.connection.handle_response(
+            {"jsonrpc": "2.0", "id": payload["id"], "result": result}
+        )
+
+
+@pytest.mark.asyncio
+async def test_init_auto_renders_idle_avatar_after_tools_list():
+    """A successful initialize + tools/list sends idle set_avatar once."""
+    ws = _AutoMcpWebSocket()
+    connection = ESP32Connection(ws, session_id="session-auto")  # type: ignore[arg-type]
+    ws.connection = connection
+    mgr = ESP32Manager()
+
+    await mgr._init_device(connection, "device-test")
+
+    assert ws.tool_calls == [("self.display.set_avatar", {"face": "idle"})]
+    assert connection.avatar_render_sent is True
+
+
+@pytest.mark.asyncio
+async def test_init_skips_auto_idle_avatar_when_avatar_already_sent():
+    """The connection-scoped flag suppresses the automatic idle render."""
+    mgr = ESP32Manager()
+    connection = _InitDeviceConnection(avatar_render_sent=True)
+
+    await mgr._init_device(connection, "device-test")  # type: ignore[arg-type]
+
+    assert connection.initialize_calls == 1
+    assert connection.discover_calls == 1
+    assert connection.call_tool_calls == []
+
+
+@pytest.mark.asyncio
+async def test_init_skips_auto_idle_avatar_when_tools_discovery_fails(caplog):
+    """The auto-render path only runs after successful tools/list discovery."""
+    caplog.set_level(logging.INFO, logger="stackchan_mcp.esp32_client")
+    mgr = ESP32Manager()
+    connection = _InitDeviceConnection(discover_ok=False)
+
+    await mgr._init_device(connection, "device-test")  # type: ignore[arg-type]
+
+    assert connection.initialize_calls == 1
+    assert connection.discover_calls == 1
+    assert connection.call_tool_calls == []
+    assert "ESP32 ready: device=device-test" not in caplog.text
+
+
+@pytest.mark.parametrize("failure_mode", ["error", "timeout"])
+@pytest.mark.asyncio
+async def test_init_continues_when_auto_idle_avatar_fails(failure_mode, caplog):
+    """Auto-render failures are warnings and do not block ESP32 ready."""
+    caplog.set_level(logging.INFO, logger="stackchan_mcp.esp32_client")
+    if failure_mode == "error":
+        connection = _InitDeviceConnection(
+            auto_error={"code": -32000, "message": "device rejected set_avatar"}
+        )
+    else:
+        connection = _InitDeviceConnection(
+            auto_exception=asyncio.TimeoutError("set_avatar timed out")
+        )
+    mgr = ESP32Manager()
+
+    await mgr._init_device(connection, "device-test")  # type: ignore[arg-type]
+
+    assert connection.call_tool_calls == [
+        ("self.display.set_avatar", {"face": "idle"})
+    ]
+    assert "auto-rendering idle avatar failed" in caplog.text
+    assert "ESP32 ready: device=device-test tools=1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reconnect_auto_renders_idle_avatar_again():
+    """A new ESP32Connection gets a fresh auto-render flag."""
+    first_ws = _AutoMcpWebSocket()
+    first = ESP32Connection(first_ws, session_id="session-first")  # type: ignore[arg-type]
+    first_ws.connection = first
+    second_ws = _AutoMcpWebSocket()
+    second = ESP32Connection(second_ws, session_id="session-second")  # type: ignore[arg-type]
+    second_ws.connection = second
+    mgr = ESP32Manager()
+
+    await mgr._init_device(first, "device-test")
+    await mgr._init_device(second, "device-test")
+
+    assert first_ws.tool_calls == [("self.display.set_avatar", {"face": "idle"})]
+    assert second_ws.tool_calls == [("self.display.set_avatar", {"face": "idle"})]
 
 
 class _GateableConnection:
@@ -726,7 +918,7 @@ def test_connection_default_protocol_version_is_one():
 # ---------------------------------------------------------------------------
 
 
-async def _complete_handshake(ws, tools=None):
+async def _complete_handshake(ws, tools=None, *, consume_auto_avatar=True):
     """Complete the full ESP32 handshake sequence."""
     if tools is None:
         tools = []
@@ -774,6 +966,49 @@ async def _complete_handshake(ws, tools=None):
         },
     }
     await ws.send(json.dumps(tools_resp))
+    if not consume_auto_avatar:
+        return None
+
+    auto_msg = await _expect_auto_idle_avatar(ws)
+    await _send_mcp_response(
+        ws,
+        auto_msg,
+        result={"content": [{"type": "text", "text": "true"}], "isError": False},
+    )
+    return auto_msg
+
+
+async def _expect_auto_idle_avatar(ws):
+    """Receive and assert the automatic idle avatar tools/call."""
+    auto_raw = await asyncio.wait_for(ws.recv(), timeout=5.0)
+    auto_msg = json.loads(auto_raw)
+    assert auto_msg["type"] == "mcp"
+    assert auto_msg["payload"]["method"] == "tools/call"
+    assert auto_msg["payload"]["params"]["name"] == "self.display.set_avatar"
+    assert auto_msg["payload"]["params"]["arguments"] == {"face": "idle"}
+    return auto_msg
+
+
+async def _send_mcp_response(ws, req_msg, *, result=None, error=None):
+    """Send a JSON-RPC response for a gateway-originated MCP request."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req_msg["payload"]["id"],
+    }
+    if error is None:
+        payload["result"] = result or {}
+    else:
+        payload["error"] = error
+
+    await ws.send(
+        json.dumps(
+            {
+                "session_id": req_msg["session_id"],
+                "type": "mcp",
+                "payload": payload,
+            }
+        )
+    )
 
 
 # --- Device-driven listen capture --------------------------------------------
@@ -932,4 +1167,3 @@ async def test_device_driven_listen_cleanup_on_disconnect(manager_with_hook):
     assert not is_recording(), "recording slot was leaked across connections"
     # No push should have fired for the aborted capture.
     assert calls == []
-


### PR DESCRIPTION
## Summary

- Auto-render the `idle` avatar once the ESP32 device session finishes MCP initialisation (initialize + tools/list) and no avatar has been rendered on that connection yet.
- Fixes the first-boot / reconnect UX gap where the LCD stays on whatever it was showing (xiaozhi setup UI or the previous session's frame) until an MCP client explicitly calls `set_avatar`, making a healthy device look "asleep" (#77).

## Design notes

- Implements **Option A** from #77: the trigger is gateway-side device session init completion, not raw boot, so the underlying xiaozhi screens (WiFi setup / OTA) remain visible while no gateway session is established.
- The tracking flag is **connection-scoped**: a reconnect creates a new connection object and auto-renders again, so the blank-after-reconnect case is also covered. A user who had `set_avatar(face="off")` active before a reconnect sees `idle` again after the reconnect and can re-issue `off` — mirroring what already happens after a firmware reboot.
- `set_avatar(face="off")` semantics are unchanged: the auto-render fires once per connection at init time and never overrides a later explicit call.
- Best-effort: an auto-render failure logs a warning and does not fail device init.
- Out of scope (per issue): default-face customisation (config / NVS), firmware changes.

## Test plan

Added to `gateway/tests/test_esp32_client.py`:

- `test_init_auto_renders_idle_avatar_after_tools_list` — successful initialize + tools/list sends `self.display.set_avatar {"face": "idle"}` once
- `test_init_skips_auto_idle_avatar_when_avatar_already_sent` — the connection-scoped flag suppresses the auto-render
- `test_init_skips_auto_idle_avatar_when_tools_discovery_fails` — the auto-render only runs after successful tools discovery (failed discovery now logs an error instead of reporting "ESP32 ready" with a partial tool list)
- `test_init_continues_when_auto_idle_avatar_fails` (parametrized: error / timeout) — auto-render failures log a warning and do not block "ESP32 ready"
- `test_reconnect_auto_renders_idle_avatar_again` — a new connection object gets a fresh flag

Existing handshake tests updated to consume the new auto-render `tools/call` frame.

- `cd gateway && uv run pytest` — 617 passed, 1 skipped
- `cd gateway && uv run ruff check .` — clean
- Codex review vs main: no findings

Closes #77
