### PR TITLE
feat(firmware/stackchan): add Port C (GPIO17) WS2812 generic MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ documented-only.
   subscriber for driving the base ring or a Port B WS2812 strip from external
   `event` / `continuous` color frames. (#335)
 
+### Firmware
+
+- Added `self.port_c.ws2812.{init,set_pixel,set_strip,refresh,clear}` for a
+  WS2812-compatible strip on Grove Port C signal 1 (GPIO 17). (#340)
+
 ## [0.15.0] - 2026-07-09
 
 ### Gateway

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -520,6 +520,12 @@ private:
     led_strip_handle_t ws2812_handle_ = nullptr;
     static constexpr gpio_num_t PORT_B_WS2812_DATA_PIN = GPIO_NUM_9;  // CoreS3 HY2.0-4P (Port B) digital OUTPUT
     static constexpr uint16_t PORT_B_WS2812_MAX_LEDS = 256;
+    // Port C WS2812 generic strip state (driven from MCP tools self.port_c.ws2812.*).
+    bool port_c_ws2812_ok_ = false;
+    uint16_t port_c_ws2812_led_count_ = 0;
+    led_strip_handle_t port_c_ws2812_handle_ = nullptr;
+    static constexpr gpio_num_t PORT_C_WS2812_DATA_PIN = GPIO_NUM_17;  // CoreS3 HY2.0-4P (Port C) signal 1
+    static constexpr uint16_t PORT_C_WS2812_MAX_LEDS = 256;
     Pmic* pmic_;
     Aw9523* aw9523_;
     Ft6336* ft6336_;
@@ -2216,6 +2222,55 @@ private:
         ws2812_ok_ = true;
         ESP_LOGI(TAG, "port_b.ws2812 initialized: %u LEDs on GPIO %d",
                  (unsigned)led_count, (int)PORT_B_WS2812_DATA_PIN);
+        return ESP_OK;
+    }
+
+    esp_err_t InitPortCWs2812(uint16_t led_count) {
+        if (port_c_ws2812_ok_ && port_c_ws2812_led_count_ == led_count) {
+            return ESP_OK;  // idempotent: same led_count is a no-op
+        }
+        if (port_c_ws2812_handle_ != nullptr) {
+            led_strip_del(port_c_ws2812_handle_);
+            port_c_ws2812_handle_ = nullptr;
+            port_c_ws2812_ok_ = false;
+            port_c_ws2812_led_count_ = 0;
+        }
+
+        led_strip_config_t strip_config = {
+            .strip_gpio_num = PORT_C_WS2812_DATA_PIN,
+            .max_leds = led_count,
+            .led_model = LED_MODEL_WS2812,
+            .color_component_format = LED_STRIP_COLOR_COMPONENT_FMT_GRB,
+            .flags = { .invert_out = false },
+        };
+        // The led_strip driver auto-allocates an RMT TX channel. ESP32-S3 has
+        // multiple TX channels, and StackChan uses RMT only for the Port B/C
+        // strips, so both WS2812 handles can coexist.
+        led_strip_rmt_config_t rmt_config = {
+            .clk_src = RMT_CLK_SRC_DEFAULT,
+            .resolution_hz = 10 * 1000 * 1000,  // 10 MHz, standard WS2812 bit timing
+            .mem_block_symbols = 0,              // 0 = driver default block size
+            .flags = { .with_dma = false },
+        };
+        esp_err_t err = led_strip_new_rmt_device(&strip_config, &rmt_config, &port_c_ws2812_handle_);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "port_c.ws2812.init Port C GPIO %d led_strip_new_rmt_device failed: %s",
+                     (int)PORT_C_WS2812_DATA_PIN, esp_err_to_name(err));
+            return err;
+        }
+
+        err = led_strip_clear(port_c_ws2812_handle_);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "port_c.ws2812.init Port C GPIO %d led_strip_clear failed: %s",
+                     (int)PORT_C_WS2812_DATA_PIN, esp_err_to_name(err));
+            led_strip_del(port_c_ws2812_handle_);
+            port_c_ws2812_handle_ = nullptr;
+            return err;
+        }
+        port_c_ws2812_led_count_ = led_count;
+        port_c_ws2812_ok_ = true;
+        ESP_LOGI(TAG, "port_c.ws2812 initialized: %u LEDs on Port C GPIO %d",
+                 (unsigned)led_count, (int)PORT_C_WS2812_DATA_PIN);
         return ESP_OK;
     }
 
@@ -6747,6 +6802,258 @@ private:
                     cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
                 }
                 ESP_LOGI(TAG, "port_b.ws2812.clear ok=%d", ok ? 1 : 0);
