### PR TITLE
feat(firmware/stackchan): show on-screen listening indicator during STT capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ documented-only.
   so emoji+text `say` calls keep the expression visible after lip-sync stops.
   (#296)
 
+### Firmware
+
+- Added a small on-screen listening indicator on the stack-chan LCD while STT
+  capture is active. (#332)
+
 ## [firmware-v1.13.1] - 2026-07-06
 
 ### Firmware

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -539,6 +539,10 @@ private:
     esp_timer_handle_t avatar_init_timer_ = nullptr;
     std::string current_avatar_face_ = "idle";
 
+    // Board-local listening cue shown above the full-screen avatar layer.
+    lv_obj_t* listening_indicator_ = nullptr;
+    std::atomic<bool> listening_indicator_visible_{false};
+
     // Dynamic avatar set loaded via the load_avatar_set MCP tool. Stays
     // unloaded by default — the index-based image lookups then fall back
     // to the static const tables in avatar_images.h (placeholder or local
@@ -2245,6 +2249,94 @@ private:
         vTaskDelay(pdMS_TO_TICKS(50));
     }
 
+    bool EnsureListeningIndicatorObjectLocked() {
+        if (listening_indicator_ != nullptr &&
+            lv_obj_is_valid(listening_indicator_)) {
+            return true;
+        }
+        listening_indicator_ = nullptr;
+
+        lv_obj_t* screen = lv_screen_active();
+        if (screen == nullptr) {
+            return false;
+        }
+
+        listening_indicator_ = lv_obj_create(screen);
+        if (listening_indicator_ == nullptr) {
+            return false;
+        }
+
+        lv_obj_set_size(listening_indicator_, 36, 30);
+        lv_obj_align(listening_indicator_, LV_ALIGN_TOP_RIGHT, -8, 8);
+        lv_obj_clear_flag(listening_indicator_, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_set_style_radius(listening_indicator_, 10, 0);
+        lv_obj_set_style_bg_color(listening_indicator_, lv_color_black(), 0);
+        lv_obj_set_style_bg_opa(listening_indicator_, LV_OPA_70, 0);
+        lv_obj_set_style_border_width(listening_indicator_, 0, 0);
+        lv_obj_set_style_pad_all(listening_indicator_, 0, 0);
+
+        lv_obj_t* icon = lv_label_create(listening_indicator_);
+        if (icon == nullptr) {
+            lv_obj_del(listening_indicator_);
+            listening_indicator_ = nullptr;
+            return false;
+        }
+        lv_label_set_text(icon, LV_SYMBOL_AUDIO);
+        lv_obj_set_style_text_color(icon, lv_color_white(), 0);
+        lv_obj_center(icon);
+
+        lv_obj_add_flag(listening_indicator_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(listening_indicator_);
+        ESP_LOGI(TAG, "Listening indicator created on active screen");
+        return true;
+    }
+
+    void BringListeningIndicatorToFrontLocked() {
+        if (listening_indicator_ == nullptr) {
+            return;
+        }
+        if (!lv_obj_is_valid(listening_indicator_)) {
+            listening_indicator_ = nullptr;
+            listening_indicator_visible_.store(false, std::memory_order_release);
+            return;
+        }
+        lv_obj_move_foreground(listening_indicator_);
+    }
+
+    void SetListeningIndicatorVisibleLocked(bool visible) {
+        if (visible) {
+            if (!EnsureListeningIndicatorObjectLocked()) {
+                listening_indicator_visible_.store(false, std::memory_order_release);
+                return;
+            }
+            lv_obj_clear_flag(listening_indicator_, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_move_foreground(listening_indicator_);
+            listening_indicator_visible_.store(true, std::memory_order_release);
+            return;
+        }
+
+        if (listening_indicator_ != nullptr) {
+            if (lv_obj_is_valid(listening_indicator_)) {
+                lv_obj_add_flag(listening_indicator_, LV_OBJ_FLAG_HIDDEN);
+            } else {
+                listening_indicator_ = nullptr;
+            }
+        }
+        listening_indicator_visible_.store(false, std::memory_order_release);
+    }
+
+    void UpdateListeningIndicatorForState(bool is_listening) {
+        if (display_ == nullptr) {
+            return;
+        }
+        if (listening_indicator_visible_.load(std::memory_order_acquire) ==
+            is_listening) {
+            return;
+        }
+        DisplayLockGuard lock(display_);
+        SetListeningIndicatorVisibleLocked(is_listening);
+    }
+
     void PollTouchpad() {
         static bool was_touched = false;
         static int64_t touch_start_time = 0;
@@ -2264,6 +2356,7 @@ private:
         // 無限持続するのを防ぐ。 StopListening 後は listening_started_ms を 0 に
         // 戻して再発火を抑止 (次に listening 突入したら再セット)。
         bool is_listening = (app.GetDeviceState() == kDeviceStateListening);
+        UpdateListeningIndicatorForState(is_listening);
         if (is_listening && !was_listening) {
             listening_started_ms = now_ms;
             ESP_LOGI(TAG, "Listening entered at %d ms (timeout in %d ms)",
@@ -4138,6 +4231,7 @@ private:
         if (!EnsureAvatarObject()) return false;
         lv_image_set_src(avatar_img_, dsc);
         lv_obj_move_foreground(avatar_img_);
+        BringListeningIndicatorToFrontLocked();
         return true;
     }
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -61,6 +61,8 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 
 #define TAG "StackChanBoard"
 
+LV_FONT_DECLARE(font_awesome_20_4);
+
 class Pmic : public Axp2101 {
 public:
     // Power Init
@@ -2282,6 +2284,7 @@ private:
             return false;
         }
         lv_label_set_text(icon, LV_SYMBOL_AUDIO);
+        lv_obj_set_style_text_font(icon, &font_awesome_20_4, 0);
         lv_obj_set_style_text_color(icon, lv_color_white(), 0);
         lv_obj_center(icon);
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -61,8 +61,6 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 
 #define TAG "StackChanBoard"
 
-LV_FONT_DECLARE(font_awesome_20_4);
-
 class Pmic : public Axp2101 {
 public:
     // Power Init
@@ -543,7 +541,9 @@ private:
 
     // Board-local listening cue shown above the full-screen avatar layer.
     lv_obj_t* listening_indicator_ = nullptr;
+    lv_obj_t* listening_indicator_dot_ = nullptr;
     std::atomic<bool> listening_indicator_visible_{false};
+    static constexpr int LISTENING_INDICATOR_DOT_SIZE_PX = 14;
 
     // Dynamic avatar set loaded via the load_avatar_set MCP tool. Stays
     // unloaded by default — the index-based image lookups then fall back
@@ -2252,11 +2252,20 @@ private:
     }
 
     bool EnsureListeningIndicatorObjectLocked() {
-        if (listening_indicator_ != nullptr &&
-            lv_obj_is_valid(listening_indicator_)) {
-            return true;
+        if (listening_indicator_ != nullptr) {
+            if (lv_obj_is_valid(listening_indicator_)) {
+                if (listening_indicator_dot_ != nullptr &&
+                    lv_obj_is_valid(listening_indicator_dot_)) {
+                    return true;
+                }
+                StopListeningIndicatorPulseLocked();
+                lv_obj_del(listening_indicator_);
+            } else {
+                StopListeningIndicatorPulseLocked();
+            }
         }
         listening_indicator_ = nullptr;
+        listening_indicator_dot_ = nullptr;
 
         lv_obj_t* screen = lv_screen_active();
         if (screen == nullptr) {
@@ -2277,16 +2286,25 @@ private:
         lv_obj_set_style_border_width(listening_indicator_, 0, 0);
         lv_obj_set_style_pad_all(listening_indicator_, 0, 0);
 
-        lv_obj_t* icon = lv_label_create(listening_indicator_);
-        if (icon == nullptr) {
+        listening_indicator_dot_ = lv_obj_create(listening_indicator_);
+        if (listening_indicator_dot_ == nullptr) {
             lv_obj_del(listening_indicator_);
             listening_indicator_ = nullptr;
+            listening_indicator_dot_ = nullptr;
             return false;
         }
-        lv_label_set_text(icon, LV_SYMBOL_AUDIO);
-        lv_obj_set_style_text_font(icon, &font_awesome_20_4, 0);
-        lv_obj_set_style_text_color(icon, lv_color_white(), 0);
-        lv_obj_center(icon);
+        lv_obj_set_size(listening_indicator_dot_,
+                        LISTENING_INDICATOR_DOT_SIZE_PX,
+                        LISTENING_INDICATOR_DOT_SIZE_PX);
+        lv_obj_clear_flag(listening_indicator_dot_, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_set_style_radius(listening_indicator_dot_, LV_RADIUS_CIRCLE, 0);
+        lv_obj_set_style_bg_color(listening_indicator_dot_,
+                                  lv_color_hex(0xE0352B), 0);
+        lv_obj_set_style_bg_opa(listening_indicator_dot_, LV_OPA_COVER, 0);
+        lv_obj_set_style_opa(listening_indicator_dot_, LV_OPA_COVER, 0);
+        lv_obj_set_style_border_width(listening_indicator_dot_, 0, 0);
+        lv_obj_set_style_pad_all(listening_indicator_dot_, 0, 0);
+        lv_obj_center(listening_indicator_dot_);
 
         lv_obj_add_flag(listening_indicator_, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(listening_indicator_);
@@ -2294,12 +2312,52 @@ private:
         return true;
     }
 
+    static void SetListeningDotOpacity(void* obj, int32_t opa) {
+        auto* dot = static_cast<lv_obj_t*>(obj);
+        if (dot == nullptr || !lv_obj_is_valid(dot)) {
+            return;
+        }
+        lv_obj_set_style_opa(dot, static_cast<lv_opa_t>(opa), 0);
+    }
+
+    void StopListeningIndicatorPulseLocked() {
+        if (listening_indicator_dot_ == nullptr) {
+            return;
+        }
+        lv_anim_delete(listening_indicator_dot_, nullptr);
+        if (lv_obj_is_valid(listening_indicator_dot_)) {
+            lv_obj_set_style_opa(listening_indicator_dot_, LV_OPA_COVER, 0);
+        }
+    }
+
+    void StartListeningIndicatorPulseLocked() {
+        if (listening_indicator_dot_ == nullptr ||
+            !lv_obj_is_valid(listening_indicator_dot_)) {
+            return;
+        }
+
+        StopListeningIndicatorPulseLocked();
+
+        lv_anim_t anim;
+        lv_anim_init(&anim);
+        lv_anim_set_var(&anim, listening_indicator_dot_);
+        lv_anim_set_values(&anim, LV_OPA_COVER, LV_OPA_40);
+        lv_anim_set_exec_cb(&anim, SetListeningDotOpacity);
+        lv_anim_set_duration(&anim, 700);
+        lv_anim_set_reverse_duration(&anim, 700);
+        lv_anim_set_path_cb(&anim, lv_anim_path_ease_in_out);
+        lv_anim_set_repeat_count(&anim, LV_ANIM_REPEAT_INFINITE);
+        lv_anim_start(&anim);
+    }
+
     void BringListeningIndicatorToFrontLocked() {
         if (listening_indicator_ == nullptr) {
             return;
         }
         if (!lv_obj_is_valid(listening_indicator_)) {
+            StopListeningIndicatorPulseLocked();
             listening_indicator_ = nullptr;
+            listening_indicator_dot_ = nullptr;
             listening_indicator_visible_.store(false, std::memory_order_release);
             return;
         }
@@ -2314,15 +2372,18 @@ private:
             }
             lv_obj_clear_flag(listening_indicator_, LV_OBJ_FLAG_HIDDEN);
             lv_obj_move_foreground(listening_indicator_);
+            StartListeningIndicatorPulseLocked();
             listening_indicator_visible_.store(true, std::memory_order_release);
             return;
         }
 
         if (listening_indicator_ != nullptr) {
+            StopListeningIndicatorPulseLocked();
             if (lv_obj_is_valid(listening_indicator_)) {
                 lv_obj_add_flag(listening_indicator_, LV_OBJ_FLAG_HIDDEN);
             } else {
                 listening_indicator_ = nullptr;
+                listening_indicator_dot_ = nullptr;
             }
         }
         listening_indicator_visible_.store(false, std::memory_order_release);


### PR DESCRIPTION
## Summary

Adds a small on-screen listening indicator to the stack-chan board LCD: a pulsing red recording-style dot on a dark badge, shown in the top-right corner while the device is actively capturing audio (device state == Listening), hidden otherwise. First "listening indicator" child of the #302 LCD UI enrichment umbrella. Real-device feedback during microphone testing flagged that there is no visual cue that the device is capturing audio, which makes voice interaction hard to trust at a glance.

Implementation notes:

- Board-local and additive: all changes live in `firmware/main/boards/stackchan/stackchan.cc`; no shared code touched.
- The indicator is a lazily-created LVGL object (rounded semi-transparent dark badge + a 14 px red dot with a slow opacity pulse via `lv_anim`) parented to the active screen, kept above the avatar overlay. The visual went through two iterations on hardware: the initial `LV_SYMBOL_AUDIO` glyph read as a music note, so it was replaced by the recording-style red dot.
- Show/hide derives from the device state machine, observed from the existing 20 ms `PollTouchpad` periodic path (the same pattern as the 30 s listen auto-stop). Because visibility follows `kDeviceStateListening` directly, every stop path (manual stop, 30 s auto-stop, disconnect) hides the cue without dedicated per-path handling.
- State-change detection is tracked in an atomic flag so the LVGL lock is only taken on transitions, not on every poll tick.
- Robust to the avatar overlay lifecycle: `lv_obj_is_valid` guards against stale objects, creation retries on the next poll if the screen is not ready yet, the indicator re-asserts its z-order after every avatar `setSrc` re-render, and the pulse animation is deleted on every hide/invalidate/re-create path.
- codex review: round 1 flagged the missing icon-font style (P2); rounds 2 and 3 clean.

## Test plan

### Code-level

- [ ] gateway: `uv run pytest` — not applicable (firmware-only change)
- [ ] gateway: `uv run ruff check .` — not applicable (firmware-only change)
- [x] firmware: `python ./scripts/release.py stackchan` — exit 0 on both iterations, artifacts generated

### Hardware

- [x] Device boots without crash — verified across two flash cycles; WebSocket reconnects and gateway re-initialises (35 tools)
- [x] Existing MCP tools still work where affected — `get_status`, `listen` (153 / 163 Opus frames captured), avatar auto-render on reconnect all healthy
- [ ] Existing touch/servo behavior still works where affected — not explicitly re-tested; the change only adds a device-state read + indicator update at the top of the existing 20 ms poll, and the poll path's health is indirectly confirmed by the indicator behaviour itself
- [x] New behavior verified on real hardware — indicator appears promptly when the listen capture window opens, disappears when it closes, and avatar rendering is unaffected (verified on a real CoreS3 for both the glyph and red-dot iterations)

## Breaking changes

None.

## Related issues

Refs #332 (parent umbrella: #302)
