### PR TITLE
fix(capture): don't 413 uploads on aiohttp>=3.14; tolerate non-UTF-8 question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ documented-only.
   (the default lock is simply named `owner-8765.lock`) and a duplicate
   start on the same port is still rejected; `--check` reads the per-port
   lock. (#320)
+- Fixed `/capture` rejecting photo uploads with HTTP 413 on aiohttp >= 3.14.
+  The capture app raised the per-request body cap with `client_max_size=0`
+  (so `/pcm` can stream long PCM), but aiohttp's multipart reader treats `0`
+  as a zero-byte limit — unlike `request.read()`/`.post()` — so every upload
+  carrying a non-empty `question` field was rejected with 413. Use a large
+  finite `client_max_size` instead; `/capture`'s real limit stays the explicit
+  per-route byte cap.
+- Hardened `/capture` to tolerate a non-UTF-8 `question` field (decode with
+  `errors="replace"`) instead of failing the upload with HTTP 500.
 
 ## [0.13.0] - 2026-07-02
 

--- a/gateway/stackchan_mcp/capture_server.py
+++ b/gateway/stackchan_mcp/capture_server.py
@@ -143,7 +143,11 @@ async def handle_capture(request: web.Request) -> web.Response:
 
     async for part in reader:
         if part.name == "question":
-            question = (await part.read()).decode("utf-8")
+            # Decode defensively: a malformed (non-UTF-8) question field must
+            # not turn a photo upload into a 500. The question is advisory
+            # metadata, so replacing undecodable bytes is preferable to
+            # dropping the whole capture.
+            question = (await part.read()).decode("utf-8", errors="replace")
         elif part.name == "file":
             timestamp = int(time.time() * 1000)
             filename = f"capture_{timestamp}.jpg"

--- a/gateway/stackchan_mcp/capture_server.py
+++ b/gateway/stackchan_mcp/capture_server.py
@@ -51,6 +51,7 @@ import json
 import logging
 import os
 import secrets
+import sys
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, AsyncIterator
@@ -445,19 +446,26 @@ def create_capture_app(
     dispatches to. May be ``None`` for tests of /capture alone; /pcm
     will return 503 in that case.
     """
-    # ``client_max_size=0`` disables aiohttp's per-request body size
-    # cap (default 1 MiB). The /pcm endpoint legitimately streams
-    # arbitrarily long PCM utterances (multi-minute TTS, live audio
-    # mixes); a 1 MiB cap would silently cut a chunked-transfer
-    # producer off mid-stream once its cumulative body exceeded that
-    # limit — observed in practice with a 200-second TTS push, which
-    # aborted around 36 s in (~2 MiB of source-rate PCM through the
-    # transfer-encoding pipe). The handler itself enforces no separate
-    # cap; back-pressure comes from the device-side Opus push rate
-    # inside ``send_pcm_stream``, which is the right place for it.
-    # /capture only receives JPEG snapshots from the ESP32 (well under
-    # 1 MiB each) so removing the cap costs it nothing.
-    app = web.Application(client_max_size=0)
+    # Raise aiohttp's per-request body cap (default 1 MiB) effectively to
+    # unlimited. The /pcm endpoint legitimately streams arbitrarily long PCM
+    # utterances (multi-minute TTS, live audio mixes); a 1 MiB cap would
+    # silently cut a chunked-transfer producer off mid-stream once its
+    # cumulative body exceeded that limit — observed in practice with a
+    # 200-second TTS push, which aborted around 36 s in (~2 MiB of
+    # source-rate PCM through the transfer-encoding pipe).
+    #
+    # Use ``sys.maxsize`` rather than ``0``. Although ``0`` disables the cap
+    # for ``request.read()`` / ``request.post()`` (both guard with
+    # ``if 0 < max_size``), aiohttp's multipart reader does NOT special-case
+    # ``0``: ``BodyPartReader.read()`` compares ``len(data) > client_max_size``
+    # directly (aiohttp >= 3.14), so a client_max_size of 0 propagated into
+    # ``request.multipart()`` rejects ANY non-empty multipart field with
+    # HTTP 413. /capture reads its ``question`` form field via ``part.read()``,
+    # so with ``client_max_size=0`` every photo upload carrying a non-empty
+    # question 413s ("Failed to upload photo"). A large finite value avoids
+    # that trap while keeping /pcm effectively unbounded. /capture's real
+    # size limit is the explicit CAPTURE_MAX_BYTES check in handle_capture.
+    app = web.Application(client_max_size=sys.maxsize)
     app[CAPTURE_TOKEN_KEY] = capture_token
     app[AVATAR_SETS_KEY] = {}
     app[AVATAR_SETS_LOCK_KEY] = asyncio.Lock()

--- a/gateway/tests/test_capture_server.py
+++ b/gateway/tests/test_capture_server.py
@@ -199,3 +199,42 @@ async def test_pcm_no_auth_allows_unauthed_request_when_token_blank():
     # We don't auth-reject (would be 401); the next guard (sample-rate)
     # fires first, so 400 here means auth was skipped as intended.
     assert response.status == 400
+
+
+# ---------------------------------------------------------------------------
+# /capture endpoint — multipart body-cap regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_accepts_nonempty_question_field(tmp_path, monkeypatch):
+    """A non-empty multipart ``question`` field must not be rejected with 413.
+
+    Regression guard. The capture app raises aiohttp's per-request body cap so
+    /pcm can stream long PCM. It must NOT do so by setting ``client_max_size=0``:
+    aiohttp's multipart reader (>= 3.14) checks ``len(data) > client_max_size``
+    directly and, unlike ``request.read()`` / ``request.post()``, does not treat
+    ``0`` as "unlimited". With ``client_max_size=0`` every /capture upload that
+    carries a non-empty ``question`` form field (read via ``part.read()``) fails
+    with HTTP 413, surfacing on the device as "Failed to upload photo". A large
+    finite cap keeps /pcm unbounded while letting normal uploads through.
+    """
+    import aiohttp
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from stackchan_mcp import capture_server
+
+    monkeypatch.setattr(capture_server, "CAPTURE_DIR", str(tmp_path))
+    app = create_capture_app(capture_token="")  # blank token → auth skipped
+
+    async with TestClient(TestServer(app)) as client:
+        form = aiohttp.FormData()
+        form.add_field("question", "what is in front of you?")
+        form.add_field(
+            "file",
+            b"\xff\xd8\xff\xe0JFIF-dummy-jpeg-bytes",
+            filename="photo.jpg",
+            content_type="image/jpeg",
+        )
+        resp = await client.post("/capture", data=form)
+        assert resp.status == 200, await resp.text()

--- a/gateway/tests/test_capture_server.py
+++ b/gateway/tests/test_capture_server.py
@@ -238,3 +238,33 @@ async def test_capture_accepts_nonempty_question_field(tmp_path, monkeypatch):
         )
         resp = await client.post("/capture", data=form)
         assert resp.status == 200, await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_capture_tolerates_non_utf8_question(tmp_path, monkeypatch):
+    """A malformed (non-UTF-8) question field must not 500 the upload.
+
+    The question is advisory metadata; a client that sends it in the wrong
+    encoding should still get its photo stored (decoded with errors=replace)
+    rather than a 500 that looks to the device like a failed capture.
+    """
+    import aiohttp
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from stackchan_mcp import capture_server
+
+    monkeypatch.setattr(capture_server, "CAPTURE_DIR", str(tmp_path))
+    app = create_capture_app(capture_token="")
+
+    async with TestClient(TestServer(app)) as client:
+        with aiohttp.MultipartWriter("form-data") as mpwriter:
+            # Raw non-UTF-8 bytes (0x96 is a Shift-JIS lead byte, an invalid
+            # UTF-8 start byte) in the question part.
+            part = mpwriter.append(b"\x96\x96\x96")
+            part.set_content_disposition("form-data", name="question")
+            fpart = mpwriter.append(b"\xff\xd8\xff\xe0JFIF-dummy")
+            fpart.set_content_disposition(
+                "form-data", name="file", filename="photo.jpg"
+            )
+            resp = await client.post("/capture", data=mpwriter)
+        assert resp.status == 200, await resp.text()


### PR DESCRIPTION
Two robustness fixes for the `/capture` photo-upload endpoint.

## Fix 1 — `/capture` returns 413 for normal uploads on aiohttp >= 3.14

`create_capture_app` sets `web.Application(client_max_size=0)` to lift aiohttp's default 1 MiB body cap so `/pcm` can stream arbitrarily long PCM.

aiohttp >= 3.14 added a size check to its multipart reader (`BodyPartReader.read()`: `if len(data) > client_max_size: raise HTTPRequestEntityTooLarge`) that — unlike `request.read()` / `request.post()`, which guard with `if 0 < max_size` — does **not** treat `0` as "unlimited". `request.multipart()` propagates the app's `client_max_size` (`0`) into that reader, so every `/capture` upload whose `question` form field is non-empty (read via `part.read()`) is rejected with **413 "Maximum request body size 0 exceeded"**. Empty-question uploads slip through (the file part is read via `read_chunk`), which masks the bug.

Downstream this surfaces as the ESP32 reporting **"Failed to upload photo"**: the device POSTs the JPEG, the gateway 413s it, `take_photo` returns an error.

**Fix:** use `client_max_size=sys.maxsize` instead of `0`. `request.read()` / `.post()` and multipart are all effectively unbounded, `/pcm` keeps streaming, and `/capture`'s real limit stays the explicit `CAPTURE_MAX_BYTES` per-route check in `handle_capture`.

Only manifests on aiohttp >= 3.14 (where the multipart size check was added); on 3.13.x the endpoint worked regardless of `client_max_size`.

## Fix 2 — non-UTF-8 `question` field 500s the upload

`handle_capture` decoded the `question` field with a strict `.decode("utf-8")`, so a client that sent it in another encoding turned a valid photo upload into a 500. The question is advisory metadata; decode with `errors="replace"` so the photo is still stored.

## Tests

- `test_capture_accepts_nonempty_question_field`: posts a non-empty `question` via `TestClient`; fails with 413 under the old `client_max_size=0` on aiohttp 3.14, passes now.
- `test_capture_tolerates_non_utf8_question`: posts raw non-UTF-8 `question` bytes; 500 without the decode change, 200 now.

Both verified against aiohttp 3.14.1 (which reproduces the 413) and on real hardware (two Stack-chan devices; the camera `see` path went from "Failed to upload photo" to returning the image).