### PR TITLE
Add StackChan sensor readings and NFC scans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           test -f firmware/build/merged-binary.bin
+          test -f firmware/build/xiaozhi.bin
           test -f firmware/releases/v2.2.6_stackchan.zip
 
       - name: Upload firmware artifacts
@@ -46,6 +47,7 @@ jobs:
           retention-days: 7
           path: |
             firmware/build/merged-binary.bin
+            firmware/build/xiaozhi.bin
             firmware/releases/v2.2.6_stackchan.zip
 
   firmware-host-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,18 @@ documented-only.
 - Added `read_imu`, a parameterless MCP wrapper for one on-board BMI270 +
   BMM150 9-axis snapshot with physical units, raw samples, and data-ready
   metadata.
+- Added `read_environment`, a parameterless MCP wrapper for one on-board
+  LTR-553ALS-WA ambient-light/proximity snapshot with ADC counts and status
+  flags.
 
 ### Firmware
 
 - Added the read-only `self.imu.read` tool for the StackChan board. It reads
   the internal BMI270 accelerometer/gyroscope and the BMM150 connected through
   BMI270 AUX without exposing the safety-critical internal I2C bus.
+- Added the read-only `self.environment.read` tool for the StackChan board. It
+  reads LTR-553ALS-WA ambient-light and proximity ADC values without exposing
+  the safety-critical internal I2C bus.
 
 ## [0.17.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ documented-only.
 - Added `read_environment`, a parameterless MCP wrapper for one on-board
   LTR-553ALS-WA ambient-light/proximity snapshot with ADC counts and status
   flags.
+- Added `scan_nfc`, a parameterless MCP wrapper for a single ISO 14443A NFC
+  tag UID scan using StackChan's body-mounted ST25R3916 reader. It performs no
+  tag memory read/write, authentication, or emulation.
 
 ### Firmware
 
@@ -47,6 +50,9 @@ documented-only.
 - Added the read-only `self.environment.read` tool for the StackChan board. It
   reads LTR-553ALS-WA ambient-light and proximity ADC values without exposing
   the safety-critical internal I2C bus.
+- Added the `self.nfc.scan` tool for the StackChan board. It turns on the
+  ST25R3916 RF field only during a single ISO 14443A UID scan, then turns it
+  off without reading or writing tag memory.
 
 ## [0.17.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,9 @@ documented-only.
 - Added `read_environment`, a parameterless MCP wrapper for one on-board
   LTR-553ALS-WA ambient-light/proximity snapshot with ADC counts and status
   flags.
-- Added `scan_nfc`, a parameterless MCP wrapper for a single ISO 14443A NFC
-  tag UID scan using StackChan's body-mounted ST25R3916 reader. It performs no
-  tag memory read/write, authentication, or emulation.
+- Added `scan_nfc`, a parameterless MCP wrapper for a single ISO 14443A UID
+  or NFC-F (FeliCa) IDm/PMm scan using StackChan's body-mounted ST25R3916
+  reader. It performs no tag memory read/write, authentication, or emulation.
 
 ### Firmware
 
@@ -51,8 +51,8 @@ documented-only.
   reads LTR-553ALS-WA ambient-light and proximity ADC values without exposing
   the safety-critical internal I2C bus.
 - Added the `self.nfc.scan` tool for the StackChan board. It turns on the
-  ST25R3916 RF field only during a single ISO 14443A UID scan, then turns it
-  off without reading or writing tag memory.
+  ST25R3916 RF field only during a single ISO 14443A UID or NFC-F IDm/PMm
+  scan, then turns it off without reading or writing tag memory.
 
 ## [0.17.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Added `read_imu`, a parameterless MCP wrapper for one on-board BMI270 +
+  BMM150 9-axis snapshot with physical units, raw samples, and data-ready
+  metadata.
+
+### Firmware
+
+- Added the read-only `self.imu.read` tool for the StackChan board. It reads
+  the internal BMI270 accelerometer/gyroscope and the BMM150 connected through
+  BMI270 AUX without exposing the safety-critical internal I2C bus.
+
 ## [0.17.0] - 2026-07-12
 
 ### Gateway

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,6 +54,7 @@
 | `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ)。`pitch` は M5Stack 推奨運用レンジ `5..85` に制限される。ファームウェア側のハードクランプ (`0..88`) を使いたい場合は、firmware-side の `set_head_angles` デバイスツールを利用する | ✅ |
 | `read_imu` | 内蔵 BMI270 + BMM150 の 9 軸スナップショットを 1 回取得（加速度 g、角速度 degree/s、磁場 µT、raw 値、data-ready）。磁気センサは近くのサーボ磁石の影響を受ける | ✅ |
 | `read_environment` | 内蔵 LTR-553ALS-WA のスナップショットを 1 回取得（可視+IR / IR の環境光 ADC count、近接 ADC count、data-ready / valid / saturation） | ✅ |
+| `scan_nfc` | 胴体側 ST25R3916 で ISO 14443A タグを 1 回スキャン。UID / ATQA / SAK のみを返し、タグ内容の読書き・認証・エミュレーションは行わない | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
 | `get_touch_sensor_enabled` | 頭部タッチ検出が有効かどうかを取得。NVS に保存され、再起動後も維持される | ✅ |
 | `set_touch_sensor_enabled(enabled)` | 頭部タッチ検出を有効/無効化。無効時は firmware 側のローカル動作反応と MCP `stackchan/event` 送信の両方を止め、設定は再起動後も維持される | ✅ |

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,7 +54,7 @@
 | `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ)。`pitch` は M5Stack 推奨運用レンジ `5..85` に制限される。ファームウェア側のハードクランプ (`0..88`) を使いたい場合は、firmware-side の `set_head_angles` デバイスツールを利用する | ✅ |
 | `read_imu` | 内蔵 BMI270 + BMM150 の 9 軸スナップショットを 1 回取得（加速度 g、角速度 degree/s、磁場 µT、raw 値、data-ready）。磁気センサは近くのサーボ磁石の影響を受ける | ✅ |
 | `read_environment` | 内蔵 LTR-553ALS-WA のスナップショットを 1 回取得（可視+IR / IR の環境光 ADC count、近接 ADC count、data-ready / valid / saturation） | ✅ |
-| `scan_nfc` | 胴体側 ST25R3916 で ISO 14443A タグを 1 回スキャン。UID / ATQA / SAK のみを返し、タグ内容の読書き・認証・エミュレーションは行わない | ✅ |
+| `scan_nfc` | 胴体側 ST25R3916 で ISO 14443A または NFC-F（FeliCa）タグを 1 回スキャン。ISO 14443A は UID / ATQA / SAK、NFC-F は IDm / PMm を返し、タグ内容の読書き・認証・エミュレーションは行わない | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
 | `get_touch_sensor_enabled` | 頭部タッチ検出が有効かどうかを取得。NVS に保存され、再起動後も維持される | ✅ |
 | `set_touch_sensor_enabled(enabled)` | 頭部タッチ検出を有効/無効化。無効時は firmware 側のローカル動作反応と MCP `stackchan/event` 送信の両方を止め、設定は再起動後も維持される | ✅ |

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,6 +52,7 @@
 | `set_volume(volume)` | スピーカー音量 (0-100) | ✅ |
 | `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ)。`pitch` は M5Stack 推奨運用レンジ `5..85` に制限される。ファームウェア側のハードクランプ (`0..88`) を使いたい場合は、firmware-side の `set_head_angles` デバイスツールを利用する | ✅ |
+| `read_imu` | 内蔵 BMI270 + BMM150 の 9 軸スナップショットを 1 回取得（加速度 g、角速度 degree/s、磁場 µT、raw 値、data-ready）。磁気センサは近くのサーボ磁石の影響を受ける | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
 | `get_touch_sensor_enabled` | 頭部タッチ検出が有効かどうかを取得。NVS に保存され、再起動後も維持される | ✅ |
 | `set_touch_sensor_enabled(enabled)` | 頭部タッチ検出を有効/無効化。無効時は firmware 側のローカル動作反応と MCP `stackchan/event` 送信の両方を止め、設定は再起動後も維持される | ✅ |

--- a/README.ja.md
+++ b/README.ja.md
@@ -53,6 +53,7 @@
 | `set_brightness(brightness)` | 画面明るさ (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | 首を動かす (サーボ)。`pitch` は M5Stack 推奨運用レンジ `5..85` に制限される。ファームウェア側のハードクランプ (`0..88`) を使いたい場合は、firmware-side の `set_head_angles` デバイスツールを利用する | ✅ |
 | `read_imu` | 内蔵 BMI270 + BMM150 の 9 軸スナップショットを 1 回取得（加速度 g、角速度 degree/s、磁場 µT、raw 値、data-ready）。磁気センサは近くのサーボ磁石の影響を受ける | ✅ |
+| `read_environment` | 内蔵 LTR-553ALS-WA のスナップショットを 1 回取得（可視+IR / IR の環境光 ADC count、近接 ADC count、data-ready / valid / saturation） | ✅ |
 | `get_touch_state` | タッチセンサ状態 (press/release/stroke 等) | ✅ |
 | `get_touch_sensor_enabled` | 頭部タッチ検出が有効かどうかを取得。NVS に保存され、再起動後も維持される | ✅ |
 | `set_touch_sensor_enabled(enabled)` | 頭部タッチ検出を有効/無効化。無効時は firmware 側のローカル動作反応と MCP `stackchan/event` 送信の両方を止め、設定は再起動後も維持される | ✅ |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository is a monorepo.
 | `move_head(yaw, pitch, speed?)` | Move the neck (servos). `pitch` is constrained to `5..85` — the M5Stack-recommended operating range. For the wider firmware hard clamp (`0..88`), use the firmware-side `set_head_angles` device tool instead. | ✅ |
 | `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot: acceleration in g, angular velocity in degrees per second, magnetic field in microtesla, raw samples, and data-ready flags. Nearby servo magnets can distort the magnetometer. | ✅ |
 | `read_environment` | Read one on-board LTR-553ALS-WA snapshot: visible+IR and IR-only ambient-light ADC counts, proximity ADC count, and data-ready/valid/saturation flags. | ✅ |
