### PR TITLE
release: cut gateway v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-03
+
 ### Gateway
 
 - Auto-render the idle avatar after a new ESP32 device session finishes
@@ -1753,7 +1755,8 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.12.0...v0.13.0
 [firmware-v1.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.12.0...firmware-v1.13.0
 [0.12.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.11.0...v0.12.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.13.0"
+version = "0.14.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Promote the accumulated `[Unreleased]` Gateway entries to **v0.14.0** (gateway-only release; the `[Unreleased]` Firmware section is empty, so no firmware release this round).

Included changes:

- Auto-render the idle avatar after device session init (#77 / #324)
- Drain `_avatar_set_waiters` on disconnect (#228 / #325)
- Ownership lock scoped per WS port (#320)
- `/capture` 413 fix on aiohttp >= 3.14 + non-UTF-8 `question` tolerance (#326)

## Release commit (3-file set)

- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.14.0] - 2026-07-03`, comparison links updated
- `gateway/pyproject.toml`: version 0.13.0 → 0.14.0
- `gateway/uv.lock`: regenerated via `uv lock`

## Post-merge steps

1. Tag `v0.14.0` pointing at the merge commit → Trusted Publishing auto-publishes to PyPI
2. Verify the PyPI version, then create the GitHub Release with the promoted notes

## Validation

Codex review skipped per the mechanical-diff exception: release-promotion changes only (CHANGELOG heading/link updates, version bump, regenerated lockfile), no logic changes, no personal-config risk; the full test suite runs in CI on this PR.