+                return root;
+            });
+
+        // ---- Generic Port C WS2812 strip tools ----
+        // Expose the CoreS3 Port C signal 1 (GPIO 17) as a generic
+        // WS2812-compatible strip driver. This is independent from self.led.*,
+        // which drives the 12-LED base strip through the PY32 I2C path.
+
+        mcp_server.AddTool(
+            "self.port_c.ws2812.init",
+            "Initialize a WS2812-compatible LED strip connected to Port C "
+            "(CoreS3 HY2.0-4P signal 1, GPIO 17). led_count is the "
+            "number of LEDs in the strip (1..256). This allocates the "
+            "ESP-IDF led_strip RMT backend and must succeed before calling "
+            "self.port_c.ws2812.set_pixel, set_strip, refresh, or clear. "
+            "Repeated calls with the same led_count are no-ops; a different "
+            "led_count tears down and rebuilds the strip handle. Returns "
+            "{\"available\":true,\"ok\":true,\"led_count\":N} on success or "
+            "{\"available\":false,\"ok\":false,\"led_count\":N,"
+            "\"error\":\"ESP_ERR_...\"} on failure. The strip protocol is "
+            "3.3 V CMOS data on GPIO 17; most modern WS2812B-V5/B2 strips "
+            "tolerate this, while older strict 5 V V_IH variants may need "
+            "an external level shifter.",
+            PropertyList({
+                Property("led_count", kPropertyTypeInteger, 1, PORT_C_WS2812_MAX_LEDS)
+            }),
+            [this](const PropertyList& props) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                uint16_t led_count = static_cast<uint16_t>(props["led_count"].value<int>());
+                esp_err_t err = InitPortCWs2812(led_count);
+                bool ok = (err == ESP_OK);
+                cJSON_AddBoolToObject(root, "available", ok);
+                cJSON_AddBoolToObject(root, "ok", ok);
+                cJSON_AddNumberToObject(root, "led_count", led_count);
+                if (!ok) {
+                    cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+                }
+                ESP_LOGI(TAG, "port_c.ws2812.init led_count=%u ok=%d",
+                         (unsigned)led_count, ok ? 1 : 0);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.port_c.ws2812.set_pixel",
+            "Set one LED in the Port C WS2812 strip buffer. Call "
+            "self.port_c.ws2812.init first; until init succeeds this returns "
+            "{\"available\":false,\"ok\":false}. index is 0..255, but the "
+            "effective range is 0..(led_count-1); out-of-range requests "
+            "return ok=false with error=\"index out of range\". r, g, and b "
+            "are 0..255. By default the color is buffered only; pass "
+            "refresh=true to immediately latch it to the strip, or call "
+            "self.port_c.ws2812.refresh after several buffered updates. "
+            "Runtime led_strip failures return ok=false with error. Port C "
+            "outputs 3.3 V CMOS data on GPIO 17; older strict 5 V WS2812 "
+            "variants may require a level shifter.",
+            PropertyList({
+                Property("index", kPropertyTypeInteger, 0, PORT_C_WS2812_MAX_LEDS - 1),
+                Property("r", kPropertyTypeInteger, 0, 255),
+                Property("g", kPropertyTypeInteger, 0, 255),
+                Property("b", kPropertyTypeInteger, 0, 255),
+                Property("refresh", kPropertyTypeBoolean, false)
+            }),
+            [this](const PropertyList& props) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", port_c_ws2812_ok_);
+                if (!port_c_ws2812_ok_ || port_c_ws2812_handle_ == nullptr) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error",
+                                            "Port C WS2812 strip not initialized.");
+                    return root;
+                }
+                int index = props["index"].value<int>();
+                if (index >= port_c_ws2812_led_count_) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error", "index out of range");
+                    ESP_LOGW(TAG, "port_c.ws2812.set_pixel index=%d out of range (led_count=%u)",
+                             index, (unsigned)port_c_ws2812_led_count_);
+                    return root;
+                }
+                uint8_t r = ClampByte(props["r"].value<int>());
+                uint8_t g = ClampByte(props["g"].value<int>());
+                uint8_t b = ClampByte(props["b"].value<int>());
+                bool refresh = props["refresh"].value<bool>();
+                esp_err_t err = led_strip_set_pixel(port_c_ws2812_handle_, index, r, g, b);
+                if (err == ESP_OK && refresh) {
+                    err = led_strip_refresh(port_c_ws2812_handle_);
+                }
+                bool ok = (err == ESP_OK);
+                cJSON_AddBoolToObject(root, "ok", ok);
+                if (!ok) {
+                    cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+                }
+                ESP_LOGI(TAG, "port_c.ws2812.set_pixel index=%d rgb=(%u,%u,%u) refresh=%d ok=%d",
+                         index, r, g, b, refresh ? 1 : 0, ok ? 1 : 0);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.port_c.ws2812.set_strip",
+            "Set multiple LEDs in the Port C WS2812 strip and refresh "
+            "immediately. Call self.port_c.ws2812.init first; until init "
+            "succeeds this returns {\"available\":false,\"ok\":false}. "
+            "colors is a JSON-encoded array of [r,g,b] integer triples, "
+            "for example \"[[255,0,0],[0,255,0],[0,0,255]]\". Entries are "
+            "applied from LED index 0; up to led_count entries are written, "
+            "extras are ignored, and missing trailing entries preserve the "
+            "previous buffered values. The payload is validate-then-write: "
+            "a malformed entry leaves the strip buffer unchanged. This tool "
+            "auto-refreshes and is the preferred path for animation frames. "
+            "Runtime led_strip failures return ok=false with error. Port C "
+            "outputs 3.3 V CMOS data on GPIO 17; older strict 5 V WS2812 "
+            "variants may require a level shifter.",
+            PropertyList({Property("colors", kPropertyTypeString)}),
+            [this](const PropertyList& props) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", port_c_ws2812_ok_);
+                if (!port_c_ws2812_ok_ || port_c_ws2812_handle_ == nullptr) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddNumberToObject(root, "written", 0);
+                    cJSON_AddStringToObject(root, "error",
+                                            "Port C WS2812 strip not initialized.");
+                    return root;
+                }
+
+                std::string json = props["colors"].value<std::string>();
+                cJSON* arr = cJSON_Parse(json.c_str());
+                if (arr == nullptr || !cJSON_IsArray(arr)) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddNumberToObject(root, "written", 0);
+                    cJSON_AddStringToObject(root, "error",
+                                            "colors must be a JSON array of [r,g,b] triples");
+                    if (arr != nullptr) cJSON_Delete(arr);
+                    return root;
+                }
+
+                int n = cJSON_GetArraySize(arr);
+                if (n > port_c_ws2812_led_count_) n = port_c_ws2812_led_count_;
+                std::vector<uint8_t> rgb;
+                rgb.reserve(static_cast<size_t>(n) * 3);
+                bool parse_ok = true;
+                for (int i = 0; i < n; i++) {
+                    cJSON* triple = cJSON_GetArrayItem(arr, i);
+                    if (!cJSON_IsArray(triple) || cJSON_GetArraySize(triple) != 3) {
+                        parse_ok = false;
+                        break;
+                    }
+                    uint8_t r = 0, g = 0, b = 0;
+                    if (!JsonByte(cJSON_GetArrayItem(triple, 0), &r) ||
+                        !JsonByte(cJSON_GetArrayItem(triple, 1), &g) ||
+                        !JsonByte(cJSON_GetArrayItem(triple, 2), &b)) {
+                        parse_ok = false;
+                        break;
+                    }
+                    rgb.push_back(r);
+                    rgb.push_back(g);
+                    rgb.push_back(b);
+                }
+                cJSON_Delete(arr);
+
+                if (!parse_ok) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddNumberToObject(root, "written", 0);
+                    cJSON_AddStringToObject(root, "error",
+                                            "Each entry must be a [r,g,b] triple of integers 0..255");
+                    ESP_LOGW(TAG, "port_c.ws2812.set_strip rejected malformed colors payload");
+                    return root;
+                }
+
+                esp_err_t err = ESP_OK;
+                for (int i = 0; i < n; i++) {
+                    size_t offset = static_cast<size_t>(i) * 3;
+                    err = led_strip_set_pixel(port_c_ws2812_handle_, i,
+                                              rgb[offset + 0],
+                                              rgb[offset + 1],
+                                              rgb[offset + 2]);
+                    if (err != ESP_OK) {
+                        break;
+                    }
+                }
+                if (err == ESP_OK) {
+                    err = led_strip_refresh(port_c_ws2812_handle_);
+                }
+
+                bool ok = (err == ESP_OK);
+                cJSON_AddBoolToObject(root, "ok", ok);
+                cJSON_AddNumberToObject(root, "written", ok ? n : 0);
+                if (!ok) {
+                    cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+                }
+                ESP_LOGI(TAG, "port_c.ws2812.set_strip written=%d ok=%d",
+                         ok ? n : 0, ok ? 1 : 0);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.port_c.ws2812.refresh",
+            "Refresh the Port C WS2812 strip, latching the current buffered "
+            "colors out on CoreS3 HY2.0-4P signal 1 GPIO 17. Call "
+            "self.port_c.ws2812.init first; until init succeeds this returns "
+            "{\"available\":false,\"ok\":false}. Use this after one or more "
+            "self.port_c.ws2812.set_pixel calls made with refresh=false. "
+            "Runtime led_strip failures return ok=false with error. Port C "
+            "outputs 3.3 V CMOS data; older strict 5 V WS2812 variants may "
+            "require a level shifter.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", port_c_ws2812_ok_);
+                if (!port_c_ws2812_ok_ || port_c_ws2812_handle_ == nullptr) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error",
+                                            "Port C WS2812 strip not initialized.");
+                    return root;
+                }
+                esp_err_t err = led_strip_refresh(port_c_ws2812_handle_);
+                bool ok = (err == ESP_OK);
+                cJSON_AddBoolToObject(root, "ok", ok);
+                if (!ok) {
+                    cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+                }
+                ESP_LOGI(TAG, "port_c.ws2812.refresh ok=%d", ok ? 1 : 0);
+                return root;
+            });
+
+        mcp_server.AddTool(
+            "self.port_c.ws2812.clear",
+            "Turn off every LED in the Port C WS2812 strip and refresh "
+            "immediately on CoreS3 HY2.0-4P signal 1 GPIO 17. Call "
+            "self.port_c.ws2812.init first; until init succeeds this returns "
+            "{\"available\":false,\"ok\":false}. This is equivalent to "
+            "self.port_c.ws2812.set_strip with an all-zero array of length "
+            "led_count, and it clears the driver's sticky per-pixel buffer. "
+            "Runtime led_strip failures return ok=false with error. Port C "
+            "outputs 3.3 V CMOS data; older strict 5 V WS2812 variants may "
+            "require a level shifter.",
+            PropertyList(),
+            [this](const PropertyList&) -> ReturnValue {
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "available", port_c_ws2812_ok_);
+                if (!port_c_ws2812_ok_ || port_c_ws2812_handle_ == nullptr) {
+                    cJSON_AddBoolToObject(root, "ok", false);
+                    cJSON_AddStringToObject(root, "error",
+                                            "Port C WS2812 strip not initialized.");
+                    return root;
+                }
+                esp_err_t err = led_strip_clear(port_c_ws2812_handle_);
+                bool ok = (err == ESP_OK);
+                cJSON_AddBoolToObject(root, "ok", ok);
+                if (!ok) {
+                    cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+                }
+                ESP_LOGI(TAG, "port_c.ws2812.clear ok=%d", ok ? 1 : 0);
                 return root;
             });
 


