### PR TITLE
release: cut pair release firmware-v1.14.0 + v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-09
+
 ### Gateway
 
 - Re-dispatch the emoji-selected avatar face after successful speech playback,
   so emoji+text `say` calls keep the expression visible after lip-sync stops.
   (#296)
+
+## [firmware-v1.14.0] - 2026-07-09
 
 ### Firmware
 
@@ -1774,7 +1778,9 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.1...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.14.0...v0.15.0
+[firmware-v1.14.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.1...firmware-v1.14.0
 [firmware-v1.13.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.0...firmware-v1.13.1
 [0.14.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.12.0...v0.13.0

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.14.0"
+version = "0.15.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Cut the pair release **firmware-v1.14.0 + gateway v0.15.0**.

- Promote CHANGELOG `[Unreleased]` entries:
  - Gateway → `[0.15.0] - 2026-07-09` (#296 emoji face re-dispatch, PR #334)
  - Firmware → `[firmware-v1.14.0] - 2026-07-09` (#332 listening indicator, PR #333)
- Bump gateway version 0.14.0 → 0.15.0 (`gateway/pyproject.toml`, `gateway/uv.lock`
  regenerated via `uv lock` — version bump only, no dependency drift)
- Update CHANGELOG comparison links

## Release plan (after merge)

1. Tag `firmware-v1.14.0` on the merge commit → firmware-release workflow builds and
   attaches the prebuilt binaries
2. Tag `v0.15.0` → Trusted Publishing to PyPI, then create the GitHub Release with
   notes extracted from the CHANGELOG

## Validation

- Release pre-flight checks passed:
  - No open verify/blocker issues for #332 / #296 (both closed with on-device
    verification noted)
  - CHANGELOG `[Unreleased]` matches `git log v0.14.0..main -- gateway/` and
    `git log firmware-v1.13.1..main -- firmware/` exactly (one behavioral commit each)
  - Release-commit file set mirrors the PR #329 / #323 / #308 precedent
    (CHANGELOG.md + gateway/pyproject.toml + gateway/uv.lock)
- CHANGELOG promotion structure mirrors the previous pair release (PR #323)
