### PR TITLE
fix(firmware/ws): arm audio session in place when the transport is already connected (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ documented-only.
 
 ## [Unreleased]
 
+### Firmware
+
+- Fixed server-driven listen activation on an already connected WebSocket to arm
+  the logical audio session in place instead of rebuilding the transport, so the
+  gateway capture window remains bound to the live connection. (#328)
+
 ## [0.14.0] - 2026-07-03
 
 ### Gateway

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -213,19 +213,23 @@ bool WebsocketProtocol::OpenAudioChannel() {
         websocket_ != nullptr &&
         websocket_->IsConnected() &&
         !error_occurred_ &&
-        !IsTimeout() &&
         !session_id_.empty();
     if (existing_transport_ready) {
         // Issue #328: PR #136 and PR #192 made the audio session a logical
         // state that can be closed while the WebSocket transport stays open.
         // Server-driven listen.start, touch, and wake-word activations from
         // that idle state should therefore arm the session on the current
-        // socket instead of rebuilding a healthy transport. The transport
-        // predicate mirrors IsAudioChannelOpened() without the logical flag,
-        // and a non-empty session_id_ is the ParseServerHello-acked signal.
+        // socket instead of rebuilding a healthy transport. Do not gate this
+        // transport predicate on Protocol::IsTimeout(): that tracks the
+        // audio-session inbound-frame deadline, while an idle persistent MCP
+        // socket can have no inbound frames for minutes and still be healthy.
+        // Refresh last_incoming_time_ when arming so IsAudioChannelOpened()
+        // starts its session deadline from this open, matching MQTT.
+        // A non-empty session_id_ is the ParseServerHello-acked signal.
         // session_id_ is read here on the main task following the existing
         // session-id gate pattern; broader cross-task hardening is out of
         // scope for this fix.
+        last_incoming_time_ = std::chrono::steady_clock::now();
         if (!audio_channel_open_.exchange(true) && on_audio_channel_opened_ != nullptr) {
             on_audio_channel_opened_();
         }

--- a/firmware/main/protocols/websocket_protocol.cc
+++ b/firmware/main/protocols/websocket_protocol.cc
@@ -209,6 +209,29 @@ void WebsocketProtocol::CloseAudioChannel(bool send_goodbye) {
 }
 
 bool WebsocketProtocol::OpenAudioChannel() {
+    const bool existing_transport_ready = transport_connected_.load() &&
+        websocket_ != nullptr &&
+        websocket_->IsConnected() &&
+        !error_occurred_ &&
+        !IsTimeout() &&
+        !session_id_.empty();
+    if (existing_transport_ready) {
+        // Issue #328: PR #136 and PR #192 made the audio session a logical
+        // state that can be closed while the WebSocket transport stays open.
+        // Server-driven listen.start, touch, and wake-word activations from
+        // that idle state should therefore arm the session on the current
+        // socket instead of rebuilding a healthy transport. The transport
+        // predicate mirrors IsAudioChannelOpened() without the logical flag,
+        // and a non-empty session_id_ is the ParseServerHello-acked signal.
+        // session_id_ is read here on the main task following the existing
+        // session-id gate pattern; broader cross-task hardening is out of
+        // scope for this fix.
+        if (!audio_channel_open_.exchange(true) && on_audio_channel_opened_ != nullptr) {
+            on_audio_channel_opened_();
+        }
+        return true;
+    }
+
     return OpenAudioChannelInternal(true, true);
 }
 


### PR DESCRIPTION
## Summary

Fixes the server-driven `listen()` failure reported in #328: calling the gateway's `listen()` MCP tool while the device sits idle caused the ESP32 to tear down its healthy WebSocket and reconnect, so the gateway's capture window (bound to the old connection) received zero audio frames.

`WebsocketProtocol::OpenAudioChannel()` now arms the logical audio session **in place** when the transport is already connected and the server hello has been acked, instead of unconditionally rebuilding the socket.

## Root cause

Confirmed analysis in #328 (see the issue comment for the full walkthrough):

- PR #136 made `CloseAudioChannel()` keep the WS alive; PR #192 made `audio_channel_open_` a logical-session flag, with the boot-time connect and every reconnect opening the socket via `OpenAudioChannelInternal(false, false)` — i.e. transport up, MCP working, audio session **not** armed.
- `HandleStartListeningEvent()` still followed the upstream assumption that "opening the audio channel" means "establishing the connection": from idle with `IsAudioChannelOpened() == false` it called `OpenAudioChannel()`, whose prologue does `websocket_.reset()` — destroying a healthy socket.
- `say()` (TTS) was unaffected because `SendAudio()` only checks transport connectivity, which is why TTS worked while `listen()` failed 100% of the time.

## Fix

`OpenAudioChannel()` first evaluates an `existing_transport_ready` predicate: `transport_connected_`, `websocket_` non-null, `websocket_->IsConnected()`, `!error_occurred_`, plus `!session_id_.empty()` as the hello-acked signal (PR #192 requires a non-empty `session_id` for a successful hello).

- Predicate true → refresh `last_incoming_time_` (the audio-session deadline clock starts at this open, matching the MQTT transport's `OpenAudioChannel()`), arm `audio_channel_open_` via `exchange(true)`, fire `on_audio_channel_opened_()` only on the false→true transition (keeps the power-save level transition symmetric with `OnAudioChannelClosed`), and return `true` without touching the socket.
- Predicate false (boot, dead socket, error, hello not acked) → unchanged full `OpenAudioChannelInternal(true, true)` path.

The predicate deliberately does **not** consult `Protocol::IsTimeout()`: that tracks the audio-session inbound-frame deadline (120 s since the last inbound message), while an idle persistent MCP socket can sit for minutes with no inbound frames and still be healthy transport — the same reasoning already documented on `IsTransportConnected()`. This was a round-1 internal review finding: gating on `IsTimeout()` would have skipped the fast path in the common "idle a few minutes, then listen/touch/wake" case, reintroducing the teardown this PR removes.

Touch and wake-word activations from the same idle state take the same shortcut, so those no longer rebuild the socket either.

## Behavior

| State when `OpenAudioChannel()` is called | Before | After |
|---|---|---|
| WS connected + hello acked, session not armed (post-boot idle) | socket teardown + rebuild; gateway sees disconnect | in-place arm; socket untouched |
| Session already armed | teardown + rebuild | no-op, returns `true` |
| No transport / dead socket / error / timeout / no hello | full rebuild path | unchanged |

## Verification

- Internal codex review: 2 rounds — round 1 surfaced the `IsTimeout()` gating issue (accepted, fixed in the second commit), round 2 clean.
- Firmware build green via `espressif/idf:v5.5.2` Docker (`release.py stackchan`): `xiaozhi.bin` 3.4 MB, `merged-binary.bin` 9.5 MB.
- `git diff --check` clean; change confined to `firmware/main/protocols/websocket_protocol.cc` + `CHANGELOG.md`.
- Real-device E2E (`listen()` from idle over a live gateway connection, confirming no disconnect and non-zero frame capture) is planned before merge; results will be posted on this PR.

## Out of scope

- #188 (late `OnDisconnected` callback ordering), #220 (`play_popup_on_listening_` leak on open failure), #233 (30 s auto-stop scoping) — adjacent known issues in the same area, tracked separately.
- Gateway-side changes (none needed).
- Threading `mode` through the server-driven listen message (follow-up noted in #91/#93).

Refs #328
