### PR TITLE
fix(gateway): drain _avatar_set_waiters on disconnect (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ documented-only.
 - Auto-render the idle avatar after a new ESP32 device session finishes
   initialization and tool discovery, unless `set_avatar` was already sent
   on that connection. (#77)
+- Fail in-flight `load_avatar_set` calls with `disconnected` immediately
+  when the ESP32 connection drops, instead of waiting for the avatar
+  load timeout. (#228)
 
 ## [0.13.0] - 2026-07-02
 

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -252,6 +252,9 @@ class ESP32Connection:
             return {"ok": False, "checksum": checksum, "error": "device_timeout"}
         except asyncio.CancelledError:
             return {"ok": False, "checksum": checksum, "error": "superseded"}
+        except ConnectionError:
+            self._avatar_set_waiters.pop(checksum, None)
+            return {"ok": False, "checksum": checksum, "error": "disconnected"}
         except Exception as exc:
             self._avatar_set_waiters.pop(checksum, None)
             return {"ok": False, "checksum": checksum, "error": f"send_failed: {exc}"}
@@ -372,6 +375,10 @@ class ESP32Connection:
             if not future.done():
                 future.set_exception(ConnectionError("ESP32 disconnected"))
         self._pending.clear()
+        for future in self._avatar_set_waiters.values():
+            if not future.done():
+                future.set_exception(ConnectionError("ESP32 disconnected"))
+        self._avatar_set_waiters.clear()
 
 
 class ESP32Manager:

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -510,6 +510,81 @@ async def test_reconnect_auto_renders_idle_avatar_again():
     assert second_ws.tool_calls == [("self.display.set_avatar", {"face": "idle"})]
 
 
+@pytest.mark.asyncio
+async def test_send_avatar_set_fetch_resolves_when_loaded_event_arrives():
+    """avatar_set_loaded resolves the matching load_avatar_set waiter."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-avatar")  # type: ignore[arg-type]
+
+    task = asyncio.create_task(
+        conn.send_avatar_set_fetch(
+            url="https://example.invalid/avatar-set.bin",
+            token="test-token",
+            mode="replace",
+            checksum="sha256:avatar-set",
+            expected_size=1234,
+            timeout=30.0,
+        )
+    )
+
+    await asyncio.sleep(0)
+    assert len(ws.sent) == 1
+    assert json.loads(ws.sent[0]) == {
+        "type": "avatar_set_fetch",
+        "url": "https://example.invalid/avatar-set.bin",
+        "token": "test-token",
+        "mode": "replace",
+        "checksum": "sha256:avatar-set",
+        "expected_size": 1234,
+    }
+
+    payload = {
+        "ok": True,
+        "checksum": "sha256:avatar-set",
+        "bytes": 1234,
+    }
+    conn.handle_avatar_set_loaded(payload)
+
+    result = await asyncio.wait_for(task, timeout=1.0)
+    assert result == payload
+    assert conn._avatar_set_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_send_avatar_set_fetch_returns_disconnected_when_connection_drops():
+    """Disconnect wakes an in-flight avatar set fetch without waiting for timeout."""
+    ws = _FakeWebSocket()
+    conn = ESP32Connection(ws, session_id="session-avatar")  # type: ignore[arg-type]
+
+    task = asyncio.create_task(
+        conn.send_avatar_set_fetch(
+            url="https://example.invalid/avatar-set.bin",
+            token="test-token",
+            mode="replace",
+            checksum="sha256:avatar-set",
+            expected_size=1234,
+            timeout=30.0,
+        )
+    )
+
+    await asyncio.sleep(0)
+    assert len(ws.sent) == 1
+    assert len(conn._avatar_set_waiters) == 1
+
+    started_at = asyncio.get_running_loop().time()
+    conn.disconnect()
+    result = await asyncio.wait_for(task, timeout=1.0)
+    elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert result == {
+        "ok": False,
+        "checksum": "sha256:avatar-set",
+        "error": "disconnected",
+    }
+    assert elapsed < 1.0
+    assert conn._avatar_set_waiters == {}
+
+
 class _GateableConnection:
     """Fake initialized connection with per-tool release gates."""
 


### PR DESCRIPTION
## Summary

- Drain `_avatar_set_waiters` in `ESP32Connection.disconnect()` the same way `_pending` is drained, so a `load_avatar_set` call awaiting `avatar_set_loaded` fails fast when the ESP32 drops the connection mid-fetch (#228).
- Surface the condition as a distinct `{"ok": false, "error": "disconnected"}` result instead of letting the exception fall into the generic `"send_failed: ..."` handler.

## Design notes

- `disconnect()` is the single funnel for every "connection definitely gone" path (`_ws_send` failure, manager connection replacement, read-loop teardown), so one drain site covers all of them.
- The drain mirrors the existing `_pending` loop (`ConnectionError("ESP32 disconnected")` + clear) to keep the two waiter dicts symmetric.
- `ConnectionError` is an `OSError` subclass, so a raw `ws.send` failure of type `ConnectionResetError` also lands in the new handler — acceptable, since "disconnected" is the accurate label either way.
- Untouched: `_pending` handling, duplicate-checksum last-writer-wins ("superseded"), timeout and generic-failure paths.

## Test plan

Added to `gateway/tests/test_esp32_client.py` (first coverage for `send_avatar_set_fetch` — a happy-path baseline plus the regression case):

- `test_send_avatar_set_fetch_resolves_when_loaded_event_arrives` — wire format + resolution via `handle_avatar_set_loaded`, waiter dict drained
- `test_send_avatar_set_fetch_returns_disconnected_when_connection_drops` — `disconnect()` mid-fetch resolves the call with `"disconnected"` well under the 30 s timeout (elapsed asserted < 1 s), waiter dict drained

- `cd gateway && uv run pytest` — 613 passed, 1 skipped
- `cd gateway && uv run ruff check .` — clean
- Codex review vs main: no findings

Closes #228
