### PR TITLE
release: cut firmware v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ documented-only.
 
 ## [Unreleased]
 
+## [firmware-v1.13.1] - 2026-07-06
+
 ### Firmware
 
 - Fixed server-driven listen activation on an already connected WebSocket to arm
@@ -1761,7 +1763,8 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.1...HEAD
+[firmware-v1.13.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.0...firmware-v1.13.1
 [0.14.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.12.0...v0.13.0
 [firmware-v1.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.12.0...firmware-v1.13.0


### PR DESCRIPTION
## Summary

Promote the `[Unreleased]` Firmware entry to `## [firmware-v1.13.1] - 2026-07-06` ahead of the release tag, per the firmware release workflow's CHANGELOG promotion gate.

Release content: the #328 fix (PR #330) — server-driven `listen()` no longer tears down a healthy WebSocket; the logical audio session is armed in place. Real-device E2E results are recorded on PR #330 (three listen runs, zero disconnects, frames flowing end to end).

Pre-flight (release-flow) summary:

- No open verification / blocker issues for the included change (verification completed and recorded on PR #330).
- No parallel debug sessions on the affected path.
- No new high-priority bugs against the changed module.
- CHANGELOG matches `git log firmware-v1.13.0..main -- firmware/` (single behavioral change).

After merge: tag `firmware-v1.13.1` on the merge commit triggers the firmware release workflow (build + GitHub Release with prebuilt binaries).

Refs #328
