### PR TITLE
feat(gateway/tts): re-dispatch emoji-selected face after speech playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Re-dispatch the emoji-selected avatar face after successful speech playback,
+  so emoji+text `say` calls keep the expression visible after lip-sync stops.
+  (#296)
+
 ## [firmware-v1.13.1] - 2026-07-06
 
 ### Firmware

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -45,6 +45,12 @@ if TYPE_CHECKING:
 #: but well below human-perceptible delay.
 TTS_START_TRANSITION_DELAY_S = 0.05
 
+#: Delay after the ``tts.stop`` notification before reasserting an
+#: emoji-selected face. Firmware handles stop by scheduling the idle /
+#: lip-sync reset on its main task, so this short settle delay lets that
+#: queued restore land before the gateway sends the final face update.
+TTS_STOP_FACE_REDISPATCH_SETTLE_DELAY_S = 0.05
+
 logger = logging.getLogger(__name__)
 
 
@@ -241,15 +247,20 @@ async def synthesize_and_send(
     speaker_name = arguments.get("speaker_name")
     reference_audio = arguments.get("reference_audio")
 
+    plain_tts_text = strip_emoji_for_plain_tts(text)
     tts_text = text
     text_stripped = False
     if not getattr(engine, "supports_emoji_style", False):
-        stripped_text = strip_emoji_for_plain_tts(text)
-        text_stripped = stripped_text != text
-        tts_text = stripped_text
+        text_stripped = plain_tts_text != text
+        tts_text = plain_tts_text
 
     face_dispatched = False
     face_error: str | None = None
+    face_redispatched = False
+    face_redispatch_error: str | None = None
+    should_redispatch_face_after_speech = (
+        face is not None and bool(plain_tts_text.strip())
+    )
 
     if not tts_text.strip():
         if face is not None:
@@ -274,6 +285,8 @@ async def synthesize_and_send(
             "face": face,
             "face_dispatched": face_dispatched,
             "face_error": face_error,
+            "face_redispatched": face_redispatched,
+            "face_redispatch_error": face_redispatch_error,
             "text_stripped": text_stripped,
             "spoke": False,
             "reason": "text empty after emoji strip",
@@ -335,6 +348,16 @@ async def synthesize_and_send(
                 face,
             )
 
+    async def redispatch_face_after_playback() -> None:
+        nonlocal face_redispatched, face_redispatch_error
+        if face is None:
+            return
+        await asyncio.sleep(TTS_STOP_FACE_REDISPATCH_SETTLE_DELAY_S)
+        face_redispatched, face_redispatch_error = await _try_set_avatar_face(
+            gateway,
+            face,
+        )
+
     # Hand the PCM off to the shared encode-and-push path. Engines that
     # have already resampled to DEVICE_SAMPLE_RATE (the documented
     # TTSEngine contract) need no further conversion here.
@@ -344,6 +367,11 @@ async def synthesize_and_send(
         source_label=f"engine:{voice}",
         before_first_frame=(
             dispatch_face_before_first_frame if face is not None else None
+        ),
+        after_playback_complete=(
+            redispatch_face_after_playback
+            if should_redispatch_face_after_speech
+            else None
         ),
     )
 
@@ -366,6 +394,8 @@ async def synthesize_and_send(
         "face": face,
         "face_dispatched": face_dispatched,
         "face_error": face_error,
+        "face_redispatched": face_redispatched,
+        "face_redispatch_error": face_redispatch_error,
         "text_stripped": text_stripped,
         "spoke": True,
     }
@@ -381,6 +411,7 @@ async def send_pcm_audio(
     source_rate: int = DEVICE_SAMPLE_RATE,
     source_label: str = "external",
     before_first_frame: Callable[[], Awaitable[None]] | None = None,
+    after_playback_complete: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Encode mono PCM and push as Opus frames to the connected device.
 
@@ -406,6 +437,9 @@ async def send_pcm_audio(
             synthesis (e.g. ``"voice-tts"``, ``"sfx:notification"``).
         before_first_frame: Internal hook for ``say()`` side effects that
             must be serialized with speech delivery.
+        after_playback_complete: Internal hook for side effects that must
+            run after the stop notification while the TTS lock is still
+            held. Skipped if frame delivery is cancelled or interrupted.
 
     Returns:
         Dict describing the push: ``source``, ``frame_count``,
@@ -517,6 +551,7 @@ async def send_pcm_audio(
         frame_period_s = DEVICE_FRAME_DURATION_MS / 1000.0
         loop = asyncio.get_event_loop()
 
+        playback_complete = False
         try:
             if before_first_frame is not None:
                 await before_first_frame()
@@ -538,6 +573,7 @@ async def send_pcm_audio(
                     break
                 sent += 1
                 next_send_time += frame_period_s
+            playback_complete = push_error is None
         finally:
             try:
                 await gateway.esp32.send_tts_state("stop")
@@ -546,6 +582,13 @@ async def send_pcm_audio(
                 # own when the WebSocket close lands; nothing to do
                 # here.
                 pass
+
+        if (
+            playback_complete
+            and push_error is None
+            and after_playback_complete is not None
+        ):
+            await after_playback_complete()
 
     if push_error is not None:
         raise RuntimeError(

--- a/gateway/stackchan_mcp/tts/orchestrator.py
+++ b/gateway/stackchan_mcp/tts/orchestrator.py
@@ -259,7 +259,7 @@ async def synthesize_and_send(
     face_redispatched = False
     face_redispatch_error: str | None = None
     should_redispatch_face_after_speech = (
-        face is not None and bool(plain_tts_text.strip())
+        face is not None and bool(tts_text.strip())
     )
 
     if not tts_text.strip():

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -378,6 +378,47 @@ async def test_pipeline_keeps_emoji_for_emoji_style_engine(fake_encode):
 
 
 @pytest.mark.asyncio
+async def test_pipeline_emoji_only_emoji_style_engine_redispatches_face(
+    fake_encode,
+):
+    """Emoji-style engines can speak emoji-only text and reassert its face."""
+    text = "😊"
+    engine = _EmojiStylePCMEngine(b"\x01\x00" * 960, name="irodori")
+    esp32 = _FakeESP32(connected=True, record_lock=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": text, "voice": "irodori"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call, avatar_call]
+    assert esp32.events == [
+        ("lock", "acquired"),
+        ("tts_state", "start"),
+        ("tool", avatar_call),
+        ("frame", b"opus_frame_0"),
+        ("tts_state", "stop"),
+        ("tool", avatar_call),
+        ("lock", "released"),
+    ]
+    assert engine.calls[0][0] == text
+    assert result["face"] == "happy"
+    assert result["face_dispatched"] is True
+    assert result["face_error"] is None
+    assert result["face_redispatched"] is True
+    assert result["face_redispatch_error"] is None
+    assert result["text_stripped"] is False
+    assert result["spoke"] is True
+    assert "tts_text" not in result
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("protocol_version", [1, 2, 3])
 async def test_pipeline_emoji_only_plain_engine_skips_speech_before_protocol_gate(
     fake_encode, protocol_version

--- a/gateway/tests/test_orchestrator.py
+++ b/gateway/tests/test_orchestrator.py
@@ -133,6 +133,11 @@ def fake_encode(monkeypatch):
     import stackchan_mcp.tts.orchestrator as orchestrator
 
     monkeypatch.setattr(orchestrator, "encode_opus_frames", fake)
+    monkeypatch.setattr(
+        orchestrator,
+        "TTS_STOP_FACE_REDISPATCH_SETTLE_DELAY_S",
+        0,
+    )
     return fake
 
 
@@ -221,6 +226,8 @@ async def test_pipeline_no_emoji_keeps_text_and_skips_face_dispatch(fake_encode)
     assert result["face"] is None
     assert result["face_dispatched"] is False
     assert result["face_error"] is None
+    assert result["face_redispatched"] is False
+    assert result["face_redispatch_error"] is None
     assert result["text_stripped"] is False
     assert result["spoke"] is True
     assert "tts_text" not in result
@@ -244,22 +251,103 @@ async def test_pipeline_dispatches_face_and_strips_plain_engine_text(fake_encode
     )
 
     avatar_call = ("self.display.set_avatar", {"face": "happy"})
-    assert esp32.tool_calls == [avatar_call]
+    assert esp32.tool_calls == [avatar_call, avatar_call]
     assert esp32.events == [
         ("lock", "acquired"),
         ("tts_state", "start"),
         ("tool", avatar_call),
         ("frame", b"opus_frame_0"),
         ("tts_state", "stop"),
+        ("tool", avatar_call),
         ("lock", "released"),
     ]
     assert engine.calls[0][0] == "やったね rocket"
     assert result["face"] == "happy"
     assert result["face_dispatched"] is True
     assert result["face_error"] is None
+    assert result["face_redispatched"] is True
+    assert result["face_redispatch_error"] is None
     assert result["text_stripped"] is True
     assert result["tts_text"] == "やったね rocket"
     assert result["spoke"] is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_redispatches_face_after_speech_completion(fake_encode):
+    """Emoji-selected faces are reasserted after the TTS stop notification."""
+    pcm = b"\x01\x00" * 1440
+    engine = _PCMEngine(pcm)
+    esp32 = _FakeESP32(connected=True, record_lock=True)
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    result = await synthesize_and_send(
+        {"text": "great 😊", "voice": "voicevox"},
+        gateway=gateway,
+        registry=reg,
+    )
+
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call, avatar_call]
+    assert esp32.events == [
+        ("lock", "acquired"),
+        ("tts_state", "start"),
+        ("tool", avatar_call),
+        ("frame", b"opus_frame_0"),
+        ("frame", b"opus_frame_1"),
+        ("tts_state", "stop"),
+        ("tool", avatar_call),
+        ("lock", "released"),
+    ]
+    assert result["face_dispatched"] is True
+    assert result["face_error"] is None
+    assert result["face_redispatched"] is True
+    assert result["face_redispatch_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_face_redispatch_when_cancelled_mid_playback(
+    fake_encode,
+):
+    """Cancelled speech sends stop but does not reassert the emoji face."""
+
+    class BlockingESP32(_FakeESP32):
+        def __init__(self) -> None:
+            super().__init__(connected=True)
+            self.first_frame_sent = asyncio.Event()
+            self.release_frame = asyncio.Event()
+
+        async def send_audio_frame(self, frame: bytes) -> None:
+            await super().send_audio_frame(frame)
+            self.first_frame_sent.set()
+            await self.release_frame.wait()
+
+    pcm = b"\x01\x00" * 1440
+    engine = _PCMEngine(pcm)
+    esp32 = BlockingESP32()
+    gateway = _FakeGateway(esp32)
+
+    reg = EngineRegistry()
+    reg.register(engine)
+
+    task = asyncio.create_task(
+        synthesize_and_send(
+            {"text": "wait 😊", "voice": "voicevox"},
+            gateway=gateway,
+            registry=reg,
+        )
+    )
+    await asyncio.wait_for(esp32.first_frame_sent.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call]
+    assert esp32.tts_states == ["start", "stop"]
 
 
 @pytest.mark.asyncio
@@ -279,9 +367,12 @@ async def test_pipeline_keeps_emoji_for_emoji_style_engine(fake_encode):
         registry=reg,
     )
 
-    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call, avatar_call]
     assert engine.calls[0][0] == text
     assert result["face"] == "happy"
+    assert result["face_redispatched"] is True
+    assert result["face_redispatch_error"] is None
     assert result["text_stripped"] is False
     assert "tts_text" not in result
 
@@ -322,6 +413,8 @@ async def test_pipeline_emoji_only_plain_engine_skips_speech_before_protocol_gat
     assert result["duration_ms"] == 0
     assert result["face"] == "happy"
     assert result["face_dispatched"] is True
+    assert result["face_redispatched"] is False
+    assert result["face_redispatch_error"] is None
     assert result["text_stripped"] is True
     assert result["tts_text"] == ""
     assert result["spoke"] is False
@@ -344,13 +437,16 @@ async def test_pipeline_face_dispatch_failure_does_not_abort_speech(fake_encode)
         registry=reg,
     )
 
-    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call, avatar_call]
     assert engine.calls[0][0] == "hello"
     assert esp32.tts_states == ["start", "stop"]
     assert esp32.frames == [b"opus_frame_0"]
     assert result["face"] == "happy"
     assert result["face_dispatched"] is False
     assert result["face_error"] == "display offline"
+    assert result["face_redispatched"] is False
+    assert result["face_redispatch_error"] == "display offline"
     assert result["spoke"] is True
 
 
@@ -382,13 +478,16 @@ async def test_pipeline_face_payload_ok_false_reports_failure(
         registry=reg,
     )
 
-    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call, avatar_call]
     assert engine.calls[0][0] == "hello"
     assert esp32.tts_states == ["start", "stop"]
     assert esp32.frames == [b"opus_frame_0"]
     assert result["face"] == "happy"
     assert result["face_dispatched"] is False
     assert result["face_error"] == expected_error
+    assert result["face_redispatched"] is False
+    assert result["face_redispatch_error"] == expected_error
     assert result["spoke"] is True
 
 
@@ -420,10 +519,13 @@ async def test_pipeline_face_odd_result_payloads_still_count_as_success(
         registry=reg,
     )
 
-    assert esp32.tool_calls == [("self.display.set_avatar", {"face": "happy"})]
+    avatar_call = ("self.display.set_avatar", {"face": "happy"})
+    assert esp32.tool_calls == [avatar_call, avatar_call]
     assert result["face"] == "happy"
     assert result["face_dispatched"] is True
     assert result["face_error"] is None
+    assert result["face_redispatched"] is True
+    assert result["face_redispatch_error"] is None
     assert result["spoke"] is True
 
 
@@ -488,8 +590,9 @@ async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
     """Concurrent ``say()`` invocations keep face dispatch with their speech.
 
     The TTS lock covers the start notification, emoji-driven avatar update,
-    audio frames, and stop notification. A later emoji face change must not
-    land between an earlier utterance's start and first frame.
+    audio frames, stop notification, and post-stop face re-dispatch. A later
+    emoji face change must not land inside an earlier utterance's playback
+    window.
     """
     pcm = b"\x01\x00" * 1440  # 1.5 -> 2 frames of audio
     engine_a = _PCMEngine(pcm, name="engine_a")
@@ -526,7 +629,7 @@ async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
 
     assert len(start_indices) == 2
     assert len(stop_indices) == 2
-    assert len(tool_indices) == 2
+    assert len(tool_indices) == 4
     assert len(frame_indices) == 4
 
     assert (
@@ -535,11 +638,13 @@ async def test_pipeline_serialises_concurrent_say_calls(fake_encode):
         < frame_indices[0]
         < frame_indices[1]
         < stop_indices[0]
-        < start_indices[1]
         < tool_indices[1]
+        < start_indices[1]
+        < tool_indices[2]
         < frame_indices[2]
         < frame_indices[3]
         < stop_indices[1]
+        < tool_indices[3]
     )
 
 


### PR DESCRIPTION
## Summary

Implements the short-term proposal from #296: after speech playback completes, the gateway re-dispatches the emoji-selected avatar face, so an emoji+text `say` call keeps its expression visible after lip-sync ends instead of falling back to the idle face.

Implementation notes:

- `send_pcm_audio` gains an optional `after_playback_complete` hook, symmetric with the existing `before_first_frame` hook, executed after the `tts.stop` notification while the TTS lock is still held (so it cannot interleave with a following `say`).
- The hook only fires when playback ran to completion: mid-playback cancellation or a device disconnect skips the re-dispatch.
- Following the round-1 review note, the re-dispatch decision derives from the actually-spoken `tts_text` (not the emoji-stripped text), so emoji-only input on emoji-style engines — which does synthesize speech — also re-asserts its face after playback.
- A short settle delay (`TTS_STOP_FACE_REDISPATCH_SETTLE_DELAY_S = 0.05`) lets the firmware's own post-stop restore land first so the re-dispatched face wins.
- Re-dispatch reuses the error-tolerant `_try_set_avatar_face` helper; the outcome is surfaced in the `say()` result metadata as `face_redispatched` / `face_redispatch_error` (additive fields).
- Emoji-only calls on plain engines (speech skipped) are unchanged.
- codex review: round 1 flagged the re-dispatch decision using the stripped text (P2); fixed in the second commit. Round 2 clean.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` — 622 passed, 5 skipped
- [x] gateway: `uv run ruff check .` — clean
- [ ] firmware: `python ./scripts/release.py stackchan` — not applicable (gateway-only change)

### Hardware

- [ ] Device boots without crash — not applicable (no firmware change)
- [ ] Existing MCP tools still work where affected — pending: `say` with emoji+text on a real device
- [ ] Existing touch/servo behavior still works where affected — not applicable
- [ ] New behavior verified on real hardware — pending: expression visibly restored after speech ends on a real CoreS3; will be reported on the issue.

## Breaking changes

None. The two new `say()` result metadata fields are additive.

## Related issues

Refs #296 (short-term path; the long-term asset-matrix work remains tracked on the issue)