### PR DESCRIPTION
## Background

The stackchan board exposes three Grove ports. PORT.B (G9/G8) already drives a WS2812 strip via the generic `self.port_b.ws2812.*` tools (#223); PORT.C (G17/G18) was unused by the firmware. A common accessory configuration attaches one WS2812 LED unit to each of the two rear Grove ports, and the second unit had no driver until now.

Refs #340 (firmware side; the gateway-side exposure mirroring #224 is a separate PR).

## Implementation

Mirrors the Port B implementation exactly:

- New members `port_c_ws2812_{ok_,led_count_,handle_}` plus `PORT_C_WS2812_DATA_PIN = GPIO_NUM_17` / `PORT_C_WS2812_MAX_LEDS = 256` (GPIO 17/18 verified unused across `boards/stackchan/`)
- `InitPortCWs2812()` — same `led_strip` (RMT backend) configuration as Port B: WS2812 GRB, 10 MHz, no DMA, idempotent re-init, rollback on failure. The RMT TX channel is driver-allocated; the StackChan build uses RMT only for the Port B/C strips, so both handles coexist
- Five MCP tools `self.port_c.ws2812.{init,set_pixel,set_strip,refresh,clear}` with the same schemas, return shapes (`available` / `ok` / `error`), and validate-then-write `set_strip` semantics as the Port B set
- Existing Port B code is untouched (members intentionally keep their historical unprefixed names)

## Validation

- `codex review` against main: no findings
- Docker build (`python ./scripts/release.py stackchan`, espressif/idf:v5.5.2): completes cleanly — `build/xiaozhi.bin` generated
- Real-device check (two WS2812 antenna units on Port B + Port C simultaneously) is planned right after merge as part of the device owner's flash session

## Refs

- #340 (feature request; gateway follow-up PR forthcoming)
- #223 / #224 / PR #291 (Port B precedent: firmware → gateway two-stage pattern)