+| `scan_nfc` | Scan once for one ISO 14443A tag with the body ST25R3916 reader. Returns UID / ATQA / SAK only; no tag-memory access, authentication, or emulation. | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
 | `get_touch_sensor_enabled` | Read whether head-touch detection is enabled. The NVS-backed setting persists across reboot. | ✅ |
 | `set_touch_sensor_enabled(enabled)` | Enable or disable head-touch detection. Disabling stops both the firmware local motion response and MCP `stackchan/event` emission, and persists across reboot. | ✅ |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repository is a monorepo.
 | `set_volume(volume)` | Speaker volume (0-100) | ✅ |
 | `set_brightness(brightness)` | Screen brightness (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | Move the neck (servos). `pitch` is constrained to `5..85` — the M5Stack-recommended operating range. For the wider firmware hard clamp (`0..88`), use the firmware-side `set_head_angles` device tool instead. | ✅ |
+| `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot: acceleration in g, angular velocity in degrees per second, magnetic field in microtesla, raw samples, and data-ready flags. Nearby servo magnets can distort the magnetometer. | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
 | `get_touch_sensor_enabled` | Read whether head-touch detection is enabled. The NVS-backed setting persists across reboot. | ✅ |
 | `set_touch_sensor_enabled(enabled)` | Enable or disable head-touch detection. Disabling stops both the firmware local motion response and MCP `stackchan/event` emission, and persists across reboot. | ✅ |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repository is a monorepo.
 | `move_head(yaw, pitch, speed?)` | Move the neck (servos). `pitch` is constrained to `5..85` — the M5Stack-recommended operating range. For the wider firmware hard clamp (`0..88`), use the firmware-side `set_head_angles` device tool instead. | ✅ |
 | `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot: acceleration in g, angular velocity in degrees per second, magnetic field in microtesla, raw samples, and data-ready flags. Nearby servo magnets can distort the magnetometer. | ✅ |
 | `read_environment` | Read one on-board LTR-553ALS-WA snapshot: visible+IR and IR-only ambient-light ADC counts, proximity ADC count, and data-ready/valid/saturation flags. | ✅ |
-| `scan_nfc` | Scan once for one ISO 14443A tag with the body ST25R3916 reader. Returns UID / ATQA / SAK only; no tag-memory access, authentication, or emulation. | ✅ |
+| `scan_nfc` | Scan once for one ISO 14443A or NFC-F (FeliCa) tag with the body ST25R3916 reader. Returns UID / ATQA / SAK for ISO 14443A or IDm / PMm for NFC-F; no tag-memory access, authentication, or emulation. | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
 | `get_touch_sensor_enabled` | Read whether head-touch detection is enabled. The NVS-backed setting persists across reboot. | ✅ |
 | `set_touch_sensor_enabled(enabled)` | Enable or disable head-touch detection. Disabling stops both the firmware local motion response and MCP `stackchan/event` emission, and persists across reboot. | ✅ |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repository is a monorepo.
 | `set_brightness(brightness)` | Screen brightness (0-100) | ✅ |
 | `move_head(yaw, pitch, speed?)` | Move the neck (servos). `pitch` is constrained to `5..85` — the M5Stack-recommended operating range. For the wider firmware hard clamp (`0..88`), use the firmware-side `set_head_angles` device tool instead. | ✅ |
 | `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot: acceleration in g, angular velocity in degrees per second, magnetic field in microtesla, raw samples, and data-ready flags. Nearby servo magnets can distort the magnetometer. | ✅ |
+| `read_environment` | Read one on-board LTR-553ALS-WA snapshot: visible+IR and IR-only ambient-light ADC counts, proximity ADC count, and data-ready/valid/saturation flags. | ✅ |
 | `get_touch_state` | Touch sensor state (press / release / stroke / etc.) | ✅ |
 | `get_touch_sensor_enabled` | Read whether head-touch detection is enabled. The NVS-backed setting persists across reboot. | ✅ |
 | `set_touch_sensor_enabled(enabled)` | Enable or disable head-touch detection. Disabling stops both the firmware local motion response and MCP `stackchan/event` emission, and persists across reboot. | ✅ |

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -34,6 +34,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include "avatar_set_fetcher.h"
 #include "stackchan_environment.h"
 #include "stackchan_imu.h"
+#include "stackchan_nfc.h"
 
 #include <smooth_ui_toolkit.hpp>
 #include <esp_log.h>
@@ -539,6 +540,7 @@ private:
     std::unique_ptr<Py32IoExpander> io_expander_;
     std::unique_ptr<StackChanEnvironment> environment_;
     std::unique_ptr<StackChanImu> imu_;
+    std::unique_ptr<StackChanNfc> nfc_;
 
     // Avatar overlay state. avatar_img_ is created lazily on the active LVGL
     // screen because the screen tree (container_, emoji_label_, ...) is built
@@ -2178,6 +2180,15 @@ private:
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "LTR-553 startup initialization failed; self.environment.read will retry: %s",
                      environment_->last_error().c_str());
+        }
+    }
+
+    void InitializeNfc() {
+        nfc_ = std::make_unique<StackChanNfc>(i2c_bus_);
+        esp_err_t err = nfc_->Initialize();
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "ST25R3916 startup initialization failed; self.nfc.scan will retry: %s",
+                     nfc_->last_error().c_str());
         }
     }
 
@@ -5626,6 +5637,74 @@ private:
             });
 
         mcp_server.AddTool(
+            "self.nfc.scan",
+            "Scan once for a single ISO 14443A NFC tag with the body-mounted ST25R3916. "
+            "Returns UID, ATQA, and SAK only; it does not read or write tag memory, authenticate, "
+            "emulate a card, or leave the RF field enabled after the call. If multiple tags collide, "
+            "reports the collision without choosing a tag.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                if (!nfc_) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", "ST25R3916 driver unavailable");
+                    return root;
+                }
+
+                StackChanNfcSnapshot sample;
+                esp_err_t err = nfc_->Scan(&sample);
+                if (err != ESP_OK) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", nfc_->last_error().c_str());
+                    cJSON_AddNumberToObject(root, "error_code", static_cast<int>(err));
+                    ESP_LOGW(TAG, "self.nfc.scan failed: %s", nfc_->last_error().c_str());
+                    return root;
+                }
+
+                cJSON_AddBoolToObject(root, "ok", true);
+                cJSON_AddStringToObject(root, "sensor", "ST25R3916");
+                cJSON_AddNumberToObject(root, "i2c_address", 0x50);
+                cJSON_AddNumberToObject(root, "sample_time_us", sample.sample_time_us);
+                cJSON* reader = cJSON_CreateObject();
+                cJSON_AddNumberToObject(reader, "chip_type", sample.chip_type);
+                cJSON_AddNumberToObject(reader, "chip_revision", sample.chip_revision);
+                cJSON_AddItemToObject(root, "reader", reader);
+
+                cJSON* tag = cJSON_CreateObject();
+                cJSON_AddBoolToObject(tag, "present", sample.tag_present);
+                cJSON_AddBoolToObject(tag, "collision_detected", sample.collision_detected);
+                if (sample.atqa != 0) {
+                    char atqa_hex[7];
+                    std::snprintf(atqa_hex, sizeof(atqa_hex), "0x%04X", sample.atqa);
+                    cJSON_AddStringToObject(tag, "atqa", atqa_hex);
+                } else {
+                    cJSON_AddNullToObject(tag, "atqa");
+                }
+                if (sample.tag_present) {
+                    char uid_hex[sizeof(sample.uid) * 2 + 1] = {};
+                    for (size_t i = 0; i < sample.uid_length; ++i) {
+                        std::snprintf(uid_hex + i * 2, sizeof(uid_hex) - i * 2,
+                                      "%02X", sample.uid[i]);
+                    }
+                    cJSON_AddStringToObject(tag, "uid", uid_hex);
+                    cJSON_AddNumberToObject(tag, "uid_length", sample.uid_length);
+                    cJSON_AddNumberToObject(tag, "sak", sample.sak);
+                } else {
+                    cJSON_AddNullToObject(tag, "uid");
+                    cJSON_AddNullToObject(tag, "uid_length");
+                    cJSON_AddNullToObject(tag, "sak");
+                }
+                cJSON_AddItemToObject(root, "tag", tag);
+
+                // A UID can be a stable personal identifier. Keep it in the
+                // explicit tool response only; logs record no UID bytes.
+                ESP_LOGD(TAG, "self.nfc.scan present=%d collision=%d uid_length=%u",
+                         sample.tag_present ? 1 : 0, sample.collision_detected ? 1 : 0,
+                         static_cast<unsigned>(sample.uid_length));
+                return root;
+            });
+
+        mcp_server.AddTool(
             "self.robot.set_touch_sensor_enabled",
             "Update the NVS-backed head-touch sensor enable flag. Disabling "
             "takes effect immediately and persists across reboot; subsequent "
@@ -7251,6 +7330,7 @@ public:
         I2cDetect();
         InitializeImu();
         InitializeEnvironment();
+        InitializeNfc();
         // Avatar auto-display disabled: WiFi config UI needs to be visible.
         // Avatar is shown on-demand via MCP set_avatar command.
         // InitializeAvatar();

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -68,16 +68,25 @@ class Pmic : public Axp2101 {
 public:
     // Power Init
     Pmic(i2c_master_bus_handle_t i2c_bus, uint8_t addr) : Axp2101(i2c_bus, addr) {
-        uint8_t data = ReadReg(0x90);
-        data |= 0b10110100;
-        WriteReg(0x90, data);
-        WriteReg(0x99, (0b11110 - 5));
-        WriteReg(0x97, (0b11110 - 2));
-        WriteReg(0x69, 0b00110101);
-        WriteReg(0x30, 0b111111);
+        // Match M5Unified's CoreS3/StackChan AXP2101 power setup.  The
+        // previous board-local sequence enabled ALDO3/4 but left ALDO1/2 and
+        // the PMU common/ADC configuration at unrelated values.  That still
+        // let the I2C devices acknowledge, but the BMI270 configuration
+        // engine never reached INTERNAL_STATUS=0x01.
         WriteReg(0x90, 0xBF);
+        WriteReg(0x92, 18 - 5);  // ALDO1: 1.8 V (AW88298)
+        WriteReg(0x93, 33 - 5);  // ALDO2: 3.3 V (ES7210)
         WriteReg(0x94, 33 - 5);
         WriteReg(0x95, 33 - 5);
+        WriteReg(0x27, 0x00);    // Power-key hold timings
+        WriteReg(0x69, 0x11);    // CHGLED setting
+        WriteReg(0x10, 0x30);    // PMU common configuration
+        WriteReg(0x30, 0x0F);    // ADC enabled
+
+        // StackChan's LCD backlight uses these PWM registers in addition to
+        // the common CoreS3 power rails above.
+        WriteReg(0x99, (0b11110 - 5));
+        WriteReg(0x97, (0b11110 - 2));
     }
 
     void SetBrightness(uint8_t brightness) {
@@ -148,7 +157,19 @@ public:
     }
 
     void UpdateTouchPoint() {
-        ReadRegs(0x02, read_buffer_, 6);
+        uint8_t reg = 0x02;
+        esp_err_t err = i2c_master_transmit_receive(i2c_device_, &reg, 1,
+                                                    read_buffer_, 6, 100);
+        if (err != ESP_OK) {
+            // Long internal-bus transactions (notably the BMI270 firmware
+            // upload) can legitimately make a touch sample miss its 100 ms
+            // deadline. Do not abort the whole board from this best-effort
+            // polling task; report no touch for this sample and let the next
+            // tick retry after the I2C driver has recovered.
+            tp_ = TouchPoint_t{};
+            ESP_LOGW(TAG, "FT6336 touch read skipped: %s", esp_err_to_name(err));
+            return;
+        }
         tp_.num = read_buffer_[0] & 0x0F;
         tp_.x = ((read_buffer_[1] & 0x0F) << 8) | read_buffer_[2];
         tp_.y = ((read_buffer_[3] & 0x0F) << 8) | read_buffer_[4];
@@ -7335,27 +7356,23 @@ public:
         InitializePortAI2c();
         InitializeAxp2101();
         InitializeAw9523();
-        // I2cDetect() moved AFTER all I2C device initializations.
-        // The 128-address probe (i2c_master_probe over the whole bus) was
-        // leaving PY32 (0x6F) in a half-finished slave state, so the
-        // following transmit_receive (REG_VERSION via Repeated Start)
-        // timed out (0x103). Doing the scan after IOExpander/Si12T init
-        // preserves the boot-log debug info without poisoning subsequent
-        // register reads. Si12T (0x68) is unaffected on the same bus,
-        // but moving the scan is safer for any future I2C peripheral too.
         InitializeSpi();
         InitializeIli9342Display();
         InitializeCamera();
-        InitializeFt6336TouchPad();
         GetBacklight()->RestoreBrightness();
         InitializeIOExpander();
         InitializeServo();
         InitializeTouchSettings();
-        InitializeSi12tTouch();
-        I2cDetect();
+        // Start the internal-bus sensor setup before the periodic touch tasks.
+        // BMI270's 8 KiB firmware upload occupies the bus long enough for a
+        // concurrent FT6336 poll to hit its 100 ms timeout and abort via the
+        // common I2cDevice helper. The external Port A scan remains available
+        // through the self.i2c.scan tool.
         InitializeImu();
         InitializeEnvironment();
         InitializeNfc();
+        InitializeFt6336TouchPad();
+        InitializeSi12tTouch();
         // Avatar auto-display disabled: WiFi config UI needs to be visible.
         // Avatar is shown on-demand via MCP set_avatar command.
         // InitializeAvatar();

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -167,8 +167,15 @@ public:
             // polling task; report no touch for this sample and let the next
             // tick retry after the I2C driver has recovered.
             tp_ = TouchPoint_t{};
-            ESP_LOGW(TAG, "FT6336 touch read skipped: %s", esp_err_to_name(err));
+            if (!read_failed_) {
+                ESP_LOGW(TAG, "FT6336 touch reads unavailable: %s", esp_err_to_name(err));
+                read_failed_ = true;
+            }
             return;
+        }
+        if (read_failed_) {
+            ESP_LOGI(TAG, "FT6336 touch reads recovered");
+            read_failed_ = false;
         }
         tp_.num = read_buffer_[0] & 0x0F;
         tp_.x = ((read_buffer_[1] & 0x0F) << 8) | read_buffer_[2];
@@ -181,6 +188,7 @@ public:
 
 private:
     uint8_t* read_buffer_ = nullptr;
+    bool read_failed_ = false;
     TouchPoint_t tp_;
 };
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -32,6 +32,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include "avatar_images.h"
 #include "avatar_set.h"
 #include "avatar_set_fetcher.h"
+#include "stackchan_imu.h"
 
 #include <smooth_ui_toolkit.hpp>
 #include <esp_log.h>
@@ -535,6 +536,7 @@ private:
     PowerSaveTimer* power_save_timer_;
     ScsBus scs_bus_;
     std::unique_ptr<Py32IoExpander> io_expander_;
+    std::unique_ptr<StackChanImu> imu_;
 
     // Avatar overlay state. avatar_img_ is created lazily on the active LVGL
     // screen because the screen tree (container_, emoji_label_, ...) is built
@@ -2157,6 +2159,15 @@ private:
             },
         };
         ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_bus_cfg, &i2c_bus_));
+    }
+
+    void InitializeImu() {
+        imu_ = std::make_unique<StackChanImu>(i2c_bus_);
+        esp_err_t err = imu_->Initialize();
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "IMU startup initialization failed; self.imu.read will retry: %s",
+                     imu_->last_error().c_str());
+        }
     }
 
     void InitializePortAI2c() {
@@ -5462,6 +5473,87 @@ private:
             });
 
         mcp_server.AddTool(
+            "self.imu.read",
+            "Read one 9-axis IMU snapshot from the on-board BMI270 accelerometer/gyroscope "
+            "and its BMM150 auxiliary magnetometer. Returns physical units (g, degrees per "
+            "second, microtesla), signed raw samples, data-ready flags, monotonic sample time, "
+            "and magnetometer availability. This dedicated read-only tool does not expose the "
+            "shared internal I2C bus.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                if (!imu_) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", "IMU driver unavailable");
+                    return root;
+                }
+
+                StackChanImuSnapshot sample;
+                esp_err_t err = imu_->Read(&sample);
+                if (err != ESP_OK) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", imu_->last_error().c_str());
+                    cJSON_AddNumberToObject(root, "error_code", static_cast<int>(err));
+                    ESP_LOGW(TAG, "self.imu.read failed: %s", imu_->last_error().c_str());
+                    return root;
+                }
+
+                auto add_float_axis = [](cJSON* parent, const char* key,
+                                         const StackChanImuAxisFloat& axis) {
+                    cJSON* value = cJSON_CreateObject();
+                    cJSON_AddNumberToObject(value, "x", axis.x);
+                    cJSON_AddNumberToObject(value, "y", axis.y);
+                    cJSON_AddNumberToObject(value, "z", axis.z);
+                    cJSON_AddItemToObject(parent, key, value);
+                };
+                auto add_raw_axis = [](cJSON* parent, const char* key,
+                                       const StackChanImuAxisRaw& axis) {
+                    cJSON* value = cJSON_CreateObject();
+                    cJSON_AddNumberToObject(value, "x", axis.x);
+                    cJSON_AddNumberToObject(value, "y", axis.y);
+                    cJSON_AddNumberToObject(value, "z", axis.z);
+                    cJSON_AddItemToObject(parent, key, value);
+                };
+
+                cJSON_AddBoolToObject(root, "ok", true);
+                cJSON_AddStringToObject(root, "sensor", "BMI270+BMM150");
+                cJSON_AddNumberToObject(root, "bmi270_i2c_address", sample.bmi270_i2c_address);
+                cJSON_AddNumberToObject(root, "sample_time_us", sample.sample_time_us);
+                cJSON_AddBoolToObject(root, "mag_available", sample.mag_available);
+                add_float_axis(root, "accel_g", sample.accel_g);
+                add_float_axis(root, "gyro_dps", sample.gyro_dps);
+                if (sample.mag_available) {
+                    add_float_axis(root, "mag_ut", sample.mag_ut);
+                } else {
+                    cJSON_AddNullToObject(root, "mag_ut");
+                }
+
+                cJSON* raw = cJSON_CreateObject();
+                add_raw_axis(raw, "accel", sample.accel_raw);
+                add_raw_axis(raw, "gyro", sample.gyro_raw);
+                if (sample.mag_available) {
+                    add_raw_axis(raw, "mag", sample.mag_raw);
+                } else {
+                    cJSON_AddNullToObject(raw, "mag");
+                }
+                cJSON_AddItemToObject(root, "raw", raw);
+
+                cJSON* ready = cJSON_CreateObject();
+                cJSON_AddBoolToObject(ready, "accel", sample.accel_data_ready);
+                cJSON_AddBoolToObject(ready, "gyro", sample.gyro_data_ready);
+                cJSON_AddBoolToObject(ready, "mag", sample.mag_data_ready);
+                cJSON_AddItemToObject(root, "data_ready", ready);
+
+                ESP_LOGD(TAG,
+                         "self.imu.read accel=(%.3f,%.3f,%.3f)g gyro=(%.2f,%.2f,%.2f)dps "
+                         "mag_available=%d",
+                         sample.accel_g.x, sample.accel_g.y, sample.accel_g.z,
+                         sample.gyro_dps.x, sample.gyro_dps.y, sample.gyro_dps.z,
+                         sample.mag_available ? 1 : 0);
+                return root;
+            });
+
+        mcp_server.AddTool(
             "self.robot.set_touch_sensor_enabled",
             "Update the NVS-backed head-touch sensor enable flag. Disabling "
             "takes effect immediately and persists across reboot; subsequent "
@@ -7085,6 +7177,7 @@ public:
         InitializeTouchSettings();
         InitializeSi12tTouch();
         I2cDetect();
+        InitializeImu();
         // Avatar auto-display disabled: WiFi config UI needs to be visible.
         // Avatar is shown on-demand via MCP set_avatar command.
         // InitializeAvatar();

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -32,6 +32,7 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 #include "avatar_images.h"
 #include "avatar_set.h"
 #include "avatar_set_fetcher.h"
+#include "stackchan_environment.h"
 #include "stackchan_imu.h"
 
 #include <smooth_ui_toolkit.hpp>
@@ -536,6 +537,7 @@ private:
     PowerSaveTimer* power_save_timer_;
     ScsBus scs_bus_;
     std::unique_ptr<Py32IoExpander> io_expander_;
+    std::unique_ptr<StackChanEnvironment> environment_;
     std::unique_ptr<StackChanImu> imu_;
 
     // Avatar overlay state. avatar_img_ is created lazily on the active LVGL
@@ -2167,6 +2169,15 @@ private:
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "IMU startup initialization failed; self.imu.read will retry: %s",
                      imu_->last_error().c_str());
+        }
+    }
+
+    void InitializeEnvironment() {
+        environment_ = std::make_unique<StackChanEnvironment>(i2c_bus_);
+        esp_err_t err = environment_->Initialize();
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "LTR-553 startup initialization failed; self.environment.read will retry: %s",
+                     environment_->last_error().c_str());
         }
     }
 
@@ -5554,6 +5565,67 @@ private:
             });
 
         mcp_server.AddTool(
+            "self.environment.read",
+            "Read one LTR-553ALS-WA ambient-light and proximity snapshot. Returns the two ambient-light "
+            "ADC channels and the proximity ADC value in raw counts, data-ready/valid/saturation flags, "
+            "sensor identity, and a monotonic sample time. This dedicated tool never exposes the shared "
+            "internal I2C bus.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                if (!environment_) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", "LTR-553 driver unavailable");
+                    return root;
+                }
+
+                StackChanEnvironmentSnapshot sample;
+                esp_err_t err = environment_->Read(&sample);
+                if (err != ESP_OK) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", environment_->last_error().c_str());
+                    cJSON_AddNumberToObject(root, "error_code", static_cast<int>(err));
+                    ESP_LOGW(TAG, "self.environment.read failed: %s",
+                             environment_->last_error().c_str());
+                    return root;
+                }
+
+                cJSON_AddBoolToObject(root, "ok", true);
+                cJSON_AddStringToObject(root, "sensor", "LTR-553ALS-WA");
+                cJSON_AddNumberToObject(root, "i2c_address", 0x23);
+                cJSON_AddNumberToObject(root, "part_id", sample.part_id);
+                cJSON_AddNumberToObject(root, "manufacturer_id", sample.manufacturer_id);
+                cJSON_AddNumberToObject(root, "sample_time_us", sample.sample_time_us);
+
+                cJSON* ambient_light = cJSON_CreateObject();
+                cJSON_AddStringToObject(ambient_light, "unit", "adc_counts");
+                cJSON_AddNumberToObject(ambient_light, "channel0_visible_ir",
+                                         sample.ambient_light_channel0);
+                cJSON_AddNumberToObject(ambient_light, "channel1_ir",
+                                         sample.ambient_light_channel1);
+                cJSON_AddBoolToObject(ambient_light, "data_ready",
+                                      sample.ambient_light_data_ready);
+                cJSON_AddBoolToObject(ambient_light, "valid", sample.ambient_light_valid);
+                cJSON_AddItemToObject(root, "ambient_light", ambient_light);
+
+                cJSON* proximity = cJSON_CreateObject();
+                cJSON_AddStringToObject(proximity, "unit", "adc_counts");
+                cJSON_AddNumberToObject(proximity, "raw", sample.proximity);
+                cJSON_AddBoolToObject(proximity, "data_ready", sample.proximity_data_ready);
+                cJSON_AddBoolToObject(proximity, "saturated", sample.proximity_saturated);
+                cJSON_AddItemToObject(root, "proximity", proximity);
+
+                ESP_LOGD(TAG,
+                         "self.environment.read als_ch0=%u als_ch1=%u ps=%u ready=%d/%d valid=%d sat=%d",
+                         sample.ambient_light_channel0, sample.ambient_light_channel1,
+                         sample.proximity, sample.ambient_light_data_ready ? 1 : 0,
+                         sample.proximity_data_ready ? 1 : 0,
+                         sample.ambient_light_valid ? 1 : 0,
+                         sample.proximity_saturated ? 1 : 0);
+                return root;
+            });
+
+        mcp_server.AddTool(
             "self.robot.set_touch_sensor_enabled",
             "Update the NVS-backed head-touch sensor enable flag. Disabling "
             "takes effect immediately and persists across reboot; subsequent "
@@ -7178,6 +7250,7 @@ public:
         InitializeSi12tTouch();
         I2cDetect();
         InitializeImu();
+        InitializeEnvironment();
         // Avatar auto-display disabled: WiFi config UI needs to be visible.
         // Avatar is shown on-demand via MCP set_avatar command.
         // InitializeAvatar();

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -5638,10 +5638,11 @@ private:
 
         mcp_server.AddTool(
             "self.nfc.scan",
-            "Scan once for a single ISO 14443A NFC tag with the body-mounted ST25R3916. "
-            "Returns UID, ATQA, and SAK only; it does not read or write tag memory, authenticate, "
-            "emulate a card, or leave the RF field enabled after the call. If multiple tags collide, "
-            "reports the collision without choosing a tag.",
+            "Scan once for a single ISO 14443A or NFC-F (FeliCa) tag with the body-mounted "
+            "ST25R3916. Returns UID/ATQA/SAK for ISO 14443A or IDm/PMm for NFC-F only; it does "
+            "not read or write tag memory, authenticate, emulate a card, or leave the RF field "
+            "enabled after the call. If multiple ISO 14443A tags collide, reports the collision "
+            "without choosing a tag.",
             PropertyList(),
             [this](const PropertyList&) -> ReturnValue {
                 cJSON* root = cJSON_CreateObject();
@@ -5673,14 +5674,21 @@ private:
                 cJSON* tag = cJSON_CreateObject();
                 cJSON_AddBoolToObject(tag, "present", sample.tag_present);
                 cJSON_AddBoolToObject(tag, "collision_detected", sample.collision_detected);
-                if (sample.atqa != 0) {
+                if (sample.protocol == StackChanNfcProtocol::kIso14443A) {
+                    cJSON_AddStringToObject(tag, "protocol", "ISO14443A");
+                } else if (sample.protocol == StackChanNfcProtocol::kNfcF) {
+                    cJSON_AddStringToObject(tag, "protocol", "NFC-F");
+                } else {
+                    cJSON_AddNullToObject(tag, "protocol");
+                }
+                if (sample.protocol == StackChanNfcProtocol::kIso14443A) {
                     char atqa_hex[7];
                     std::snprintf(atqa_hex, sizeof(atqa_hex), "0x%04X", sample.atqa);
                     cJSON_AddStringToObject(tag, "atqa", atqa_hex);
                 } else {
                     cJSON_AddNullToObject(tag, "atqa");
                 }
-                if (sample.tag_present) {
+                if (sample.protocol == StackChanNfcProtocol::kIso14443A) {
                     char uid_hex[sizeof(sample.uid) * 2 + 1] = {};
                     for (size_t i = 0; i < sample.uid_length; ++i) {
                         std::snprintf(uid_hex + i * 2, sizeof(uid_hex) - i * 2,
@@ -5694,12 +5702,29 @@ private:
                     cJSON_AddNullToObject(tag, "uid_length");
                     cJSON_AddNullToObject(tag, "sak");
                 }
+                if (sample.protocol == StackChanNfcProtocol::kNfcF) {
+                    char idm_hex[sizeof(sample.idm) * 2 + 1] = {};
+                    char pmm_hex[sizeof(sample.pmm) * 2 + 1] = {};
+                    for (size_t i = 0; i < sizeof(sample.idm); ++i) {
+                        std::snprintf(idm_hex + i * 2, sizeof(idm_hex) - i * 2,
+                                      "%02X", sample.idm[i]);
+                        std::snprintf(pmm_hex + i * 2, sizeof(pmm_hex) - i * 2,
+                                      "%02X", sample.pmm[i]);
+                    }
+                    cJSON_AddStringToObject(tag, "idm", idm_hex);
+                    cJSON_AddStringToObject(tag, "pmm", pmm_hex);
+                } else {
+                    cJSON_AddNullToObject(tag, "idm");
+                    cJSON_AddNullToObject(tag, "pmm");
+                }
                 cJSON_AddItemToObject(root, "tag", tag);
 
-                // A UID can be a stable personal identifier. Keep it in the
-                // explicit tool response only; logs record no UID bytes.
-                ESP_LOGD(TAG, "self.nfc.scan present=%d collision=%d uid_length=%u",
+                // A UID or NFC-F IDm can be a stable personal identifier.
+                // Keep it in the explicit tool response only; logs record no
+                // identifier bytes.
+                ESP_LOGD(TAG, "self.nfc.scan present=%d collision=%d protocol=%d uid_length=%u",
                          sample.tag_present ? 1 : 0, sample.collision_detected ? 1 : 0,
+                         static_cast<int>(sample.protocol),
                          static_cast<unsigned>(sample.uid_length));
                 return root;
             });

--- a/firmware/main/boards/stackchan/stackchan_environment.cc
+++ b/firmware/main/boards/stackchan/stackchan_environment.cc
@@ -1,0 +1,202 @@
+/*
+ * SPDX-FileCopyrightText: 2026 StackChan contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "stackchan_environment.h"
+
+#include <cstdio>
+
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <freertos/task.h>
+
+namespace {
+
+constexpr char kTag[] = "StackChanEnvironment";
+constexpr uint8_t kLtr553Address = 0x23;
+constexpr uint8_t kLtr553PartIdMask = 0xF0;
+constexpr uint8_t kLtr553PartId = 0x90;
+
+constexpr uint8_t kRegAlsControl = 0x80;
+constexpr uint8_t kRegPsControl = 0x81;
+constexpr uint8_t kRegPsLed = 0x82;
+constexpr uint8_t kRegPsPulseCount = 0x83;
+constexpr uint8_t kRegPsMeasurementRate = 0x84;
+constexpr uint8_t kRegAlsDataChannel1 = 0x88;
+constexpr uint8_t kRegStatus = 0x8C;
+constexpr uint8_t kRegPsData = 0x8D;
+
+constexpr uint8_t kRegPartId = 0x86;
+constexpr uint8_t kRegManufacturerId = 0x87;
+
+// These are the settings in M5Stack's StackChan LTR553 sample: ALS gain 48x,
+// 40 kHz PS LED pulses, and a 50 ms PS measurement interval. The values are
+// configured before activating either sensing mode, as required by the chip.
+constexpr uint8_t kAlsGain48xActive = 0x19;
+constexpr uint8_t kPsActiveWithSaturationIndicator = 0x23;
+constexpr uint8_t kPsLed40Khz100Percent100mA = 0x3F;
+constexpr uint8_t kPsOnePulse = 0x01;
+constexpr uint8_t kPsMeasurementRate50Ms = 0x00;
+
+constexpr int kI2cTimeoutMs = 100;
+
+uint16_t ReadUint16Le(const uint8_t* data) {
+    return static_cast<uint16_t>(data[0]) |
+           (static_cast<uint16_t>(data[1]) << 8);
+}
+
+}  // namespace
+
+StackChanEnvironment::StackChanEnvironment(i2c_master_bus_handle_t bus) : bus_(bus) {
+    mutex_ = xSemaphoreCreateMutex();
+}
+
+StackChanEnvironment::~StackChanEnvironment() {
+    Detach();
+    if (mutex_ != nullptr) {
+        vSemaphoreDelete(mutex_);
+    }
+}
+
+esp_err_t StackChanEnvironment::Fail(const char* operation, esp_err_t err) {
+    char message[128];
+    std::snprintf(message, sizeof(message), "%s: %s", operation, esp_err_to_name(err));
+    last_error_ = message;
+    ESP_LOGE(kTag, "%s", last_error_.c_str());
+    return err;
+}
+
+void StackChanEnvironment::Detach() {
+    if (ltr553_ != nullptr) {
+        esp_err_t err = i2c_master_bus_rm_device(ltr553_);
+        if (err != ESP_OK) {
+            ESP_LOGW(kTag, "Failed to detach LTR-553: %s", esp_err_to_name(err));
+        }
+        ltr553_ = nullptr;
+    }
+    initialized_ = false;
+    part_id_ = 0;
+    manufacturer_id_ = 0;
+}
+
+esp_err_t StackChanEnvironment::ReadRegisters(uint8_t reg, uint8_t* data, size_t length) {
+    if (ltr553_ == nullptr || data == nullptr || length == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return i2c_master_transmit_receive(ltr553_, &reg, 1, data, length, kI2cTimeoutMs);
+}
+
+esp_err_t StackChanEnvironment::WriteRegister(uint8_t reg, uint8_t value) {
+    if (ltr553_ == nullptr) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    const uint8_t data[] = {reg, value};
+    return i2c_master_transmit(ltr553_, data, sizeof(data), kI2cTimeoutMs);
+}
+
+esp_err_t StackChanEnvironment::InitializeLocked() {
+    Detach();
+
+    i2c_device_config_t config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = kLtr553Address,
+        .scl_speed_hz = 400000,
+        .scl_wait_us = 0,
+        .flags = {
+            .disable_ack_check = false,
+        },
+    };
+    esp_err_t err = i2c_master_bus_add_device(bus_, &config, &ltr553_);
+    if (err != ESP_OK) {
+        return Fail("attach LTR-553", err);
+    }
+
+    uint8_t identity[2] = {};
+    err = ReadRegisters(kRegPartId, identity, sizeof(identity));
+    if (err != ESP_OK) {
+        Detach();
+        return Fail("read LTR-553 identity", err);
+    }
+    if ((identity[0] & kLtr553PartIdMask) != kLtr553PartId) {
+        Detach();
+        return Fail("validate LTR-553 identity", ESP_ERR_NOT_FOUND);
+    }
+    part_id_ = identity[0];
+    manufacturer_id_ = identity[1];
+
+    // Do not issue a reset: another firmware revision may already have tuned
+    // thresholds. This tool owns only the measurement configuration it needs.
+    err = WriteRegister(kRegPsLed, kPsLed40Khz100Percent100mA);
+    if (err == ESP_OK) err = WriteRegister(kRegPsPulseCount, kPsOnePulse);
+    if (err == ESP_OK) err = WriteRegister(kRegPsMeasurementRate, kPsMeasurementRate50Ms);
+    if (err == ESP_OK) err = WriteRegister(kRegAlsControl, kAlsGain48xActive);
+    if (err == ESP_OK) err = WriteRegister(kRegPsControl, kPsActiveWithSaturationIndicator);
+    if (err != ESP_OK) {
+        Detach();
+        return Fail("configure LTR-553", err);
+    }
+
+    // The datasheet specifies a 100 ms initial startup time after activation.
+    vTaskDelay(pdMS_TO_TICKS(100));
+    initialized_ = true;
+    last_error_.clear();
+    ESP_LOGI(kTag, "LTR-553 ready (part_id=0x%02X manufacturer_id=0x%02X)",
+             part_id_, manufacturer_id_);
+    return ESP_OK;
+}
+
+esp_err_t StackChanEnvironment::Initialize() {
+    if (mutex_ == nullptr || bus_ == nullptr) {
+        return Fail("initialize LTR-553", ESP_ERR_INVALID_STATE);
+    }
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return Fail("lock LTR-553", ESP_ERR_TIMEOUT);
+    }
+    esp_err_t err = initialized_ ? ESP_OK : InitializeLocked();
+    xSemaphoreGive(mutex_);
+    return err;
+}
+
+esp_err_t StackChanEnvironment::Read(StackChanEnvironmentSnapshot* snapshot) {
+    if (snapshot == nullptr) {
+        return Fail("read LTR-553", ESP_ERR_INVALID_ARG);
+    }
+    if (mutex_ == nullptr || bus_ == nullptr) {
+        return Fail("read LTR-553", ESP_ERR_INVALID_STATE);
+    }
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return Fail("lock LTR-553", ESP_ERR_TIMEOUT);
+    }
+
+    esp_err_t err = initialized_ ? ESP_OK : InitializeLocked();
+    uint8_t status = 0;
+    uint8_t als_data[4] = {};
+    uint8_t ps_data[2] = {};
+    if (err == ESP_OK) err = ReadRegisters(kRegStatus, &status, 1);
+    // LTR-553 requires the four ALS registers to be read low-to-high as one
+    // group; reading 0x8B latches the next coherent sample.
+    if (err == ESP_OK) err = ReadRegisters(kRegAlsDataChannel1, als_data, sizeof(als_data));
+    if (err == ESP_OK) err = ReadRegisters(kRegPsData, ps_data, sizeof(ps_data));
+    if (err != ESP_OK) {
+        xSemaphoreGive(mutex_);
+        return Fail("read LTR-553 sample", err);
+    }
+
+    snapshot->ambient_light_channel1 = ReadUint16Le(als_data);
+    snapshot->ambient_light_channel0 = ReadUint16Le(als_data + 2);
+    snapshot->proximity = static_cast<uint16_t>(ps_data[0]) |
+                          (static_cast<uint16_t>(ps_data[1] & 0x07) << 8);
+    snapshot->ambient_light_data_ready = (status & 0x04) != 0;
+    snapshot->ambient_light_valid = (status & 0x80) == 0;
+    snapshot->proximity_data_ready = (status & 0x01) != 0;
+    snapshot->proximity_saturated = (ps_data[1] & 0x80) != 0;
+    snapshot->part_id = part_id_;
+    snapshot->manufacturer_id = manufacturer_id_;
+    snapshot->sample_time_us = esp_timer_get_time();
+    last_error_.clear();
+
+    xSemaphoreGive(mutex_);
+    return ESP_OK;
+}

--- a/firmware/main/boards/stackchan/stackchan_environment.h
+++ b/firmware/main/boards/stackchan/stackchan_environment.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 StackChan contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <driver/i2c_master.h>
+#include <esp_err.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+struct StackChanEnvironmentSnapshot {
+    uint16_t ambient_light_channel0 = 0;
+    uint16_t ambient_light_channel1 = 0;
+    uint16_t proximity = 0;
+    bool ambient_light_data_ready = false;
+    bool ambient_light_valid = false;
+    bool proximity_data_ready = false;
+    bool proximity_saturated = false;
+    uint8_t part_id = 0;
+    uint8_t manufacturer_id = 0;
+    int64_t sample_time_us = 0;
+};
+
+// Dedicated LTR-553ALS-WA driver for the CoreS3 system I2C bus. This is
+// intentionally separate from generic self.i2c.* tools so those tools cannot
+// access the CoreS3's power-management or codec devices on the same bus.
+class StackChanEnvironment {
+public:
+    explicit StackChanEnvironment(i2c_master_bus_handle_t bus);
+    ~StackChanEnvironment();
+
+    StackChanEnvironment(const StackChanEnvironment&) = delete;
+    StackChanEnvironment& operator=(const StackChanEnvironment&) = delete;
+
+    esp_err_t Initialize();
+    esp_err_t Read(StackChanEnvironmentSnapshot* snapshot);
+    const std::string& last_error() const { return last_error_; }
+
+private:
+    esp_err_t InitializeLocked();
+    esp_err_t ReadRegisters(uint8_t reg, uint8_t* data, size_t length);
+    esp_err_t WriteRegister(uint8_t reg, uint8_t value);
+    esp_err_t Fail(const char* operation, esp_err_t err);
+    void Detach();
+
+    i2c_master_bus_handle_t bus_ = nullptr;
+    i2c_master_dev_handle_t ltr553_ = nullptr;
+    SemaphoreHandle_t mutex_ = nullptr;
+    bool initialized_ = false;
+    uint8_t part_id_ = 0;
+    uint8_t manufacturer_id_ = 0;
+    std::string last_error_;
+};

--- a/firmware/main/boards/stackchan/stackchan_imu.cc
+++ b/firmware/main/boards/stackchan/stackchan_imu.cc
@@ -6,7 +6,6 @@
 
 #include "stackchan_imu.h"
 
-#include <algorithm>
 #include <cstdio>
 #include <cstring>
 
@@ -48,8 +47,9 @@ constexpr uint8_t kBmm150DataRegister = 0x42;
 constexpr uint8_t kBmm150PowerRegister = 0x4B;
 constexpr uint8_t kBmm150ModeRegister = 0x4C;
 
-constexpr size_t kConfigChunkSize = 32;
+constexpr size_t kMaxRegisterWriteSize = 32;
 constexpr int kI2cTimeoutMs = 100;
+constexpr int kConfigUploadTimeoutMs = 500;
 
 int16_t ReadInt16(const uint8_t* data) {
     return static_cast<int16_t>(static_cast<uint16_t>(data[0]) |
@@ -132,8 +132,8 @@ esp_err_t StackChanImu::WriteRegisters(uint8_t reg, const uint8_t* data, size_t 
     if (bmi270_ == nullptr || data == nullptr || length == 0) {
         return ESP_ERR_INVALID_STATE;
     }
-    uint8_t buffer[kConfigChunkSize + 1];
-    if (length > kConfigChunkSize) {
+    uint8_t buffer[kMaxRegisterWriteSize + 1];
+    if (length > kMaxRegisterWriteSize) {
         return ESP_ERR_INVALID_SIZE;
     }
     buffer[0] = reg;
@@ -142,29 +142,34 @@ esp_err_t StackChanImu::WriteRegisters(uint8_t reg, const uint8_t* data, size_t 
 }
 
 esp_err_t StackChanImu::UploadBmi270Config() {
-    esp_err_t err = WriteRegister(kRegInitCtrl, 0x00);
+    // BMI270's feature configuration is an uninterrupted byte stream.  The
+    // M5Unified CoreS3 driver writes the complete Bosch configuration file in
+    // one I2C transaction after setting INIT_ADDR to zero; splitting it into
+    // register writes can leave the sensor's internal loader incomplete.
+    const uint8_t init_address[] = {0x00, 0x00};
+    esp_err_t err = WriteRegisters(kRegInitAddr, init_address, sizeof(init_address));
     if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 config: set INIT_ADDR failed: %s", esp_err_to_name(err));
         return err;
     }
 
-    for (size_t offset = 0; offset < BMI270_CONFIG_FILE_SIZE; offset += kConfigChunkSize) {
-        uint8_t init_address[2] = {
-            static_cast<uint8_t>((offset >> 1) & 0x0F),
-            static_cast<uint8_t>(offset >> 5),
-        };
-        err = WriteRegisters(kRegInitAddr, init_address, sizeof(init_address));
-        if (err != ESP_OK) {
-            return err;
-        }
-        const size_t chunk = std::min(kConfigChunkSize, BMI270_CONFIG_FILE_SIZE - offset);
-        err = WriteRegisters(kRegInitData, bmi270_config_file + offset, chunk);
-        if (err != ESP_OK) {
-            return err;
-        }
+    const uint8_t config_register = kRegInitData;
+    i2c_master_transmit_multi_buffer_info_t config_buffers[] = {
+        {.write_buffer = &config_register, .buffer_size = sizeof(config_register)},
+        {.write_buffer = bmi270_config_file, .buffer_size = BMI270_CONFIG_FILE_SIZE},
+    };
+    err = i2c_master_multi_buffer_transmit(bmi270_, config_buffers,
+                                           sizeof(config_buffers) / sizeof(config_buffers[0]),
+                                           kConfigUploadTimeoutMs);
+    if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 config: upload %u bytes failed: %s",
+                 static_cast<unsigned>(BMI270_CONFIG_FILE_SIZE), esp_err_to_name(err));
+        return err;
     }
 
     err = WriteRegister(kRegInitCtrl, 0x01);
     if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 config: start feature engine failed: %s", esp_err_to_name(err));
         return err;
     }
 
@@ -175,7 +180,12 @@ esp_err_t StackChanImu::UploadBmi270Config() {
         if (err == ESP_OK && (status & 0x0F) == 0x01) {
             return ESP_OK;
         }
+        if (err != ESP_OK) {
+            ESP_LOGE(kTag, "BMI270 config: read internal status failed: %s", esp_err_to_name(err));
+            return err;
+        }
     }
+    ESP_LOGE(kTag, "BMI270 config: feature engine did not become ready");
     return ESP_ERR_INVALID_RESPONSE;
 }
 
@@ -274,24 +284,56 @@ esp_err_t StackChanImu::InitializeBmm150() {
 esp_err_t StackChanImu::InitializeBmi270() {
     esp_err_t err = WriteRegister(kRegCommand, kBmi270SoftReset);
     if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 reset command failed: %s", esp_err_to_name(err));
         return err;
     }
-    vTaskDelay(pdMS_TO_TICKS(3));
+
+    // The sensor NACKs feature-register writes while its reset state machine
+    // is active.  Wait for PWR_CONF to leave its reset value, matching the
+    // vendor's CoreS3 BMI270 driver.
+    uint8_t power_conf = 0;
+    bool reset_complete = false;
+    for (int attempt = 0; attempt < 16; ++attempt) {
+        vTaskDelay(pdMS_TO_TICKS(1));
+        err = ReadRegisters(kRegPowerConf, &power_conf, 1);
+        if (err != ESP_OK) {
+            ESP_LOGE(kTag, "BMI270 reset: read PWR_CONF failed: %s", esp_err_to_name(err));
+            return err;
+        }
+        if (power_conf != 0) {
+            reset_complete = true;
+            break;
+        }
+    }
+    if (!reset_complete) {
+        ESP_LOGE(kTag, "BMI270 reset: PWR_CONF did not leave reset state");
+        return ESP_ERR_TIMEOUT;
+    }
 
     uint8_t chip_id = 0;
     err = ReadRegisters(kRegChipId, &chip_id, 1);
     if (err != ESP_OK || chip_id != kBmi270ChipId) {
+        if (err != ESP_OK) {
+            ESP_LOGE(kTag, "BMI270 reset: re-read chip ID failed: %s", esp_err_to_name(err));
+        }
         return err == ESP_OK ? ESP_ERR_NOT_FOUND : err;
     }
 
     err = WriteRegister(kRegPowerConf, 0x00);
     if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 disable power save failed: %s", esp_err_to_name(err));
         return err;
     }
     vTaskDelay(pdMS_TO_TICKS(1));
 
     err = UploadBmi270Config();
     if (err != ESP_OK) {
+        return err;
+    }
+
+    err = WriteRegister(kRegIntMapData, 0xFF);
+    if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 map data interrupts failed: %s", esp_err_to_name(err));
         return err;
     }
 

--- a/firmware/main/boards/stackchan/stackchan_imu.cc
+++ b/firmware/main/boards/stackchan/stackchan_imu.cc
@@ -1,0 +1,413 @@
+/*
+ * SPDX-FileCopyrightText: 2026 StackChan contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "stackchan_imu.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+#include <bmi270_api.h>
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <freertos/task.h>
+
+namespace {
+
+constexpr char kTag[] = "StackChanImu";
+
+constexpr uint8_t kBmi270PrimaryAddress = 0x69;
+constexpr uint8_t kBmi270FallbackAddress = 0x68;
+constexpr uint8_t kBmi270ChipId = 0x24;
+constexpr uint8_t kBmm150Address = 0x10;
+constexpr uint8_t kBmm150ChipId = 0x32;
+
+constexpr uint8_t kRegChipId = 0x00;
+constexpr uint8_t kRegStatus = 0x03;
+constexpr uint8_t kRegAuxData = 0x04;
+constexpr uint8_t kRegInternalStatus = 0x21;
+constexpr uint8_t kRegAuxDevId = 0x4B;
+constexpr uint8_t kRegAuxIfConf = 0x4C;
+constexpr uint8_t kRegAuxReadAddr = 0x4D;
+constexpr uint8_t kRegAuxWriteAddr = 0x4E;
+constexpr uint8_t kRegAuxWriteData = 0x4F;
+constexpr uint8_t kRegInitCtrl = 0x59;
+constexpr uint8_t kRegInitAddr = 0x5B;
+constexpr uint8_t kRegInitData = 0x5E;
+constexpr uint8_t kRegIfConf = 0x6B;
+constexpr uint8_t kRegPowerConf = 0x7C;
+constexpr uint8_t kRegPowerCtrl = 0x7D;
+constexpr uint8_t kRegCommand = 0x7E;
+
+constexpr uint8_t kBmi270SoftReset = 0xB6;
+constexpr uint8_t kBmm150ChipIdRegister = 0x40;
+constexpr uint8_t kBmm150DataRegister = 0x42;
+constexpr uint8_t kBmm150PowerRegister = 0x4B;
+constexpr uint8_t kBmm150ModeRegister = 0x4C;
+
+constexpr size_t kConfigChunkSize = 32;
+constexpr int kI2cTimeoutMs = 100;
+
+int16_t ReadInt16(const uint8_t* data) {
+    return static_cast<int16_t>(static_cast<uint16_t>(data[0]) |
+                                (static_cast<uint16_t>(data[1]) << 8));
+}
+
+}  // namespace
+
+StackChanImu::StackChanImu(i2c_master_bus_handle_t bus) : bus_(bus) {
+    mutex_ = xSemaphoreCreateMutex();
+}
+
+StackChanImu::~StackChanImu() {
+    DetachBmi270();
+    if (mutex_ != nullptr) {
+        vSemaphoreDelete(mutex_);
+    }
+}
+
+esp_err_t StackChanImu::Fail(const char* operation, esp_err_t err) {
+    char message[128];
+    std::snprintf(message, sizeof(message), "%s: %s", operation, esp_err_to_name(err));
+    last_error_ = message;
+    ESP_LOGE(kTag, "%s", last_error_.c_str());
+    return err;
+}
+
+void StackChanImu::DetachBmi270() {
+    if (bmi270_ != nullptr) {
+        esp_err_t err = i2c_master_bus_rm_device(bmi270_);
+        if (err != ESP_OK) {
+            ESP_LOGW(kTag, "Failed to detach BMI270: %s", esp_err_to_name(err));
+        }
+        bmi270_ = nullptr;
+    }
+    initialized_ = false;
+    mag_available_ = false;
+    bmi270_address_ = 0;
+}
+
+esp_err_t StackChanImu::AttachBmi270(uint8_t address) {
+    i2c_device_config_t config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = address,
+        .scl_speed_hz = 400000,
+        .scl_wait_us = 0,
+        .flags = {
+            .disable_ack_check = false,
+        },
+    };
+    esp_err_t err = i2c_master_bus_add_device(bus_, &config, &bmi270_);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    uint8_t chip_id = 0;
+    err = ReadRegisters(kRegChipId, &chip_id, 1);
+    if (err == ESP_OK && chip_id == kBmi270ChipId) {
+        bmi270_address_ = address;
+        return ESP_OK;
+    }
+
+    i2c_master_bus_rm_device(bmi270_);
+    bmi270_ = nullptr;
+    return err == ESP_OK ? ESP_ERR_NOT_FOUND : err;
+}
+
+esp_err_t StackChanImu::ReadRegisters(uint8_t reg, uint8_t* data, size_t length) {
+    if (bmi270_ == nullptr || data == nullptr || length == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return i2c_master_transmit_receive(bmi270_, &reg, 1, data, length, kI2cTimeoutMs);
+}
+
+esp_err_t StackChanImu::WriteRegister(uint8_t reg, uint8_t value) {
+    return WriteRegisters(reg, &value, 1);
+}
+
+esp_err_t StackChanImu::WriteRegisters(uint8_t reg, const uint8_t* data, size_t length) {
+    if (bmi270_ == nullptr || data == nullptr || length == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    uint8_t buffer[kConfigChunkSize + 1];
+    if (length > kConfigChunkSize) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    buffer[0] = reg;
+    std::memcpy(buffer + 1, data, length);
+    return i2c_master_transmit(bmi270_, buffer, length + 1, kI2cTimeoutMs);
+}
+
+esp_err_t StackChanImu::UploadBmi270Config() {
+    esp_err_t err = WriteRegister(kRegInitCtrl, 0x00);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    for (size_t offset = 0; offset < BMI270_CONFIG_FILE_SIZE; offset += kConfigChunkSize) {
+        uint8_t init_address[2] = {
+            static_cast<uint8_t>((offset >> 1) & 0x0F),
+            static_cast<uint8_t>(offset >> 5),
+        };
+        err = WriteRegisters(kRegInitAddr, init_address, sizeof(init_address));
+        if (err != ESP_OK) {
+            return err;
+        }
+        const size_t chunk = std::min(kConfigChunkSize, BMI270_CONFIG_FILE_SIZE - offset);
+        err = WriteRegisters(kRegInitData, bmi270_config_file + offset, chunk);
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    err = WriteRegister(kRegInitCtrl, 0x01);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    for (int attempt = 0; attempt < 20; ++attempt) {
+        vTaskDelay(pdMS_TO_TICKS(5));
+        uint8_t status = 0;
+        err = ReadRegisters(kRegInternalStatus, &status, 1);
+        if (err == ESP_OK && (status & 0x0F) == 0x01) {
+            return ESP_OK;
+        }
+    }
+    return ESP_ERR_INVALID_RESPONSE;
+}
+
+esp_err_t StackChanImu::WaitForAuxReady() {
+    for (int attempt = 0; attempt < 20; ++attempt) {
+        uint8_t status = 0;
+        esp_err_t err = ReadRegisters(kRegStatus, &status, 1);
+        if (err != ESP_OK) {
+            return err;
+        }
+        if ((status & 0x04) == 0) {
+            return ESP_OK;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+    return ESP_ERR_TIMEOUT;
+}
+
+esp_err_t StackChanImu::AuxWriteRegister(uint8_t reg, uint8_t value) {
+    esp_err_t err = WriteRegister(kRegAuxWriteData, value);
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegAuxWriteAddr, reg);
+    }
+    if (err == ESP_OK) {
+        err = WaitForAuxReady();
+    }
+    return err;
+}
+
+esp_err_t StackChanImu::AuxReadRegister(uint8_t reg, uint8_t* value) {
+    esp_err_t err = WriteRegister(kRegAuxIfConf, 0x80);
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegAuxReadAddr, reg);
+    }
+    if (err == ESP_OK) {
+        err = WaitForAuxReady();
+    }
+    if (err == ESP_OK) {
+        err = ReadRegisters(kRegAuxData, value, 1);
+    }
+    return err;
+}
+
+esp_err_t StackChanImu::InitializeBmm150() {
+    esp_err_t err = WriteRegister(kRegIfConf, 0x20);
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegPowerConf, 0x00);
+    }
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegPowerCtrl, 0x0E);
+    }
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegAuxIfConf, 0x80);
+    }
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegAuxDevId, static_cast<uint8_t>(kBmm150Address << 1));
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = AuxWriteRegister(kBmm150PowerRegister, 0x83);
+    if (err != ESP_OK) {
+        return err;
+    }
+    vTaskDelay(pdMS_TO_TICKS(3));
+
+    // The first AUX read after reset may still contain the previous register's
+    // byte. M5Unified intentionally performs this WhoAmI read twice as well.
+    uint8_t chip_id = 0;
+    err = AuxReadRegister(kBmm150ChipIdRegister, &chip_id);
+    if (err == ESP_OK) {
+        err = AuxReadRegister(kBmm150ChipIdRegister, &chip_id);
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+    if (chip_id != kBmm150ChipId) {
+        ESP_LOGW(kTag, "BMM150 not detected through BMI270 AUX (chip_id=0x%02X)", chip_id);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    err = AuxWriteRegister(kBmm150ModeRegister, 0x38);
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegAuxIfConf, 0x4F);
+    }
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegAuxReadAddr, kBmm150DataRegister);
+    }
+    if (err == ESP_OK) {
+        err = WriteRegister(kRegPowerCtrl, 0x0F);
+    }
+    return err;
+}
+
+esp_err_t StackChanImu::InitializeBmi270() {
+    esp_err_t err = WriteRegister(kRegCommand, kBmi270SoftReset);
+    if (err != ESP_OK) {
+        return err;
+    }
+    vTaskDelay(pdMS_TO_TICKS(3));
+
+    uint8_t chip_id = 0;
+    err = ReadRegisters(kRegChipId, &chip_id, 1);
+    if (err != ESP_OK || chip_id != kBmi270ChipId) {
+        return err == ESP_OK ? ESP_ERR_NOT_FOUND : err;
+    }
+
+    err = WriteRegister(kRegPowerConf, 0x00);
+    if (err != ESP_OK) {
+        return err;
+    }
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    err = UploadBmi270Config();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = InitializeBmm150();
+    if (err == ESP_OK) {
+        mag_available_ = true;
+    } else {
+        mag_available_ = false;
+        ESP_LOGW(kTag, "BMM150 initialization failed; accel/gyro remain available: %s",
+                 esp_err_to_name(err));
+        err = WriteRegister(kRegPowerCtrl, 0x0E);
+    }
+    return err;
+}
+
+esp_err_t StackChanImu::InitializeLocked() {
+    if (initialized_) {
+        return ESP_OK;
+    }
+    if (bus_ == nullptr || mutex_ == nullptr) {
+        return Fail("IMU prerequisites unavailable", ESP_ERR_INVALID_STATE);
+    }
+
+    DetachBmi270();
+    esp_err_t err = AttachBmi270(kBmi270PrimaryAddress);
+    if (err != ESP_OK) {
+        ESP_LOGW(kTag, "BMI270 not found at 0x%02X; trying 0x%02X",
+                 kBmi270PrimaryAddress, kBmi270FallbackAddress);
+        err = AttachBmi270(kBmi270FallbackAddress);
+    }
+    if (err != ESP_OK) {
+        return Fail("BMI270 probe failed", err);
+    }
+
+    err = InitializeBmi270();
+    if (err != ESP_OK) {
+        DetachBmi270();
+        return Fail("BMI270 initialization failed", err);
+    }
+
+    initialized_ = true;
+    last_error_.clear();
+    ESP_LOGI(kTag, "IMU initialized: BMI270 address=0x%02X, BMM150=%s",
+             bmi270_address_, mag_available_ ? "available" : "unavailable");
+    return ESP_OK;
+}
+
+esp_err_t StackChanImu::Initialize() {
+    if (mutex_ == nullptr || xSemaphoreTake(mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return Fail("IMU initialization mutex timeout", ESP_ERR_TIMEOUT);
+    }
+    esp_err_t err = InitializeLocked();
+    xSemaphoreGive(mutex_);
+    return err;
+}
+
+esp_err_t StackChanImu::Read(StackChanImuSnapshot* snapshot) {
+    if (snapshot == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (mutex_ == nullptr || xSemaphoreTake(mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return Fail("IMU read mutex timeout", ESP_ERR_TIMEOUT);
+    }
+
+    esp_err_t err = InitializeLocked();
+    if (err != ESP_OK) {
+        xSemaphoreGive(mutex_);
+        return err;
+    }
+
+    uint8_t data[20] = {};
+    err = ReadRegisters(kRegAuxData, data, sizeof(data));
+    if (err != ESP_OK) {
+        Fail("IMU sample read failed", err);
+        xSemaphoreGive(mutex_);
+        return err;
+    }
+
+    StackChanImuSnapshot result;
+    result.mag_raw.x = static_cast<int16_t>(ReadInt16(data) >> 2);
+    result.mag_raw.y = static_cast<int16_t>(ReadInt16(data + 2) >> 2);
+    result.mag_raw.z = static_cast<int16_t>(ReadInt16(data + 4) & 0xFFFE);
+    result.accel_raw.x = ReadInt16(data + 8);
+    result.accel_raw.y = ReadInt16(data + 10);
+    result.accel_raw.z = ReadInt16(data + 12);
+    result.gyro_raw.x = ReadInt16(data + 14);
+    result.gyro_raw.y = ReadInt16(data + 16);
+    result.gyro_raw.z = ReadInt16(data + 18);
+
+    constexpr float kAccelScale = 8.0f / 32768.0f;
+    constexpr float kGyroScale = 2000.0f / 32768.0f;
+    constexpr float kMagScale = 10.0f * 4912.0f / 32760.0f;
+    result.accel_g = {result.accel_raw.x * kAccelScale,
+                      result.accel_raw.y * kAccelScale,
+                      result.accel_raw.z * kAccelScale};
+    result.gyro_dps = {result.gyro_raw.x * kGyroScale,
+                       result.gyro_raw.y * kGyroScale,
+                       result.gyro_raw.z * kGyroScale};
+    // CoreS3 / StackChan mount the BMM150 with Y and Z inverted relative to
+    // the body axes. Match M5Unified's board-specific axis correction.
+    result.mag_ut = {result.mag_raw.x * kMagScale,
+                     -result.mag_raw.y * kMagScale,
+                     -result.mag_raw.z * kMagScale};
+    result.mag_available = mag_available_;
+    result.mag_data_ready = mag_available_ && ((data[6] & 0x01) != 0);
+
+    uint8_t status = 0;
+    if (ReadRegisters(0x1D, &status, 1) == ESP_OK) {
+        result.accel_data_ready = (status & 0x80) != 0;
+        result.gyro_data_ready = (status & 0x40) != 0;
+        result.mag_data_ready = mag_available_ && ((status & 0x20) != 0);
+    }
+    result.bmi270_i2c_address = bmi270_address_;
+    result.sample_time_us = esp_timer_get_time();
+    *snapshot = result;
+    last_error_.clear();
+    xSemaphoreGive(mutex_);
+    return ESP_OK;
+}

--- a/firmware/main/boards/stackchan/stackchan_imu.cc
+++ b/firmware/main/boards/stackchan/stackchan_imu.cc
@@ -6,6 +6,7 @@
 
 #include "stackchan_imu.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 
@@ -33,6 +34,7 @@ constexpr uint8_t kRegAuxIfConf = 0x4C;
 constexpr uint8_t kRegAuxReadAddr = 0x4D;
 constexpr uint8_t kRegAuxWriteAddr = 0x4E;
 constexpr uint8_t kRegAuxWriteData = 0x4F;
+constexpr uint8_t kRegIntMapData = 0x58;
 constexpr uint8_t kRegInitCtrl = 0x59;
 constexpr uint8_t kRegInitAddr = 0x5B;
 constexpr uint8_t kRegInitData = 0x5E;
@@ -47,9 +49,8 @@ constexpr uint8_t kBmm150DataRegister = 0x42;
 constexpr uint8_t kBmm150PowerRegister = 0x4B;
 constexpr uint8_t kBmm150ModeRegister = 0x4C;
 
-constexpr size_t kMaxRegisterWriteSize = 32;
+constexpr size_t kConfigChunkSize = 32;
 constexpr int kI2cTimeoutMs = 100;
-constexpr int kConfigUploadTimeoutMs = 500;
 
 int16_t ReadInt16(const uint8_t* data) {
     return static_cast<int16_t>(static_cast<uint16_t>(data[0]) |
@@ -94,7 +95,11 @@ esp_err_t StackChanImu::AttachBmi270(uint8_t address) {
     i2c_device_config_t config = {
         .dev_addr_length = I2C_ADDR_BIT_LEN_7,
         .device_address = address,
-        .scl_speed_hz = 400000,
+        // M5Unified uses the CoreS3 internal bus at 100 kHz.  The BMI270
+        // configuration stream is unusually sensitive to the host burst
+        // timing; keep this device at the board's reference rate while other
+        // internal peripherals retain their existing 400 kHz handles.
+        .scl_speed_hz = 100000,
         .scl_wait_us = 0,
         .flags = {
             .disable_ack_check = false,
@@ -121,7 +126,12 @@ esp_err_t StackChanImu::ReadRegisters(uint8_t reg, uint8_t* data, size_t length)
     if (bmi270_ == nullptr || data == nullptr || length == 0) {
         return ESP_ERR_INVALID_STATE;
     }
-    return i2c_master_transmit_receive(bmi270_, &reg, 1, data, length, kI2cTimeoutMs);
+    esp_err_t err = i2c_master_transmit_receive(bmi270_, &reg, 1, data, length, kI2cTimeoutMs);
+    if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 read reg 0x%02X (%u bytes) failed: %s",
+                 reg, static_cast<unsigned>(length), esp_err_to_name(err));
+    }
+    return err;
 }
 
 esp_err_t StackChanImu::WriteRegister(uint8_t reg, uint8_t value) {
@@ -132,39 +142,54 @@ esp_err_t StackChanImu::WriteRegisters(uint8_t reg, const uint8_t* data, size_t 
     if (bmi270_ == nullptr || data == nullptr || length == 0) {
         return ESP_ERR_INVALID_STATE;
     }
-    uint8_t buffer[kMaxRegisterWriteSize + 1];
-    if (length > kMaxRegisterWriteSize) {
+    uint8_t buffer[kConfigChunkSize + 1];
+    if (length > kConfigChunkSize) {
         return ESP_ERR_INVALID_SIZE;
     }
     buffer[0] = reg;
     std::memcpy(buffer + 1, data, length);
-    return i2c_master_transmit(bmi270_, buffer, length + 1, kI2cTimeoutMs);
+    esp_err_t err = i2c_master_transmit(bmi270_, buffer, length + 1, kI2cTimeoutMs);
+    if (err != ESP_OK) {
+        ESP_LOGE(kTag, "BMI270 write reg 0x%02X (%u bytes) failed: %s",
+                 reg, static_cast<unsigned>(length), esp_err_to_name(err));
+    }
+    return err;
 }
 
 esp_err_t StackChanImu::UploadBmi270Config() {
-    // BMI270's feature configuration is an uninterrupted byte stream.  The
-    // M5Unified CoreS3 driver writes the complete Bosch configuration file in
-    // one I2C transaction after setting INIT_ADDR to zero; splitting it into
-    // register writes can leave the sensor's internal loader incomplete.
-    const uint8_t init_address[] = {0x00, 0x00};
-    esp_err_t err = WriteRegisters(kRegInitAddr, init_address, sizeof(init_address));
+    // Explicitly enter the configuration-loader state. The soft-reset value
+    // is normally zero, but the datasheet requires INIT_CTRL=0 before a new
+    // stream and this also makes retries deterministic after a failed load.
+    esp_err_t err = WriteRegister(kRegInitCtrl, 0x00);
     if (err != ESP_OK) {
-        ESP_LOGE(kTag, "BMI270 config: set INIT_ADDR failed: %s", esp_err_to_name(err));
+        ESP_LOGE(kTag, "BMI270 config: prepare loader failed: %s", esp_err_to_name(err));
         return err;
     }
 
-    const uint8_t config_register = kRegInitData;
-    i2c_master_transmit_multi_buffer_info_t config_buffers[] = {
-        {.write_buffer = &config_register, .buffer_size = sizeof(config_register)},
-        {.write_buffer = bmi270_config_file, .buffer_size = BMI270_CONFIG_FILE_SIZE},
-    };
-    err = i2c_master_multi_buffer_transmit(bmi270_, config_buffers,
-                                           sizeof(config_buffers) / sizeof(config_buffers[0]),
-                                           kConfigUploadTimeoutMs);
-    if (err != ESP_OK) {
-        ESP_LOGE(kTag, "BMI270 config: upload %u bytes failed: %s",
-                 static_cast<unsigned>(BMI270_CONFIG_FILE_SIZE), esp_err_to_name(err));
-        return err;
+    // The BMI270 I2C interface accepts at most a 32-byte burst reliably. For
+    // shorter host FIFOs, Bosch requires advancing INIT_ADDR by chunk_size/2
+    // words between writes; 0x5B is the low nibble and 0x5C the upper byte.
+    for (size_t offset = 0; offset < BMI270_CONFIG_FILE_SIZE; offset += kConfigChunkSize) {
+        const uint8_t init_address[] = {
+            static_cast<uint8_t>((offset >> 1) & 0x0F),
+            static_cast<uint8_t>(offset >> 5),
+        };
+        err = WriteRegisters(kRegInitAddr, init_address, sizeof(init_address));
+        if (err != ESP_OK) {
+            ESP_LOGE(kTag, "BMI270 config: set INIT_ADDR at offset %u failed: %s",
+                     static_cast<unsigned>(offset), esp_err_to_name(err));
+            return err;
+        }
+
+        const size_t chunk = std::min(kConfigChunkSize,
+                                      static_cast<size_t>(BMI270_CONFIG_FILE_SIZE) - offset);
+        err = WriteRegisters(kRegInitData, bmi270_config_file + offset, chunk);
+        if (err != ESP_OK) {
+            ESP_LOGE(kTag, "BMI270 config: upload offset %u (%u bytes) failed: %s",
+                     static_cast<unsigned>(offset), static_cast<unsigned>(chunk),
+                     esp_err_to_name(err));
+            return err;
+        }
     }
 
     err = WriteRegister(kRegInitCtrl, 0x01);
@@ -172,21 +197,9 @@ esp_err_t StackChanImu::UploadBmi270Config() {
         ESP_LOGE(kTag, "BMI270 config: start feature engine failed: %s", esp_err_to_name(err));
         return err;
     }
-
-    for (int attempt = 0; attempt < 20; ++attempt) {
-        vTaskDelay(pdMS_TO_TICKS(5));
-        uint8_t status = 0;
-        err = ReadRegisters(kRegInternalStatus, &status, 1);
-        if (err == ESP_OK && (status & 0x0F) == 0x01) {
-            return ESP_OK;
-        }
-        if (err != ESP_OK) {
-            ESP_LOGE(kTag, "BMI270 config: read internal status failed: %s", esp_err_to_name(err));
-            return err;
-        }
-    }
-    ESP_LOGE(kTag, "BMI270 config: feature engine did not become ready");
-    return ESP_ERR_INVALID_RESPONSE;
+    // M5Unified maps the data-ready interrupts before polling INTERNAL_STATUS;
+    // keep that ordering in InitializeBmi270().
+    return ESP_OK;
 }
 
 esp_err_t StackChanImu::WaitForAuxReady() {
@@ -278,47 +291,31 @@ esp_err_t StackChanImu::InitializeBmm150() {
     if (err == ESP_OK) {
         err = WriteRegister(kRegPowerCtrl, 0x0F);
     }
+    if (err == ESP_OK) {
+        // The first sample is not valid immediately after powering the
+        // accelerometer/gyro/auxiliary engine. Give the 100 Hz default ODR
+        // one complete sample period before the first self.imu.read call.
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
     return err;
 }
 
 esp_err_t StackChanImu::InitializeBmi270() {
+    ESP_LOGI(kTag, "BMI270 init: soft reset");
     esp_err_t err = WriteRegister(kRegCommand, kBmi270SoftReset);
     if (err != ESP_OK) {
         ESP_LOGE(kTag, "BMI270 reset command failed: %s", esp_err_to_name(err));
         return err;
     }
 
-    // The sensor NACKs feature-register writes while its reset state machine
-    // is active.  Wait for PWR_CONF to leave its reset value, matching the
-    // vendor's CoreS3 BMI270 driver.
-    uint8_t power_conf = 0;
-    bool reset_complete = false;
-    for (int attempt = 0; attempt < 16; ++attempt) {
-        vTaskDelay(pdMS_TO_TICKS(1));
-        err = ReadRegisters(kRegPowerConf, &power_conf, 1);
-        if (err != ESP_OK) {
-            ESP_LOGE(kTag, "BMI270 reset: read PWR_CONF failed: %s", esp_err_to_name(err));
-            return err;
-        }
-        if (power_conf != 0) {
-            reset_complete = true;
-            break;
-        }
-    }
-    if (!reset_complete) {
-        ESP_LOGE(kTag, "BMI270 reset: PWR_CONF did not leave reset state");
-        return ESP_ERR_TIMEOUT;
-    }
+    // BMI270 NACKs register reads while its reset state machine is active.
+    // The ESP-IDF new I2C driver reports that NACK as ESP_ERR_INVALID_STATE,
+    // so avoid probing PWR_CONF during the reset window.  Sixteen milliseconds
+    // matches the retry window in M5Unified's CoreS3 driver and is long enough
+    // for the sensor to accept the next command.
+    vTaskDelay(pdMS_TO_TICKS(16));
 
-    uint8_t chip_id = 0;
-    err = ReadRegisters(kRegChipId, &chip_id, 1);
-    if (err != ESP_OK || chip_id != kBmi270ChipId) {
-        if (err != ESP_OK) {
-            ESP_LOGE(kTag, "BMI270 reset: re-read chip ID failed: %s", esp_err_to_name(err));
-        }
-        return err == ESP_OK ? ESP_ERR_NOT_FOUND : err;
-    }
-
+    ESP_LOGI(kTag, "BMI270 init: disable power save");
     err = WriteRegister(kRegPowerConf, 0x00);
     if (err != ESP_OK) {
         ESP_LOGE(kTag, "BMI270 disable power save failed: %s", esp_err_to_name(err));
@@ -326,17 +323,40 @@ esp_err_t StackChanImu::InitializeBmi270() {
     }
     vTaskDelay(pdMS_TO_TICKS(1));
 
+    ESP_LOGI(kTag, "BMI270 init: upload configuration");
     err = UploadBmi270Config();
     if (err != ESP_OK) {
         return err;
     }
 
+    ESP_LOGI(kTag, "BMI270 init: map data interrupts");
     err = WriteRegister(kRegIntMapData, 0xFF);
     if (err != ESP_OK) {
         ESP_LOGE(kTag, "BMI270 map data interrupts failed: %s", esp_err_to_name(err));
         return err;
     }
 
+    uint8_t last_status = 0;
+    for (int attempt = 0; attempt < 20; ++attempt) {
+        vTaskDelay(pdMS_TO_TICKS(5));
+        uint8_t status = 0;
+        err = ReadRegisters(kRegInternalStatus, &status, 1);
+        last_status = status;
+        if (err == ESP_OK && (status & 0x0F) == 0x01) {
+            break;
+        }
+        if (err != ESP_OK) {
+            ESP_LOGE(kTag, "BMI270 init: read internal status failed: %s", esp_err_to_name(err));
+            return err;
+        }
+    }
+    if ((last_status & 0x0F) != 0x01) {
+        ESP_LOGE(kTag, "BMI270 init: feature engine did not become ready (status=0x%02X)",
+                 last_status);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    ESP_LOGI(kTag, "BMI270 init: initialize BMM150 auxiliary bus");
     err = InitializeBmm150();
     if (err == ESP_OK) {
         mag_available_ = true;
@@ -404,6 +424,23 @@ esp_err_t StackChanImu::Read(StackChanImuSnapshot* snapshot) {
         return err;
     }
 
+    // A freshly powered BMI270 can acknowledge register reads before its
+    // first accelerometer/gyro frame exists. Poll STATUS rather than
+    // returning that all-zero shadow frame to the first caller.
+    uint8_t ready_status = 0;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        err = ReadRegisters(kRegStatus, &ready_status, 1);
+        if (err != ESP_OK) {
+            Fail("IMU status read failed", err);
+            xSemaphoreGive(mutex_);
+            return err;
+        }
+        if ((ready_status & 0xC0) == 0xC0) {
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+
     uint8_t data[20] = {};
     err = ReadRegisters(kRegAuxData, data, sizeof(data));
     if (err != ESP_OK) {
@@ -439,13 +476,9 @@ esp_err_t StackChanImu::Read(StackChanImuSnapshot* snapshot) {
                      -result.mag_raw.z * kMagScale};
     result.mag_available = mag_available_;
     result.mag_data_ready = mag_available_ && ((data[6] & 0x01) != 0);
-
-    uint8_t status = 0;
-    if (ReadRegisters(0x1D, &status, 1) == ESP_OK) {
-        result.accel_data_ready = (status & 0x80) != 0;
-        result.gyro_data_ready = (status & 0x40) != 0;
-        result.mag_data_ready = mag_available_ && ((status & 0x20) != 0);
-    }
+    result.accel_data_ready = (ready_status & 0x80) != 0;
+    result.gyro_data_ready = (ready_status & 0x40) != 0;
+    result.mag_data_ready = mag_available_ && ((ready_status & 0x20) != 0);
     result.bmi270_i2c_address = bmi270_address_;
     result.sample_time_us = esp_timer_get_time();
     *snapshot = result;

--- a/firmware/main/boards/stackchan/stackchan_imu.cc
+++ b/firmware/main/boards/stackchan/stackchan_imu.cc
@@ -28,6 +28,7 @@ constexpr uint8_t kBmm150ChipId = 0x32;
 constexpr uint8_t kRegChipId = 0x00;
 constexpr uint8_t kRegStatus = 0x03;
 constexpr uint8_t kRegAuxData = 0x04;
+constexpr uint8_t kRegIntStatus1 = 0x1D;
 constexpr uint8_t kRegInternalStatus = 0x21;
 constexpr uint8_t kRegAuxDevId = 0x4B;
 constexpr uint8_t kRegAuxIfConf = 0x4C;
@@ -425,13 +426,13 @@ esp_err_t StackChanImu::Read(StackChanImuSnapshot* snapshot) {
     }
 
     // A freshly powered BMI270 can acknowledge register reads before its
-    // first accelerometer/gyro frame exists. Poll STATUS rather than
+    // first accelerometer/gyro frame exists. Poll INT_STATUS_1 rather than
     // returning that all-zero shadow frame to the first caller.
     uint8_t ready_status = 0;
     for (int attempt = 0; attempt < 100; ++attempt) {
-        err = ReadRegisters(kRegStatus, &ready_status, 1);
+        err = ReadRegisters(kRegIntStatus1, &ready_status, 1);
         if (err != ESP_OK) {
-            Fail("IMU status read failed", err);
+            Fail("IMU data-ready status read failed", err);
             xSemaphoreGive(mutex_);
             return err;
         }
@@ -439,6 +440,11 @@ esp_err_t StackChanImu::Read(StackChanImuSnapshot* snapshot) {
             break;
         }
         vTaskDelay(pdMS_TO_TICKS(1));
+    }
+    if ((ready_status & 0xC0) != 0xC0) {
+        err = Fail("IMU sample not ready", ESP_ERR_TIMEOUT);
+        xSemaphoreGive(mutex_);
+        return err;
     }
 
     uint8_t data[20] = {};
@@ -475,7 +481,6 @@ esp_err_t StackChanImu::Read(StackChanImuSnapshot* snapshot) {
                      -result.mag_raw.y * kMagScale,
                      -result.mag_raw.z * kMagScale};
     result.mag_available = mag_available_;
-    result.mag_data_ready = mag_available_ && ((data[6] & 0x01) != 0);
     result.accel_data_ready = (ready_status & 0x80) != 0;
     result.gyro_data_ready = (ready_status & 0x40) != 0;
     result.mag_data_ready = mag_available_ && ((ready_status & 0x20) != 0);

--- a/firmware/main/boards/stackchan/stackchan_imu.h
+++ b/firmware/main/boards/stackchan/stackchan_imu.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 StackChan contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <driver/i2c_master.h>
+#include <esp_err.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+struct StackChanImuAxisRaw {
+    int16_t x = 0;
+    int16_t y = 0;
+    int16_t z = 0;
+};
+
+struct StackChanImuAxisFloat {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+struct StackChanImuSnapshot {
+    StackChanImuAxisRaw accel_raw;
+    StackChanImuAxisRaw gyro_raw;
+    StackChanImuAxisRaw mag_raw;
+    StackChanImuAxisFloat accel_g;
+    StackChanImuAxisFloat gyro_dps;
+    StackChanImuAxisFloat mag_ut;
+    bool accel_data_ready = false;
+    bool gyro_data_ready = false;
+    bool mag_data_ready = false;
+    bool mag_available = false;
+    uint8_t bmi270_i2c_address = 0;
+    int64_t sample_time_us = 0;
+};
+
+class StackChanImu {
+public:
+    explicit StackChanImu(i2c_master_bus_handle_t bus);
+    ~StackChanImu();
+
+    StackChanImu(const StackChanImu&) = delete;
+    StackChanImu& operator=(const StackChanImu&) = delete;
+
+    esp_err_t Initialize();
+    esp_err_t Read(StackChanImuSnapshot* snapshot);
+    const std::string& last_error() const { return last_error_; }
+
+private:
+    esp_err_t InitializeLocked();
+    esp_err_t AttachBmi270(uint8_t address);
+    esp_err_t InitializeBmi270();
+    esp_err_t InitializeBmm150();
+    esp_err_t UploadBmi270Config();
+    esp_err_t WaitForAuxReady();
+    esp_err_t AuxWriteRegister(uint8_t reg, uint8_t value);
+    esp_err_t AuxReadRegister(uint8_t reg, uint8_t* value);
+    esp_err_t ReadRegisters(uint8_t reg, uint8_t* data, size_t length);
+    esp_err_t WriteRegister(uint8_t reg, uint8_t value);
+    esp_err_t WriteRegisters(uint8_t reg, const uint8_t* data, size_t length);
+    esp_err_t Fail(const char* operation, esp_err_t err);
+    void DetachBmi270();
+
+    i2c_master_bus_handle_t bus_ = nullptr;
+    i2c_master_dev_handle_t bmi270_ = nullptr;
+    SemaphoreHandle_t mutex_ = nullptr;
+    bool initialized_ = false;
+    bool mag_available_ = false;
+    uint8_t bmi270_address_ = 0;
+    std::string last_error_;
+};

--- a/firmware/main/boards/stackchan/stackchan_nfc.cc
+++ b/firmware/main/boards/stackchan/stackchan_nfc.cc
@@ -1,0 +1,500 @@
+/*
+ * SPDX-FileCopyrightText: 2026 StackChan contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "stackchan_nfc.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <freertos/task.h>
+
+namespace {
+
+constexpr char kTag[] = "StackChanNfc";
+constexpr uint8_t kSt25r3916Address = 0x50;
+constexpr uint8_t kSt25r3916ChipType = 0x05;
+
+constexpr uint8_t kRegIoConfig1 = 0x00;
+constexpr uint8_t kRegIoConfig2 = 0x01;
+constexpr uint8_t kRegOperationControl = 0x02;
+constexpr uint8_t kRegModeDefinition = 0x03;
+constexpr uint8_t kRegBitrateDefinition = 0x04;
+constexpr uint8_t kRegIso14443aSettings = 0x05;
+constexpr uint8_t kRegAuxiliaryDefinition = 0x0A;
+constexpr uint8_t kRegReceiverConfiguration1 = 0x0B;
+constexpr uint8_t kRegReceiverConfiguration2 = 0x0C;
+constexpr uint8_t kRegReceiverConfiguration3 = 0x0D;
+constexpr uint8_t kRegReceiverConfiguration4 = 0x0E;
+constexpr uint8_t kRegMaskMainInterrupt = 0x16;
+constexpr uint8_t kRegMainInterrupt = 0x1A;
+constexpr uint8_t kRegErrorAndWakeupInterrupt = 0x1C;
+constexpr uint8_t kRegPassiveTargetInterrupt = 0x1D;
+constexpr uint8_t kRegFifoStatus1 = 0x1E;
+constexpr uint8_t kRegNumberOfTransmittedBytes1 = 0x22;
+constexpr uint8_t kRegTxDriver = 0x28;
+constexpr uint8_t kRegExternalFieldDetectorActivation = 0x2A;
+constexpr uint8_t kRegExternalFieldDetectorDeactivation = 0x2B;
+constexpr uint8_t kRegAuxiliaryDisplay = 0x31;
+constexpr uint8_t kRegIcIdentity = 0x3F;
+
+constexpr uint8_t kCommandSetDefault = 0xC1;
+constexpr uint8_t kCommandStopAllActivities = 0xC2;
+constexpr uint8_t kCommandTransmitWithCrc = 0xC4;
+constexpr uint8_t kCommandTransmitWithoutCrc = 0xC5;
+constexpr uint8_t kCommandTransmitReqa = 0xC6;
+constexpr uint8_t kCommandInitialFieldOn = 0xC8;
+constexpr uint8_t kCommandResetReceiverGain = 0xD5;
+constexpr uint8_t kCommandAdjustRegulators = 0xD6;
+constexpr uint8_t kCommandClearFifo = 0xDB;
+constexpr uint8_t kCommandTestAccess = 0xFC;
+
+constexpr uint8_t kOpReadRegister = 0x40;
+constexpr uint8_t kOpLoadFifo = 0x80;
+constexpr uint8_t kOpReadFifo = 0x9F;
+
+constexpr uint8_t kOperationEnableOscillator = 0x80;
+constexpr uint8_t kOperationEnableReceive = 0x40;
+constexpr uint8_t kOperationEnableTransmit = 0x08;
+constexpr uint8_t kAuxiliaryNoCrcReceive = 0x80;
+constexpr uint8_t kMainIrqReceiveEnd = 0x10;
+constexpr uint8_t kMainIrqCollision = 0x04;
+constexpr uint8_t kAuxiliaryOscillatorReady = 0x10;
+
+constexpr int kI2cTimeoutMs = 100;
+constexpr uint32_t kRequestTimeoutMs = 15;
+constexpr uint32_t kCascadeTimeoutMs = 20;
+constexpr size_t kMaxFifoDepth = 512;
+
+}  // namespace
+
+StackChanNfc::StackChanNfc(i2c_master_bus_handle_t bus) : bus_(bus) {
+    mutex_ = xSemaphoreCreateMutex();
+}
+
+StackChanNfc::~StackChanNfc() {
+    if (nfc_ != nullptr) {
+        (void)StopField();
+    }
+    Detach();
+    if (mutex_ != nullptr) {
+        vSemaphoreDelete(mutex_);
+    }
+}
+
+esp_err_t StackChanNfc::Fail(const char* operation, esp_err_t err) {
+    char message[128];
+    std::snprintf(message, sizeof(message), "%s: %s", operation, esp_err_to_name(err));
+    last_error_ = message;
+    ESP_LOGE(kTag, "%s", last_error_.c_str());
+    return err;
+}
+
+void StackChanNfc::Detach() {
+    if (nfc_ != nullptr) {
+        esp_err_t err = i2c_master_bus_rm_device(nfc_);
+        if (err != ESP_OK) {
+            ESP_LOGW(kTag, "Failed to detach ST25R3916: %s", esp_err_to_name(err));
+        }
+        nfc_ = nullptr;
+    }
+    initialized_ = false;
+    chip_type_ = 0;
+    chip_revision_ = 0;
+}
+
+esp_err_t StackChanNfc::ReadCommand(uint8_t command, uint8_t* data, size_t length) {
+    if (nfc_ == nullptr || data == nullptr || length == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return i2c_master_transmit_receive(nfc_, &command, 1, data, length, kI2cTimeoutMs);
+}
+
+esp_err_t StackChanNfc::WriteCommand(uint8_t command, const uint8_t* data, size_t length) {
+    if (nfc_ == nullptr) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    uint8_t buffer[33] = {};
+    if (length > sizeof(buffer) - 1 || (length > 0 && data == nullptr)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    buffer[0] = command;
+    if (length > 0) {
+        std::memcpy(buffer + 1, data, length);
+    }
+    return i2c_master_transmit(nfc_, buffer, length + 1, kI2cTimeoutMs);
+}
+
+esp_err_t StackChanNfc::ReadRegister(uint8_t reg, uint8_t* value) {
+    return ReadCommand(static_cast<uint8_t>(kOpReadRegister | (reg & 0x3F)), value, 1);
+}
+
+esp_err_t StackChanNfc::WriteRegister(uint8_t reg, uint8_t value) {
+    return WriteCommand(reg & 0x3F, &value, 1);
+}
+
+esp_err_t StackChanNfc::WriteRegister16(uint8_t reg, uint16_t value) {
+    const uint8_t data[] = {
+        static_cast<uint8_t>(value >> 8),
+        static_cast<uint8_t>(value),
+    };
+    return WriteCommand(reg & 0x3F, data, sizeof(data));
+}
+
+esp_err_t StackChanNfc::ModifyRegister(uint8_t reg, uint8_t set_mask, uint8_t clear_mask) {
+    uint8_t value = 0;
+    esp_err_t err = ReadRegister(reg, &value);
+    if (err != ESP_OK) {
+        return err;
+    }
+    const uint8_t updated = static_cast<uint8_t>((value & ~clear_mask) | set_mask);
+    return updated == value ? ESP_OK : WriteRegister(reg, updated);
+}
+
+esp_err_t StackChanNfc::ClearInterrupts() {
+    // Reading MAIN clears the error register, so read ERROR first. Reading all
+    // sources is also how the official M5 driver acknowledges old IRQs.
+    uint8_t discard = 0;
+    esp_err_t err = ReadRegister(kRegErrorAndWakeupInterrupt, &discard);
+    if (err == ESP_OK) err = ReadRegister(kRegMainInterrupt, &discard);
+    if (err == ESP_OK) err = ReadRegister(kRegPassiveTargetInterrupt, &discard);
+    return err;
+}
+
+esp_err_t StackChanNfc::WaitForMainInterrupt(uint8_t mask, uint32_t timeout_ms,
+                                              uint8_t* observed) {
+    if (observed == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    *observed = 0;
+    const int64_t deadline_us = esp_timer_get_time() + static_cast<int64_t>(timeout_ms) * 1000;
+    while (esp_timer_get_time() <= deadline_us) {
+        uint8_t flags = 0;
+        esp_err_t err = ReadRegister(kRegMainInterrupt, &flags);
+        if (err != ESP_OK) {
+            return err;
+        }
+        *observed = static_cast<uint8_t>(*observed | flags);
+        if ((*observed & mask) != 0) {
+            return ESP_OK;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+    return ESP_ERR_TIMEOUT;
+}
+
+esp_err_t StackChanNfc::ReadFifo(uint8_t* data, size_t capacity, size_t* actual) {
+    if (data == nullptr || actual == nullptr || capacity == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    *actual = 0;
+    uint8_t status[2] = {};
+    esp_err_t err = ReadCommand(static_cast<uint8_t>(kOpReadRegister | kRegFifoStatus1),
+                                status, sizeof(status));
+    if (err != ESP_OK) {
+        return err;
+    }
+    const uint16_t packed = static_cast<uint16_t>(status[0]) << 8 | status[1];
+    const size_t count = static_cast<size_t>((packed >> 8) | ((packed & 0x00C0) << 2));
+    if (count == 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (count > kMaxFifoDepth || count > capacity) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    err = ReadCommand(kOpReadFifo, data, count);
+    if (err == ESP_OK) {
+        *actual = count;
+    }
+    return err;
+}
+
+esp_err_t StackChanNfc::Transmit(const uint8_t* data, size_t length, uint8_t bits,
+                                  bool append_crc) {
+    if (data == nullptr || length == 0 || length > kMaxFifoDepth || bits > 7) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_err_t err = ClearInterrupts();
+    if (err == ESP_OK) err = WriteCommand(kCommandClearFifo, nullptr, 0);
+    if (err == ESP_OK) err = WriteCommand(kOpLoadFifo, data, length);
+    if (err == ESP_OK) {
+        const uint16_t transmitted = static_cast<uint16_t>((length << 3) | bits);
+        err = WriteRegister16(kRegNumberOfTransmittedBytes1, transmitted);
+    }
+    if (err == ESP_OK) {
+        err = WriteCommand(append_crc ? kCommandTransmitWithCrc : kCommandTransmitWithoutCrc,
+                           nullptr, 0);
+    }
+    return err;
+}
+
+esp_err_t StackChanNfc::StartField() {
+    esp_err_t err = WriteCommand(kCommandInitialFieldOn, nullptr, 0);
+    if (err == ESP_OK) {
+        vTaskDelay(pdMS_TO_TICKS(5));
+        err = ModifyRegister(kRegOperationControl,
+                             kOperationEnableTransmit | kOperationEnableReceive, 0);
+    }
+    return err;
+}
+
+esp_err_t StackChanNfc::StopField() {
+    esp_err_t err = WriteCommand(kCommandStopAllActivities, nullptr, 0);
+    if (err == ESP_OK) {
+        err = ModifyRegister(kRegOperationControl, 0,
+                             kOperationEnableTransmit | kOperationEnableReceive);
+    }
+    return err;
+}
+
+esp_err_t StackChanNfc::InitializeLocked() {
+    Detach();
+    i2c_device_config_t config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = kSt25r3916Address,
+        .scl_speed_hz = 400000,
+        .scl_wait_us = 0,
+        .flags = {
+            .disable_ack_check = false,
+        },
+    };
+    esp_err_t err = i2c_master_bus_add_device(bus_, &config, &nfc_);
+    if (err != ESP_OK) {
+        return Fail("attach ST25R3916", err);
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(50));
+    uint8_t identity = 0;
+    err = ReadRegister(kRegIcIdentity, &identity);
+    if (err != ESP_OK) {
+        Detach();
+        return Fail("read ST25R3916 identity", err);
+    }
+    chip_type_ = static_cast<uint8_t>((identity >> 3) & 0x1F);
+    chip_revision_ = identity & 0x07;
+    if (chip_type_ != kSt25r3916ChipType || chip_revision_ == 0) {
+        Detach();
+        return Fail("validate ST25R3916 identity", ESP_ERR_NOT_FOUND);
+    }
+
+    // This power-up and ISO 14443A configuration mirrors the official
+    // M5Unit-NFC ST25R3916 driver, reduced to the polling path used here.
+    const uint8_t protection_command[] = {0x04, 0x10};
+    err = WriteCommand(kCommandStopAllActivities, nullptr, 0);
+    if (err == ESP_OK) err = WriteCommand(kCommandSetDefault, nullptr, 0);
+    if (err == ESP_OK) err = WriteCommand(kCommandTestAccess, protection_command,
+                                          sizeof(protection_command));
+    if (err == ESP_OK) err = WriteRegister(kRegIoConfig1, 0x10);  // 400 kHz I2C threshold
+    if (err == ESP_OK) err = WriteRegister(kRegIoConfig2, 0xA4);  // 3.3 V, AAT, high IO drive
+    if (err == ESP_OK) err = WriteRegister(kRegTxDriver, 0xD0);
+    if (err == ESP_OK) err = WriteRegister(kRegExternalFieldDetectorActivation, 0x13);
+    if (err == ESP_OK) err = WriteRegister(kRegExternalFieldDetectorDeactivation, 0x02);
+    if (err == ESP_OK) err = WriteRegister(kRegMaskMainInterrupt, 0x00);
+    if (err == ESP_OK) err = ClearInterrupts();
+    if (err == ESP_OK) err = ModifyRegister(kRegOperationControl, kOperationEnableOscillator, 0);
+    if (err == ESP_OK) {
+        const int64_t deadline_us = esp_timer_get_time() + 50000;
+        uint8_t auxiliary = 0;
+        do {
+            err = ReadRegister(kRegAuxiliaryDisplay, &auxiliary);
+            if (err != ESP_OK || (auxiliary & kAuxiliaryOscillatorReady) != 0) {
+                break;
+            }
+            vTaskDelay(pdMS_TO_TICKS(1));
+        } while (esp_timer_get_time() <= deadline_us);
+        if (err == ESP_OK && (auxiliary & kAuxiliaryOscillatorReady) == 0) {
+            err = ESP_ERR_TIMEOUT;
+        }
+    }
+    if (err == ESP_OK) err = WriteCommand(kCommandAdjustRegulators, nullptr, 0);
+    if (err == ESP_OK) vTaskDelay(pdMS_TO_TICKS(5));
+    if (err == ESP_OK) err = WriteRegister(kRegModeDefinition, 0x01);       // ISO 14443A initiator
+    if (err == ESP_OK) err = WriteRegister(kRegBitrateDefinition, 0x00);    // 106 kbps TX/RX
+    if (err == ESP_OK) err = WriteRegister(kRegIso14443aSettings, 0x00);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration1, 0x08);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration2, 0x2D);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration3, 0xD8);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration4, 0x22);
+    if (err == ESP_OK) err = WriteCommand(kCommandResetReceiverGain, nullptr, 0);
+    if (err != ESP_OK) {
+        Detach();
+        return Fail("configure ST25R3916", err);
+    }
+
+    initialized_ = true;
+    last_error_.clear();
+    ESP_LOGI(kTag, "ST25R3916 ready (type=0x%02X revision=0x%02X)",
+             chip_type_, chip_revision_);
+    return ESP_OK;
+}
+
+esp_err_t StackChanNfc::Initialize() {
+    if (mutex_ == nullptr || bus_ == nullptr) {
+        return Fail("initialize ST25R3916", ESP_ERR_INVALID_STATE);
+    }
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return Fail("lock ST25R3916", ESP_ERR_TIMEOUT);
+    }
+    const esp_err_t err = initialized_ ? ESP_OK : InitializeLocked();
+    xSemaphoreGive(mutex_);
+    return err;
+}
+
+esp_err_t StackChanNfc::RequestA(uint16_t* atqa, bool* collision_detected) {
+    if (atqa == nullptr || collision_detected == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    *atqa = 0;
+    *collision_detected = false;
+    esp_err_t err = WriteRegister(kRegIso14443aSettings, 0x01);  // anticollision frame
+    if (err == ESP_OK) err = ModifyRegister(kRegAuxiliaryDefinition, kAuxiliaryNoCrcReceive, 0);
+    if (err == ESP_OK) err = ClearInterrupts();
+    if (err == ESP_OK) err = WriteCommand(kCommandClearFifo, nullptr, 0);
+    if (err == ESP_OK) err = WriteCommand(kCommandTransmitReqa, nullptr, 0);
+    uint8_t irq = 0;
+    if (err == ESP_OK) err = WaitForMainInterrupt(kMainIrqReceiveEnd | kMainIrqCollision,
+                                                   kRequestTimeoutMs, &irq);
+    if (err == ESP_ERR_TIMEOUT) {
+        return ESP_ERR_NOT_FOUND;  // no tag is a successful empty scan
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+    if ((irq & kMainIrqCollision) != 0) {
+        *collision_detected = true;
+        return ESP_OK;
+    }
+    uint8_t response[2] = {};
+    size_t actual = 0;
+    err = ReadFifo(response, sizeof(response), &actual);
+    if (err != ESP_OK || actual != sizeof(response)) {
+        return err == ESP_OK ? ESP_ERR_INVALID_RESPONSE : err;
+    }
+    *atqa = static_cast<uint16_t>(response[1]) << 8 | response[0];
+    return ESP_OK;
+}
+
+esp_err_t StackChanNfc::SelectCascadeLevel(uint8_t cascade_level, uint8_t* uid_part,
+                                            size_t* uid_part_length, uint8_t* sak,
+                                            bool* collision_detected) {
+    if (cascade_level < 1 || cascade_level > 3 || uid_part == nullptr ||
+        uid_part_length == nullptr || sak == nullptr || collision_detected == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    *uid_part_length = 0;
+    *collision_detected = false;
+    const uint8_t select_code = static_cast<uint8_t>(0x91 + cascade_level * 2);
+    const uint8_t anticollision[] = {select_code, 0x20};
+
+    esp_err_t err = WriteRegister(kRegIso14443aSettings, 0x01);
+    if (err == ESP_OK) err = ModifyRegister(kRegAuxiliaryDefinition, 0, kAuxiliaryNoCrcReceive);
+    if (err == ESP_OK) err = Transmit(anticollision, sizeof(anticollision), 0, false);
+    uint8_t irq = 0;
+    if (err == ESP_OK) err = WaitForMainInterrupt(kMainIrqReceiveEnd | kMainIrqCollision,
+                                                   kCascadeTimeoutMs, &irq);
+    if (err != ESP_OK) {
+        return err;
+    }
+    if ((irq & kMainIrqCollision) != 0) {
+        *collision_detected = true;
+        return ESP_OK;
+    }
+
+    uint8_t anticollision_response[5] = {};
+    size_t actual = 0;
+    err = ReadFifo(anticollision_response, sizeof(anticollision_response), &actual);
+    if (err != ESP_OK || actual != sizeof(anticollision_response)) {
+        return err == ESP_OK ? ESP_ERR_INVALID_RESPONSE : err;
+    }
+    const uint8_t bcc = static_cast<uint8_t>(anticollision_response[0] ^ anticollision_response[1] ^
+                                             anticollision_response[2] ^ anticollision_response[3]);
+    if (bcc != anticollision_response[4]) {
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+    const bool has_cascade_tag = anticollision_response[0] == 0x88;
+    const size_t copied = has_cascade_tag ? 3 : 4;
+    std::memcpy(uid_part, anticollision_response + (has_cascade_tag ? 1 : 0), copied);
+    *uid_part_length = copied;
+
+    const uint8_t select_frame[] = {
+        select_code, 0x70,
+        anticollision_response[0], anticollision_response[1], anticollision_response[2],
+        anticollision_response[3], anticollision_response[4],
+    };
+    err = WriteRegister(kRegIso14443aSettings, 0x00);
+    if (err == ESP_OK) err = Transmit(select_frame, sizeof(select_frame), 0, true);
+    if (err == ESP_OK) err = WaitForMainInterrupt(kMainIrqReceiveEnd, kCascadeTimeoutMs, &irq);
+    if (err != ESP_OK) {
+        return err;
+    }
+    uint8_t select_response[3] = {};
+    err = ReadFifo(select_response, sizeof(select_response), &actual);
+    if (err != ESP_OK || actual < 1) {
+        return err == ESP_OK ? ESP_ERR_INVALID_RESPONSE : err;
+    }
+    *sak = select_response[0];
+    return ESP_OK;
+}
+
+esp_err_t StackChanNfc::Scan(StackChanNfcSnapshot* snapshot) {
+    if (snapshot == nullptr) {
+        return Fail("scan NFC", ESP_ERR_INVALID_ARG);
+    }
+    if (mutex_ == nullptr || bus_ == nullptr) {
+        return Fail("scan NFC", ESP_ERR_INVALID_STATE);
+    }
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return Fail("lock ST25R3916", ESP_ERR_TIMEOUT);
+    }
+
+    *snapshot = {};
+    esp_err_t err = initialized_ ? ESP_OK : InitializeLocked();
+    if (err == ESP_OK) err = StartField();
+    if (err == ESP_OK) {
+        err = RequestA(&snapshot->atqa, &snapshot->collision_detected);
+        if (err == ESP_ERR_NOT_FOUND) {
+            err = ESP_OK;
+        }
+    }
+
+    if (err == ESP_OK && !snapshot->collision_detected && snapshot->atqa != 0) {
+        bool more_cascade_levels = true;
+        for (uint8_t level = 1; level <= 3 && more_cascade_levels; ++level) {
+            uint8_t part[4] = {};
+            size_t part_length = 0;
+            bool collision = false;
+            err = SelectCascadeLevel(level, part, &part_length, &snapshot->sak, &collision);
+            if (err != ESP_OK || collision || snapshot->uid_length + part_length > sizeof(snapshot->uid)) {
+                snapshot->collision_detected = collision;
+                break;
+            }
+            std::memcpy(snapshot->uid + snapshot->uid_length, part, part_length);
+            snapshot->uid_length += part_length;
+            more_cascade_levels = (snapshot->sak & 0x04) != 0;
+            if (!more_cascade_levels) {
+                snapshot->tag_present = true;
+            }
+        }
+        if (err == ESP_OK && !snapshot->collision_detected && !snapshot->tag_present) {
+            err = ESP_ERR_INVALID_RESPONSE;
+        }
+    }
+
+    const esp_err_t stop_err = StopField();
+    if (err == ESP_OK && stop_err != ESP_OK) {
+        err = stop_err;
+    }
+    if (err == ESP_OK) {
+        snapshot->chip_type = chip_type_;
+        snapshot->chip_revision = chip_revision_;
+        snapshot->sample_time_us = esp_timer_get_time();
+        last_error_.clear();
+    }
+    xSemaphoreGive(mutex_);
+    return err == ESP_OK ? ESP_OK : Fail("scan NFC", err);
+}

--- a/firmware/main/boards/stackchan/stackchan_nfc.cc
+++ b/firmware/main/boards/stackchan/stackchan_nfc.cc
@@ -35,6 +35,7 @@ constexpr uint8_t kRegNoResponseTimer1 = 0x10;
 constexpr uint8_t kRegTimerAndEmvControl = 0x12;
 constexpr uint8_t kRegMaskMainInterrupt = 0x16;
 constexpr uint8_t kRegMainInterrupt = 0x1A;
+constexpr uint8_t kRegTimerAndNfcInterrupt = 0x1B;
 constexpr uint8_t kRegErrorAndWakeupInterrupt = 0x1C;
 constexpr uint8_t kRegPassiveTargetInterrupt = 0x1D;
 constexpr uint8_t kRegFifoStatus1 = 0x1E;
@@ -199,6 +200,7 @@ esp_err_t StackChanNfc::ClearInterrupts() {
     uint8_t discard = 0;
     esp_err_t err = ReadRegister(kRegErrorAndWakeupInterrupt, &discard);
     if (err == ESP_OK) err = ReadRegister(kRegMainInterrupt, &discard);
+    if (err == ESP_OK) err = ReadRegister(kRegTimerAndNfcInterrupt, &discard);
     if (err == ESP_OK) err = ReadRegister(kRegPassiveTargetInterrupt, &discard);
     return err;
 }

--- a/firmware/main/boards/stackchan/stackchan_nfc.cc
+++ b/firmware/main/boards/stackchan/stackchan_nfc.cc
@@ -31,6 +31,8 @@ constexpr uint8_t kRegReceiverConfiguration1 = 0x0B;
 constexpr uint8_t kRegReceiverConfiguration2 = 0x0C;
 constexpr uint8_t kRegReceiverConfiguration3 = 0x0D;
 constexpr uint8_t kRegReceiverConfiguration4 = 0x0E;
+constexpr uint8_t kRegNoResponseTimer1 = 0x10;
+constexpr uint8_t kRegTimerAndEmvControl = 0x12;
 constexpr uint8_t kRegMaskMainInterrupt = 0x16;
 constexpr uint8_t kRegMainInterrupt = 0x1A;
 constexpr uint8_t kRegErrorAndWakeupInterrupt = 0x1C;
@@ -52,6 +54,7 @@ constexpr uint8_t kCommandInitialFieldOn = 0xC8;
 constexpr uint8_t kCommandResetReceiverGain = 0xD5;
 constexpr uint8_t kCommandAdjustRegulators = 0xD6;
 constexpr uint8_t kCommandClearFifo = 0xDB;
+constexpr uint8_t kCommandRegisterSpaceBAccess = 0xFB;
 constexpr uint8_t kCommandTestAccess = 0xFC;
 
 constexpr uint8_t kOpReadRegister = 0x40;
@@ -63,12 +66,14 @@ constexpr uint8_t kOperationEnableReceive = 0x40;
 constexpr uint8_t kOperationEnableTransmit = 0x08;
 constexpr uint8_t kAuxiliaryNoCrcReceive = 0x80;
 constexpr uint8_t kMainIrqReceiveEnd = 0x10;
+constexpr uint8_t kMainIrqTransmitEnd = 0x08;
 constexpr uint8_t kMainIrqCollision = 0x04;
 constexpr uint8_t kAuxiliaryOscillatorReady = 0x10;
 
 constexpr int kI2cTimeoutMs = 100;
 constexpr uint32_t kRequestTimeoutMs = 15;
 constexpr uint32_t kCascadeTimeoutMs = 20;
+constexpr uint32_t kNfcFPollTimeoutMs = 15;
 constexpr size_t kMaxFifoDepth = 512;
 
 }  // namespace
@@ -146,6 +151,18 @@ esp_err_t StackChanNfc::WriteRegister16(uint8_t reg, uint16_t value) {
     return WriteCommand(reg & 0x3F, data, sizeof(data));
 }
 
+esp_err_t StackChanNfc::WriteSpaceBRegister(uint8_t reg, uint8_t value) {
+    // ST25R3916 requires the Register Space-B access direct command before
+    // the normal register-write opcode. This is a single I2C frame:
+    // [0xFB, register, value].
+    const uint8_t buffer[] = {
+        kCommandRegisterSpaceBAccess,
+        static_cast<uint8_t>(reg & 0x3F),
+        value,
+    };
+    return i2c_master_transmit(nfc_, buffer, sizeof(buffer), kI2cTimeoutMs);
+}
+
 esp_err_t StackChanNfc::ModifyRegister(uint8_t reg, uint8_t set_mask, uint8_t clear_mask) {
     uint8_t value = 0;
     esp_err_t err = ReadRegister(reg, &value);
@@ -154,6 +171,26 @@ esp_err_t StackChanNfc::ModifyRegister(uint8_t reg, uint8_t set_mask, uint8_t cl
     }
     const uint8_t updated = static_cast<uint8_t>((value & ~clear_mask) | set_mask);
     return updated == value ? ESP_OK : WriteRegister(reg, updated);
+}
+
+esp_err_t StackChanNfc::SetNoResponseTimerMs(uint32_t timeout_ms) {
+    uint8_t timer_control = 0;
+    esp_err_t err = ReadRegister(kRegTimerAndEmvControl, &timer_control);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    const uint32_t step_cycles = (timer_control & 0x01) != 0 ? 4096 : 64;
+    const uint64_t numerator = static_cast<uint64_t>(timeout_ms) * 1000u * 13560000u;
+    const uint64_t denominator = static_cast<uint64_t>(step_cycles) * 1000000u;
+    uint64_t nrt = (numerator + denominator - 1) / denominator;
+    if (nrt == 0) {
+        nrt = 1;
+    }
+    if (nrt > 0xFFFFu) {
+        nrt = 0xFFFFu;
+    }
+    return WriteRegister16(kRegNoResponseTimer1, static_cast<uint16_t>(nrt));
 }
 
 esp_err_t StackChanNfc::ClearInterrupts() {
@@ -252,6 +289,44 @@ esp_err_t StackChanNfc::StopField() {
     return err;
 }
 
+esp_err_t StackChanNfc::ConfigureIso14443A() {
+    // Mirrors UnitST25R3916::configure_nfc_a().  0x09 is initiator
+    // ISO14443A with automatic 106 kbps rate selection; 0x01 alone only
+    // carries the automatic-rate bit and leaves the protocol mode unset.
+    esp_err_t err = WriteRegister(kRegModeDefinition, 0x09);
+    if (err == ESP_OK) err = WriteRegister(kRegBitrateDefinition, 0x00);
+    if (err == ESP_OK) err = WriteRegister(kRegIso14443aSettings, 0x00);
+    if (err == ESP_OK) err = WriteRegister(kRegIoConfig1, 0x10);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration1, 0x08);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration2, 0x2D);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration3, 0xD8);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration4, 0x22);
+    if (err == ESP_OK) err = WriteRegister(kRegMaskMainInterrupt, 0x00);
+    if (err == ESP_OK) err = ClearInterrupts();
+    if (err == ESP_OK) err = WriteCommand(kCommandResetReceiverGain, nullptr, 0);
+    return err;
+}
+
+esp_err_t StackChanNfc::ConfigureNfcF() {
+    // Mirrors M5UnitUnified's ST25R3916 NFC-F (FeliCa) profile.  This
+    // supports SENSF polling only; it does not issue service, read, write,
+    // authentication, or emulation commands.
+    esp_err_t err = WriteRegister(kRegModeDefinition, 0x1C);  // FeliCa initiator, TR_AM
+    if (err == ESP_OK) err = WriteRegister(kRegBitrateDefinition, 0x11);  // 212 kbps TX/RX
+    if (err == ESP_OK) err = ModifyRegister(kRegOperationControl, 0x03, 0x00);
+    if (err == ESP_OK) err = WriteRegister(kRegIoConfig1, 0x07);
+    if (err == ESP_OK) err = WriteRegister(kRegAuxiliaryDefinition, 0x00);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration1, 0x13);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration2, 0x3D);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration3, 0x00);
+    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration4, 0x00);
+    if (err == ESP_OK) err = WriteSpaceBRegister(0x0C, 0x54);  // correlator 1
+    if (err == ESP_OK) err = WriteSpaceBRegister(0x0D, 0x00);  // correlator 2
+    if (err == ESP_OK) err = WriteRegister(kRegMaskMainInterrupt, 0x00);
+    if (err == ESP_OK) err = ClearInterrupts();
+    return err;
+}
+
 esp_err_t StackChanNfc::InitializeLocked() {
     Detach();
     i2c_device_config_t config = {
@@ -313,14 +388,7 @@ esp_err_t StackChanNfc::InitializeLocked() {
     }
     if (err == ESP_OK) err = WriteCommand(kCommandAdjustRegulators, nullptr, 0);
     if (err == ESP_OK) vTaskDelay(pdMS_TO_TICKS(5));
-    if (err == ESP_OK) err = WriteRegister(kRegModeDefinition, 0x01);       // ISO 14443A initiator
-    if (err == ESP_OK) err = WriteRegister(kRegBitrateDefinition, 0x00);    // 106 kbps TX/RX
-    if (err == ESP_OK) err = WriteRegister(kRegIso14443aSettings, 0x00);
-    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration1, 0x08);
-    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration2, 0x2D);
-    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration3, 0xD8);
-    if (err == ESP_OK) err = WriteRegister(kRegReceiverConfiguration4, 0x22);
-    if (err == ESP_OK) err = WriteCommand(kCommandResetReceiverGain, nullptr, 0);
+    if (err == ESP_OK) err = ConfigureIso14443A();
     if (err != ESP_OK) {
         Detach();
         return Fail("configure ST25R3916", err);
@@ -376,6 +444,52 @@ esp_err_t StackChanNfc::RequestA(uint16_t* atqa, bool* collision_detected) {
         return err == ESP_OK ? ESP_ERR_INVALID_RESPONSE : err;
     }
     *atqa = static_cast<uint16_t>(response[1]) << 8 | response[0];
+    return ESP_OK;
+}
+
+esp_err_t StackChanNfc::PollNfcF(StackChanNfcSnapshot* snapshot) {
+    if (snapshot == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // SENSF_REQ: polling command, wildcard system code, no extra request
+    // data, one response slot. The ST25R3916 calculates the NFC-F frame
+    // length from NUMBER_OF_TRANSMITTED_BYTES, so the command byte is first.
+    const uint8_t polling_frame[] = {0x00, 0xFF, 0xFF, 0x00, 0x00};
+    esp_err_t err = SetNoResponseTimerMs(kNfcFPollTimeoutMs);
+    if (err == ESP_OK) err = Transmit(polling_frame, sizeof(polling_frame), 0, true);
+
+    uint8_t irq = 0;
+    if (err == ESP_OK) {
+        err = WaitForMainInterrupt(kMainIrqTransmitEnd, kNfcFPollTimeoutMs, &irq);
+    }
+    // A very close tag can answer before the first interrupt poll. Preserve a
+    // receive-end flag observed together with transmit-end rather than
+    // clearing it in a second read of the clear-on-read MAIN register.
+    if (err == ESP_OK && (irq & kMainIrqReceiveEnd) == 0) {
+        err = WaitForMainInterrupt(kMainIrqReceiveEnd, kNfcFPollTimeoutMs, &irq);
+    }
+    if (err == ESP_ERR_TIMEOUT) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    uint8_t response[18] = {};
+    size_t actual = 0;
+    err = ReadFifo(response, sizeof(response), &actual);
+    if (err != ESP_OK) {
+        return err;
+    }
+    if (actual != sizeof(response) || response[0] < sizeof(response) || response[1] != 0x01) {
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    std::memcpy(snapshot->idm, response + 2, sizeof(snapshot->idm));
+    std::memcpy(snapshot->pmm, response + 10, sizeof(snapshot->pmm));
+    snapshot->protocol = StackChanNfcProtocol::kNfcF;
+    snapshot->tag_present = true;
     return ESP_OK;
 }
 
@@ -454,7 +568,12 @@ esp_err_t StackChanNfc::Scan(StackChanNfcSnapshot* snapshot) {
 
     *snapshot = {};
     esp_err_t err = initialized_ ? ESP_OK : InitializeLocked();
-    if (err == ESP_OK) err = StartField();
+    bool field_started = false;
+    if (err == ESP_OK) err = ConfigureIso14443A();
+    if (err == ESP_OK) {
+        err = StartField();
+        field_started = err == ESP_OK;
+    }
     if (err == ESP_OK) {
         err = RequestA(&snapshot->atqa, &snapshot->collision_detected);
         if (err == ESP_ERR_NOT_FOUND) {
@@ -478,6 +597,7 @@ esp_err_t StackChanNfc::Scan(StackChanNfcSnapshot* snapshot) {
             more_cascade_levels = (snapshot->sak & 0x04) != 0;
             if (!more_cascade_levels) {
                 snapshot->tag_present = true;
+                snapshot->protocol = StackChanNfcProtocol::kIso14443A;
             }
         }
         if (err == ESP_OK && !snapshot->collision_detected && !snapshot->tag_present) {
@@ -485,9 +605,34 @@ esp_err_t StackChanNfc::Scan(StackChanNfcSnapshot* snapshot) {
         }
     }
 
-    const esp_err_t stop_err = StopField();
-    if (err == ESP_OK && stop_err != ESP_OK) {
-        err = stop_err;
+    // Suica and other FeliCa cards are NFC-F, not ISO 14443A. When no A tag
+    // answered, switch profiles and perform one SENSF wildcard poll.
+    if (err == ESP_OK && !snapshot->collision_detected && snapshot->atqa == 0) {
+        if (field_started) {
+            const esp_err_t stop_err = StopField();
+            field_started = false;
+            if (stop_err != ESP_OK) {
+                err = stop_err;
+            }
+        }
+        if (err == ESP_OK) err = ConfigureNfcF();
+        if (err == ESP_OK) {
+            err = StartField();
+            field_started = err == ESP_OK;
+        }
+        if (err == ESP_OK) {
+            err = PollNfcF(snapshot);
+            if (err == ESP_ERR_NOT_FOUND) {
+                err = ESP_OK;
+            }
+        }
+    }
+
+    if (field_started) {
+        const esp_err_t stop_err = StopField();
+        if (err == ESP_OK && stop_err != ESP_OK) {
+            err = stop_err;
+        }
     }
     if (err == ESP_OK) {
         snapshot->chip_type = chip_type_;

--- a/firmware/main/boards/stackchan/stackchan_nfc.h
+++ b/firmware/main/boards/stackchan/stackchan_nfc.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 StackChan contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <driver/i2c_master.h>
+#include <esp_err.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+struct StackChanNfcSnapshot {
+    bool tag_present = false;
+    bool collision_detected = false;
+    uint16_t atqa = 0;
+    uint8_t sak = 0;
+    uint8_t uid[10] = {};
+    size_t uid_length = 0;
+    uint8_t chip_type = 0;
+    uint8_t chip_revision = 0;
+    int64_t sample_time_us = 0;
+};
+
+// Minimal ISO 14443A polling driver for StackChan's body-mounted ST25R3916.
+// It detects a single tag and exposes only its UID/classification bytes. It
+// deliberately contains no tag memory reads/writes, authentication, or card
+// emulation APIs.
+class StackChanNfc {
+public:
+    explicit StackChanNfc(i2c_master_bus_handle_t bus);
+    ~StackChanNfc();
+
+    StackChanNfc(const StackChanNfc&) = delete;
+    StackChanNfc& operator=(const StackChanNfc&) = delete;
+
+    esp_err_t Initialize();
+    esp_err_t Scan(StackChanNfcSnapshot* snapshot);
+    const std::string& last_error() const { return last_error_; }
+
+private:
+    esp_err_t InitializeLocked();
+    esp_err_t StartField();
+    esp_err_t StopField();
+    esp_err_t RequestA(uint16_t* atqa, bool* collision_detected);
+    esp_err_t SelectCascadeLevel(uint8_t cascade_level, uint8_t* uid_part,
+                                 size_t* uid_part_length, uint8_t* sak,
+                                 bool* collision_detected);
+    esp_err_t Transmit(const uint8_t* data, size_t length, uint8_t bits,
+                       bool append_crc);
+    esp_err_t ReadFifo(uint8_t* data, size_t capacity, size_t* actual);
+    esp_err_t WaitForMainInterrupt(uint8_t mask, uint32_t timeout_ms,
+                                   uint8_t* observed);
+    esp_err_t ReadCommand(uint8_t command, uint8_t* data, size_t length);
+    esp_err_t WriteCommand(uint8_t command, const uint8_t* data, size_t length);
+    esp_err_t ReadRegister(uint8_t reg, uint8_t* value);
+    esp_err_t WriteRegister(uint8_t reg, uint8_t value);
+    esp_err_t WriteRegister16(uint8_t reg, uint16_t value);
+    esp_err_t ModifyRegister(uint8_t reg, uint8_t set_mask, uint8_t clear_mask);
+    esp_err_t ClearInterrupts();
+    esp_err_t Fail(const char* operation, esp_err_t err);
+    void Detach();
+
+    i2c_master_bus_handle_t bus_ = nullptr;
+    i2c_master_dev_handle_t nfc_ = nullptr;
+    SemaphoreHandle_t mutex_ = nullptr;
+    bool initialized_ = false;
+    uint8_t chip_type_ = 0;
+    uint8_t chip_revision_ = 0;
+    std::string last_error_;
+};

--- a/firmware/main/boards/stackchan/stackchan_nfc.h
+++ b/firmware/main/boards/stackchan/stackchan_nfc.h
@@ -15,22 +15,31 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
+enum class StackChanNfcProtocol : uint8_t {
+    kNone,
+    kIso14443A,
+    kNfcF,
+};
+
 struct StackChanNfcSnapshot {
     bool tag_present = false;
     bool collision_detected = false;
+    StackChanNfcProtocol protocol = StackChanNfcProtocol::kNone;
     uint16_t atqa = 0;
     uint8_t sak = 0;
     uint8_t uid[10] = {};
     size_t uid_length = 0;
+    uint8_t idm[8] = {};
+    uint8_t pmm[8] = {};
     uint8_t chip_type = 0;
     uint8_t chip_revision = 0;
     int64_t sample_time_us = 0;
 };
 
-// Minimal ISO 14443A polling driver for StackChan's body-mounted ST25R3916.
-// It detects a single tag and exposes only its UID/classification bytes. It
-// deliberately contains no tag memory reads/writes, authentication, or card
-// emulation APIs.
+// Minimal ISO 14443A and NFC-F polling driver for StackChan's body-mounted
+// ST25R3916. It detects a single tag and exposes only its identifier metadata.
+// It deliberately contains no tag memory reads/writes, authentication, or
+// card emulation APIs.
 class StackChanNfc {
 public:
     explicit StackChanNfc(i2c_master_bus_handle_t bus);
@@ -45,12 +54,15 @@ public:
 
 private:
     esp_err_t InitializeLocked();
+    esp_err_t ConfigureIso14443A();
+    esp_err_t ConfigureNfcF();
     esp_err_t StartField();
     esp_err_t StopField();
     esp_err_t RequestA(uint16_t* atqa, bool* collision_detected);
     esp_err_t SelectCascadeLevel(uint8_t cascade_level, uint8_t* uid_part,
                                  size_t* uid_part_length, uint8_t* sak,
                                  bool* collision_detected);
+    esp_err_t PollNfcF(StackChanNfcSnapshot* snapshot);
     esp_err_t Transmit(const uint8_t* data, size_t length, uint8_t bits,
                        bool append_crc);
     esp_err_t ReadFifo(uint8_t* data, size_t capacity, size_t* actual);
@@ -61,7 +73,9 @@ private:
     esp_err_t ReadRegister(uint8_t reg, uint8_t* value);
     esp_err_t WriteRegister(uint8_t reg, uint8_t value);
     esp_err_t WriteRegister16(uint8_t reg, uint16_t value);
+    esp_err_t WriteSpaceBRegister(uint8_t reg, uint8_t value);
     esp_err_t ModifyRegister(uint8_t reg, uint8_t set_mask, uint8_t clear_mask);
+    esp_err_t SetNoResponseTimerMs(uint32_t timeout_ms);
     esp_err_t ClearInterrupts();
     esp_err_t Fail(const char* operation, esp_err_t err);
     void Detach();

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -179,7 +179,7 @@ Same shape, under `mcpServers`.
 | `get_head_angles` | Read current yaw + pitch servo angles |
 | `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot in g / degrees per second / microtesla, with raw samples and data-ready flags |
 | `read_environment` | Read one on-board LTR-553ALS-WA ambient-light/proximity snapshot in raw ADC counts, with data-ready/valid/saturation flags |
-| `scan_nfc` | Scan one ISO 14443A tag with the body ST25R3916 reader; returns UID / ATQA / SAK only, without tag-memory access or emulation |
+| `scan_nfc` | Scan one ISO 14443A or NFC-F (FeliCa) tag with the body ST25R3916 reader; returns UID / ATQA / SAK for ISO 14443A or IDm / PMm for NFC-F, without tag-memory access or emulation |
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are visible. A subsequent `set_avatar(<other face>)` brings it back and restores blink. |
 | `set_blink(state)` | Blink animation on/off |

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -178,6 +178,7 @@ Same shape, under `mcpServers`.
 | `move_head(yaw, pitch, speed?)` | Drive yaw + pitch servos |
 | `get_head_angles` | Read current yaw + pitch servo angles |
 | `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot in g / degrees per second / microtesla, with raw samples and data-ready flags |
+| `read_environment` | Read one on-board LTR-553ALS-WA ambient-light/proximity snapshot in raw ADC counts, with data-ready/valid/saturation flags |
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are visible. A subsequent `set_avatar(<other face>)` brings it back and restores blink. |
 | `set_blink(state)` | Blink animation on/off |

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -179,6 +179,7 @@ Same shape, under `mcpServers`.
 | `get_head_angles` | Read current yaw + pitch servo angles |
 | `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot in g / degrees per second / microtesla, with raw samples and data-ready flags |
 | `read_environment` | Read one on-board LTR-553ALS-WA ambient-light/proximity snapshot in raw ADC counts, with data-ready/valid/saturation flags |
+| `scan_nfc` | Scan one ISO 14443A tag with the body ST25R3916 reader; returns UID / ATQA / SAK only, without tag-memory access or emulation |
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are visible. A subsequent `set_avatar(<other face>)` brings it back and restores blink. |
 | `set_blink(state)` | Blink animation on/off |

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -177,6 +177,7 @@ Same shape, under `mcpServers`.
 | `set_brightness(brightness)` | Screen brightness 0-100 |
 | `move_head(yaw, pitch, speed?)` | Drive yaw + pitch servos |
 | `get_head_angles` | Read current yaw + pitch servo angles |
+| `read_imu` | Read one on-board BMI270 + BMM150 9-axis snapshot in g / degrees per second / microtesla, with raw samples and data-ready flags |
 | `get_touch_state` | Touch sensor state (press/release/stroke) |
 | `set_avatar(face)` | Switch avatar expression (`idle` / `happy` / `thinking` / `sad` / `surprised` / `embarrassed`), or `off` to hide the avatar and disable blink so the underlying xiaozhi-esp32 screens (WiFi config UI, OTA, settings) are visible. A subsequent `set_avatar(<other face>)` brings it back and restores blink. |
 | `set_blink(state)` | Blink animation on/off |

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1045,6 +1045,10 @@ async def _dispatch_mcp_tool(
             "self.robot.get_head_angles",
             {},
         ),
+        "read_imu": (
+            "self.imu.read",
+            {},
+        ),
         "gpio_test": (
             "self.robot.gpio_test",
             {},
@@ -1572,6 +1576,19 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "type": "object",
                     "properties": {},
                 },
+            ),
+            Tool(
+                name="read_imu",
+                description=(
+                    "Read one 9-axis snapshot from the robot's on-board BMI270 "
+                    "accelerometer/gyroscope and BMM150 magnetometer. Returns "
+                    "acceleration in g, angular velocity in degrees per second, "
+                    "magnetic field in microtesla, signed raw values, data-ready "
+                    "flags, and a monotonic sample timestamp. The magnetometer can "
+                    "be distorted by the nearby servos and is best used as an "
+                    "availability/change signal unless calibrated in place."
+                ),
+                inputSchema={"type": "object", "properties": {}},
             ),
             Tool(
                 name="gpio_test",

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1053,6 +1053,10 @@ async def _dispatch_mcp_tool(
             "self.environment.read",
             {},
         ),
+        "scan_nfc": (
+            "self.nfc.scan",
+            {},
+        ),
         "gpio_test": (
             "self.robot.gpio_test",
             {},
@@ -1602,6 +1606,17 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "channels plus the proximity ADC value in raw counts, with "
                     "data-ready, validity, and saturation flags. This is a "
                     "single read; it does not start a monitoring stream."
+                ),
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="scan_nfc",
+                description=(
+                    "Scan once for one ISO 14443A NFC tag with the robot's "
+                    "body-mounted ST25R3916 reader. Returns a detected UID, "
+                    "ATQA, SAK, or a collision indication. It never reads or "
+                    "writes tag memory, authenticates, emulates a card, or "
+                    "keeps the RF field enabled after the scan."
                 ),
                 inputSchema={"type": "object", "properties": {}},
             ),

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1612,11 +1612,12 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
             Tool(
                 name="scan_nfc",
                 description=(
-                    "Scan once for one ISO 14443A NFC tag with the robot's "
-                    "body-mounted ST25R3916 reader. Returns a detected UID, "
-                    "ATQA, SAK, or a collision indication. It never reads or "
-                    "writes tag memory, authenticates, emulates a card, or "
-                    "keeps the RF field enabled after the scan."
+                    "Scan once for one ISO 14443A or NFC-F (FeliCa) tag with "
+                    "the robot's body-mounted ST25R3916 reader. Returns UID, "
+                    "ATQA, and SAK for ISO 14443A, or IDm and PMm for NFC-F. "
+                    "It never reads or writes tag memory, authenticates, "
+                    "emulates a card, or keeps the RF field enabled after "
+                    "the scan."
                 ),
                 inputSchema={"type": "object", "properties": {}},
             ),

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1049,6 +1049,10 @@ async def _dispatch_mcp_tool(
             "self.imu.read",
             {},
         ),
+        "read_environment": (
+            "self.environment.read",
+            {},
+        ),
         "gpio_test": (
             "self.robot.gpio_test",
             {},
@@ -1587,6 +1591,17 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "flags, and a monotonic sample timestamp. The magnetometer can "
                     "be distorted by the nearby servos and is best used as an "
                     "availability/change signal unless calibrated in place."
+                ),
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="read_environment",
+                description=(
+                    "Read one LTR-553ALS-WA ambient-light and proximity snapshot. "
+                    "Returns the visible-plus-IR and IR-only ambient-light ADC "
+                    "channels plus the proximity ADC value in raw counts, with "
+                    "data-ready, validity, and saturation flags. This is a "
+                    "single read; it does not start a monitoring stream."
                 ),
                 inputSchema={"type": "object", "properties": {}},
             ),

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -204,6 +204,53 @@ async def test_read_environment_is_exposed_and_relays_to_esp32(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_scan_nfc_is_exposed_and_relays_to_esp32(monkeypatch):
+    """scan_nfc is parameterless and maps to the safe NFC firmware tool."""
+    calls = []
+    payload = {
+        "ok": True,
+        "sensor": "ST25R3916",
+        "tag": {"present": True, "uid": "04A1B2C3", "sak": 0},
+    }
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(payload),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    listed = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+    tools = {tool.name: tool for tool in listed.root.tools}
+    assert tools["scan_nfc"].inputSchema == {"type": "object", "properties": {}}
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "scan_nfc", "arguments": {}},
+        )
+    )
+
+    assert calls == [("self.nfc.scan", {})]
+    assert json.loads(result.root.content[0].text) == payload
+
+
+@pytest.mark.asyncio
 async def test_list_tools_includes_gateway_config_tools():
     """gateway_config_get/set are exposed with the expected schemas."""
     server = create_server()

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -205,12 +205,12 @@ async def test_read_environment_is_exposed_and_relays_to_esp32(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_scan_nfc_is_exposed_and_relays_to_esp32(monkeypatch):
-    """scan_nfc is parameterless and maps to the safe NFC firmware tool."""
+    """scan_nfc relays NFC-F identifier metadata without transforming it."""
     calls = []
     payload = {
         "ok": True,
         "sensor": "ST25R3916",
-        "tag": {"present": True, "uid": "04A1B2C3", "sak": 0},
+        "tag": {"present": True, "protocol": "NFC-F", "idm": "0123456789ABCDEF", "pmm": "0011223344556677"},
     }
 
     class FakeESP32:
@@ -238,6 +238,7 @@ async def test_scan_nfc_is_exposed_and_relays_to_esp32(monkeypatch):
     )
     tools = {tool.name: tool for tool in listed.root.tools}
     assert tools["scan_nfc"].inputSchema == {"type": "object", "properties": {}}
+    assert "FeliCa" in tools["scan_nfc"].description
 
     result = await server.request_handlers[CallToolRequest](
         CallToolRequest(

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -108,6 +108,54 @@ async def test_get_head_angles_relays_to_esp32(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_read_imu_is_exposed_and_relays_to_esp32(monkeypatch):
+    """read_imu is parameterless and maps to the dedicated firmware tool."""
+    calls = []
+    payload = {
+        "ok": True,
+        "accel_g": {"x": 0.01, "y": -0.02, "z": -0.99},
+        "gyro_dps": {"x": 0.1, "y": 0.2, "z": 0.3},
+        "mag_ut": {"x": 12.0, "y": -4.0, "z": 31.0},
+    }
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(payload),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    listed = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+    tools = {tool.name: tool for tool in listed.root.tools}
+    assert tools["read_imu"].inputSchema == {"type": "object", "properties": {}}
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "read_imu", "arguments": {}},
+        )
+    )
+
+    assert calls == [("self.imu.read", {})]
+    assert json.loads(result.root.content[0].text) == payload
+
+
+@pytest.mark.asyncio
 async def test_list_tools_includes_gateway_config_tools():
     """gateway_config_get/set are exposed with the expected schemas."""
     server = create_server()

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -156,6 +156,54 @@ async def test_read_imu_is_exposed_and_relays_to_esp32(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_read_environment_is_exposed_and_relays_to_esp32(monkeypatch):
+    """read_environment is parameterless and maps to the LTR-553 tool."""
+    calls = []
+    payload = {
+        "ok": True,
+        "sensor": "LTR-553ALS-WA",
+        "ambient_light": {"channel0_visible_ir": 321, "channel1_ir": 45},
+        "proximity": {"raw": 76},
+    }
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(payload),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    listed = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+    tools = {tool.name: tool for tool in listed.root.tools}
+    assert tools["read_environment"].inputSchema == {"type": "object", "properties": {}}
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={"name": "read_environment", "arguments": {}},
+        )
+    )
+
+    assert calls == [("self.environment.read", {})]
+    assert json.loads(result.root.content[0].text) == payload
+
+
+@pytest.mark.asyncio
 async def test_list_tools_includes_gateway_config_tools():
     """gateway_config_get/set are exposed with the expected schemas."""
     server = create_server()


### PR DESCRIPTION
## What changed

- Add `self.imu.read` for a BMI270 + BMM150 9-axis snapshot.
- Add `self.environment.read` for one LTR-553ALS-WA ambient-light/proximity snapshot.
- Add `self.nfc.scan` for one body-mounted ST25R3916 ISO 14443A UID scan.
- Expose the firmware tools as parameterless gateway tools: `read_imu`, `read_environment`, and `scan_nfc`.
- Document all three tools and add gateway relay tests.

## Safety and scope

The CoreS3 and body peripherals share safety-critical internal I2C buses, so no generic internal-bus read/write tool is exposed.

- IMU returns physical units plus raw samples and data-ready metadata.
- LTR-553 returns its two ambient-light ADC channels and proximity ADC count with ready/valid/saturation flags; it does not start a monitoring stream.
- NFC enables its RF field only for the explicit scan and turns it off afterward. It returns UID / ATQA / SAK only: no tag-memory read/write, authentication, or emulation. UID bytes are not written to firmware logs.

## Validation

- `pytest tests/test_stdio_server.py -q` — 93 passed
- `ruff check stackchan_mcp tests/test_stdio_server.py` — passed
- Previous LTR-553 head commit completed the repository CI, including the fixed `espressif/idf:v5.5.2` firmware build.
- The same CI is running for the NFC head commit.