### PR TITLE
feat(gateway): color_order option for Port B/C WS2812 strips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ documented-only.
 
 ### Gateway
 
+- Added a `color_order` option (`grb` default, `rgb`) for Port B/C WS2812
+  gateway tools and `stackchan_follow_led_stream`, allowing RGB-wired LEDs to
+  render correct colors by swapping R/G in the gateway before relay. (#343)
 - Added `stackchan_follow_led_stream`, a gateway-side WebSocket LED-frame
   subscriber for driving the base ring or a Port B WS2812 strip from external
   `event` / `continuous` color frames. (#335)

--- a/gateway/stackchan_mcp/follow_led_stream.py
+++ b/gateway/stackchan_mcp/follow_led_stream.py
@@ -26,6 +26,8 @@ WS2812_TARGET_TOOL_PREFIXES = {
 }
 LED_TARGETS = {"base_ring", *WS2812_TARGET_TOOL_PREFIXES}
 LED_TARGET_ERROR = "target must be 'base_ring', 'port_b', or 'port_c'"
+WS2812_COLOR_ORDERS = {"grb", "rgb"}
+WS2812_COLOR_ORDER_ERROR = "color_order must be 'grb' or 'rgb'"
 
 
 def _is_finite_number(value: Any) -> bool:
@@ -47,6 +49,7 @@ class FollowLedStreamConfig:
     target: str
     led_count: int | None = None
     max_fps: float = LED_STREAM_MAX_FPS
+    color_order: str = "grb"
     source_filter: Optional[str] = None
     frame_filter: Optional[str] = None
     reconnect_initial_backoff_s: float = 1.5
@@ -57,9 +60,15 @@ class FollowLedStreamConfig:
             raise ValueError("url is required")
         if self.target not in LED_TARGETS:
             raise ValueError(LED_TARGET_ERROR)
+        if self.color_order not in WS2812_COLOR_ORDERS:
+            raise ValueError(WS2812_COLOR_ORDER_ERROR)
         if not _is_finite_number(self.max_fps) or not 0 < self.max_fps <= 30:
             raise ValueError("max_fps must be a number in (0, 30]")
         if self.target == "base_ring":
+            if self.color_order != "grb":
+                raise ValueError(
+                    "color_order is only supported for target=port_b or target=port_c"
+                )
             if self.led_count is not None and self.led_count != BASE_RING_LED_COUNT:
                 raise ValueError("led_count for base_ring must be 12 when provided")
         else:
@@ -114,6 +123,7 @@ class FollowLedStream:
             "target": self._cfg.target,
             "led_count": self._cfg.capacity,
             "max_fps": self._cfg.max_fps,
+            "color_order": self._cfg.color_order,
             "source_filter": self._cfg.source_filter,
             "frame_filter": self._cfg.frame_filter,
             "connected": self._connect_state == "connected",
@@ -347,6 +357,9 @@ class FollowLedStream:
             return True
         assert self._cfg.led_count is not None
         operation = f"{self._cfg.target} WS2812 init"
+        from .stdio_server import _set_ws2812_color_order
+
+        _set_ws2812_color_order(self._cfg.target, self._cfg.color_order)
         try:
             result, error = await self._gateway.esp32.call_tool(
                 self._ws2812_tool_name("init"),
@@ -382,12 +395,19 @@ class FollowLedStream:
     ) -> bool:
         if self._cfg.target == "base_ring":
             tool_name = "self.led.set_many"
+            colors_for_device = colors
         else:
             tool_name = self._ws2812_tool_name("set_strip")
+            from .stdio_server import _remap_ws2812_colors_for_color_order
+
+            colors_for_device = _remap_ws2812_colors_for_color_order(
+                self._cfg.color_order,
+                colors,
+            )
         try:
             result, error = await self._gateway.esp32.call_tool(
                 tool_name,
-                {"colors": json.dumps(colors)},
+                {"colors": json.dumps(colors_for_device)},
             )
         except Exception as exc:
             self._last_error = str(exc)

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -34,6 +34,14 @@ _SUPPORTED_EVENT_METHODS = {STACKCHAN_EVENT_METHOD, CHANNEL_NOTIFICATION_METHOD}
 FOLLOW_LED_TARGETS = {"base_ring", "port_b", "port_c"}
 FOLLOW_LED_WS2812_TARGETS = {"port_b", "port_c"}
 FOLLOW_LED_TARGET_ERROR = "target must be 'base_ring', 'port_b', or 'port_c'"
+WS2812_COLOR_ORDERS = {"grb", "rgb"}
+WS2812_COLOR_ORDER_ERROR = "color_order must be 'grb' or 'rgb'"
+# Process-local init state. Re-running a Port B/C WS2812 init call updates the
+# selected order for that port; no persistence is needed across gateway restarts.
+_WS2812_COLOR_ORDER_BY_PORT = {
+    "port_b": "grb",
+    "port_c": "grb",
+}
 STACKCHAN_EVENT_INSTRUCTIONS = (
     "Stack-chan physical events arrive as server-initiated "
     "notifications with method='stackchan/event'. Params include "
@@ -69,6 +77,74 @@ SPEED_DESCRIPTION = """speed (optional): How fast to move the head.
 
 _active_session: Any | None = None
 _active_sessions: dict[int, Any] = {}
+
+
+def _reset_ws2812_color_orders_for_tests() -> None:
+    _WS2812_COLOR_ORDER_BY_PORT.update({"port_b": "grb", "port_c": "grb"})
+
+
+def _set_ws2812_color_order(port: str, color_order: str) -> None:
+    if port not in _WS2812_COLOR_ORDER_BY_PORT:
+        raise ValueError(f"unsupported WS2812 port: {port}")
+    if color_order not in WS2812_COLOR_ORDERS:
+        raise ValueError(WS2812_COLOR_ORDER_ERROR)
+    _WS2812_COLOR_ORDER_BY_PORT[port] = color_order
+
+
+def _get_ws2812_color_order(port: str) -> str:
+    return _WS2812_COLOR_ORDER_BY_PORT.get(port, "grb")
+
+
+def _remap_ws2812_pixel_args_for_color_order(
+    color_order: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    if color_order != "rgb":
+        return arguments
+    if "r" not in arguments or "g" not in arguments:
+        return arguments
+    return {
+        **arguments,
+        "r": arguments["g"],
+        "g": arguments["r"],
+    }
+
+
+def _remap_ws2812_pixel_args_for_device(
+    port: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    return _remap_ws2812_pixel_args_for_color_order(
+        _get_ws2812_color_order(port),
+        arguments,
+    )
+
+
+def _remap_ws2812_colors_for_color_order(
+    color_order: str,
+    colors: Any,
+) -> Any:
+    if color_order != "rgb":
+        return colors
+    if not isinstance(colors, list):
+        return colors
+    remapped: list[Any] = []
+    for color in colors:
+        if isinstance(color, list) and len(color) == 3:
+            remapped.append([color[1], color[0], color[2]])
+        else:
+            remapped.append(color)
+    return remapped
+
+
+def _remap_ws2812_colors_for_device(
+    port: str,
+    colors: Any,
+) -> Any:
+    return _remap_ws2812_colors_for_color_order(
+        _get_ws2812_color_order(port),
+        colors,
+    )
 
 
 class StackChanEventNotification(
@@ -553,6 +629,18 @@ async def _handle_follow_led_stream(
                 "led_count for base_ring must be 12 when provided"
             )
 
+    color_order = (
+        arguments["color_order"]
+        if "color_order" in arguments
+        else resolve_default(tool_name, "color_order", "grb")
+    )
+    if color_order not in WS2812_COLOR_ORDERS:
+        return _follow_led_error(WS2812_COLOR_ORDER_ERROR)
+    if target == "base_ring" and color_order != "grb":
+        return _follow_led_error(
+            "color_order is only supported for target=port_b or target=port_c"
+        )
+
     max_fps = (
         arguments["max_fps"]
         if "max_fps" in arguments
@@ -604,6 +692,7 @@ async def _handle_follow_led_stream(
             target=target,
             led_count=led_count,
             max_fps=float(max_fps),
+            color_order=color_order,
             source_filter=source_filter,
             frame_filter=frame_filter,
             reconnect_initial_backoff_s=float(reconnect_initial_backoff_s),
@@ -745,6 +834,44 @@ async def _dispatch_mcp_tool(
         arguments = {"yaw": yaw_val, "pitch": pitch_val}
         if speed_dps is not None:
             arguments["speed_dps"] = speed_dps
+
+    ws2812_port_by_init_tool = {
+        "port_b_ws2812_init": "port_b",
+        "port_c_ws2812_init": "port_c",
+    }
+    ws2812_port_by_set_pixel_tool = {
+        "port_b_ws2812_set_pixel": "port_b",
+        "port_c_ws2812_set_pixel": "port_c",
+    }
+    ws2812_port_by_set_strip_tool = {
+        "port_b_ws2812_set_strip": "port_b",
+        "port_c_ws2812_set_strip": "port_c",
+    }
+    if name in ws2812_port_by_init_tool:
+        color_order = arguments.get("color_order", "grb")
+        if color_order not in WS2812_COLOR_ORDERS:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps({"error": WS2812_COLOR_ORDER_ERROR}),
+                )
+            ]
+        _set_ws2812_color_order(ws2812_port_by_init_tool[name], color_order)
+        arguments = {"led_count": arguments.get("led_count")}
+    elif name in ws2812_port_by_set_pixel_tool:
+        arguments = _remap_ws2812_pixel_args_for_device(
+            ws2812_port_by_set_pixel_tool[name],
+            arguments,
+        )
+    elif name in ws2812_port_by_set_strip_tool:
+        port = ws2812_port_by_set_strip_tool[name]
+        arguments = {
+            **arguments,
+            "colors": _remap_ws2812_colors_for_device(
+                port,
+                arguments.get("colors", []),
+            ),
+        }
 
     tool_map: dict[str, tuple[str, dict[str, Any]]] = {
         "get_device_info": (
@@ -1235,6 +1362,17 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                                 "For base_ring, omit or pass 12."
                             ),
                         },
+                        "color_order": {
+                            "type": "string",
+                            "enum": ["grb", "rgb"],
+                            "default": "grb",
+                            "description": (
+                                "WS2812 strip color order for target=port_b or "
+                                "target=port_c. Use rgb for RGB-wired LEDs; the "
+                                "gateway swaps R/G before forwarding to the "
+                                "firmware. base_ring only supports grb."
+                            ),
+                        },
                         "max_fps": {
                             "type": "number",
                             "default": 30,
@@ -1714,6 +1852,17 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             "minimum": 1,
                             "maximum": 256,
                         },
+                        "color_order": {
+                            "type": "string",
+                            "enum": ["grb", "rgb"],
+                            "default": "grb",
+                            "description": (
+                                "Logical LED color order. Use grb for standard "
+                                "WS2812/NeoPixel strips, or rgb for RGB-wired "
+                                "LEDs; the gateway swaps R/G before forwarding "
+                                "colors to the firmware."
+                            ),
+                        },
                     },
                     "required": ["led_count"],
                 },
@@ -1846,6 +1995,17 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                             "description": "Number of LEDs in the strip (1..256).",
                             "minimum": 1,
                             "maximum": 256,
+                        },
+                        "color_order": {
+                            "type": "string",
+                            "enum": ["grb", "rgb"],
+                            "default": "grb",
+                            "description": (
+                                "Logical LED color order. Use grb for standard "
+                                "WS2812/NeoPixel strips, or rgb for RGB-wired "
+                                "LEDs; the gateway swaps R/G before forwarding "
+                                "colors to the firmware."
+                            ),
                         },
                     },
                     "required": ["led_count"],

--- a/gateway/stackchan_mcp/user_defaults.py
+++ b/gateway/stackchan_mcp/user_defaults.py
@@ -35,6 +35,7 @@ _SCHEMA_DEFAULTS: dict[str, dict[str, Any]] = {
         "target": "",
         "led_count": 12,
         "max_fps": 30.0,
+        "color_order": "grb",
         "source_filter": "",
         "frame_filter": "",
         "reconnect_initial_backoff_s": 1.5,
@@ -88,6 +89,8 @@ def _is_supported_value(tool_name: str, arg_name: str, value: Any) -> bool:
             return 1 <= value <= 256
         if arg_name == "max_fps":
             return 0 < float(value) <= 30
+        if arg_name == "color_order":
+            return value in {"grb", "rgb"}
         if arg_name in {"source_filter", "frame_filter"}:
             return value != ""
         if arg_name in {"reconnect_initial_backoff_s", "reconnect_max_backoff_s"}:

--- a/gateway/tests/test_follow_led_stream.py
+++ b/gateway/tests/test_follow_led_stream.py
@@ -6,6 +6,7 @@ import pytest
 import pytest_asyncio
 
 from stackchan_mcp import follow_led_stream as fls
+from stackchan_mcp import stdio_server
 from stackchan_mcp import wifi_power_save
 from stackchan_mcp.follow_led_stream import (
     FollowLedStream,
@@ -33,6 +34,8 @@ _PORT_WS2812_SET_STRIP = {
 
 
 class _FakeESP32:
+    device_connected = True
+
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self._replies: dict[str, list[tuple[Any, Any]]] = {}
@@ -151,9 +154,11 @@ def _mark_wifi_ok(follower: FollowLedStream) -> None:
 @pytest_asyncio.fixture(autouse=True)
 async def _reset_singleton() -> Any:
     await fls.stop_follow()
+    stdio_server._reset_ws2812_color_orders_for_tests()
     wifi_power_save._clear_for_tests()
     yield
     await fls.stop_follow()
+    stdio_server._reset_ws2812_color_orders_for_tests()
     wifi_power_save._clear_for_tests()
 
 
@@ -174,6 +179,15 @@ def test_config_validation_accepts_expected_target_led_count_pairs() -> None:
         .capacity
         == 18
     )
+    assert (
+        FollowLedStreamConfig(
+            url=_url("port-b-rgb"),
+            target="port_b",
+            led_count=18,
+            color_order="rgb",
+        ).color_order
+        == "rgb"
+    )
 
 
 @pytest.mark.parametrize(
@@ -188,6 +202,17 @@ def test_config_validation_accepts_expected_target_led_count_pairs() -> None:
         {"url": _url("port-c-zero"), "target": "port_c", "led_count": 0},
         {"url": _url("port-too-many"), "target": "port_b", "led_count": 257},
         {"url": _url("port-c-too-many"), "target": "port_c", "led_count": 257},
+        {
+            "url": _url("base-rgb"),
+            "target": "base_ring",
+            "color_order": "rgb",
+        },
+        {
+            "url": _url("bad-color-order"),
+            "target": "port_b",
+            "led_count": 1,
+            "color_order": "bgr",
+        },
         {"url": _url("fps-zero"), "target": "base_ring", "max_fps": 0},
         {"url": _url("fps-too-high"), "target": "base_ring", "max_fps": 31},
     ],
@@ -195,6 +220,15 @@ def test_config_validation_accepts_expected_target_led_count_pairs() -> None:
 def test_config_validation_rejects_invalid_values(kwargs: dict[str, Any]) -> None:
     with pytest.raises(ValueError):
         FollowLedStreamConfig(**kwargs)
+
+
+def test_config_validation_rejects_base_ring_color_order_with_clear_error() -> None:
+    with pytest.raises(ValueError, match="color_order is only supported"):
+        FollowLedStreamConfig(
+            url=_url("base-rgb-clear"),
+            target="base_ring",
+            color_order="rgb",
+        )
 
 
 @pytest.mark.asyncio
@@ -309,6 +343,76 @@ async def test_ws2812_dispatch_uses_json_encoded_set_strip_payload(
         (_PORT_WS2812_SET_STRIP[target], {"colors": json.dumps(colors)})
     ]
     assert follower.status()["frames_sent"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target", ["port_b", "port_c"])
+async def test_ws2812_dispatch_rgb_color_order_swaps_channels(
+    target: str,
+) -> None:
+    gateway = _FakeGateway()
+    follower = FollowLedStream(
+        gateway,
+        FollowLedStreamConfig(
+            url=_url(f"{target}-rgb-dispatch"),
+            target=target,
+            led_count=3,
+            color_order="rgb",
+        ),
+    )
+    _mark_wifi_ok(follower)
+    colors = [[255, 0, 64], [0, 16, 32]]
+
+    await follower._consume(_FakeWebSocket([_frame(colors=colors)]))
+
+    assert gateway.esp32.calls == [
+        (_PORT_WS2812_INIT[target], {"led_count": 3}),
+        (
+            _PORT_WS2812_SET_STRIP[target],
+            {"colors": json.dumps([[0, 255, 64], [16, 0, 32]])},
+        ),
+    ]
+    assert stdio_server._get_ws2812_color_order(target) == "rgb"
+    assert follower.status()["frames_sent"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target", ["port_b", "port_c"])
+async def test_ws2812_stream_then_tool_map_uses_single_rgb_swap(
+    target: str,
+) -> None:
+    gateway = _FakeGateway()
+    follower = FollowLedStream(
+        gateway,
+        FollowLedStreamConfig(
+            url=_url(f"{target}-rgb-single-swap"),
+            target=target,
+            led_count=1,
+            color_order="rgb",
+        ),
+    )
+    _mark_wifi_ok(follower)
+
+    await follower._consume(
+        _FakeWebSocket([_frame(colors=[[255, 0, 64]])])
+    )
+    await stdio_server._dispatch_mcp_tool(
+        f"{target}_ws2812_set_pixel",
+        {"index": 0, "r": 255, "g": 0, "b": 64},
+        gateway,
+    )
+
+    assert gateway.esp32.calls == [
+        (_PORT_WS2812_INIT[target], {"led_count": 1}),
+        (
+            _PORT_WS2812_SET_STRIP[target],
+            {"colors": json.dumps([[0, 255, 64]])},
+        ),
+        (
+            f"self.{target}.ws2812.set_pixel",
+            {"index": 0, "r": 0, "g": 255, "b": 64},
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -43,8 +43,10 @@ def _isolate_user_defaults_config(monkeypatch, tmp_path):
         fake_user_config_path,
     )
     user_defaults._clear_user_defaults_cache_for_tests()
+    stdio_server._reset_ws2812_color_orders_for_tests()
     yield
     user_defaults._clear_user_defaults_cache_for_tests()
+    stdio_server._reset_ws2812_color_orders_for_tests()
 
 
 def test_create_server():
@@ -701,6 +703,16 @@ async def test_list_tools_includes_ws2812_tools_with_schemas(
         "minimum": 1,
         "maximum": 256,
     }
+    assert init_schema["properties"]["color_order"] == {
+        "type": "string",
+        "enum": ["grb", "rgb"],
+        "default": "grb",
+        "description": (
+            "Logical LED color order. Use grb for standard WS2812/NeoPixel "
+            "strips, or rgb for RGB-wired LEDs; the gateway swaps R/G before "
+            "forwarding colors to the firmware."
+        ),
+    }
     assert init_schema["required"] == ["led_count"]
 
     pixel_schema = tools_by_name[f"{port}_ws2812_set_pixel"].inputSchema
@@ -938,6 +950,113 @@ async def test_ws2812_set_strip_relays_colors_as_json_string(monkeypatch, port):
     assert set(arguments.keys()) == {"colors"}
     assert json.loads(arguments["colors"]) == colors
     assert json.loads(result.root.content[0].text) == {"ok": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("port", ["port_b", "port_c"])
+async def test_ws2812_rgb_color_order_swaps_channels_until_reinitialized(
+    monkeypatch,
+    port,
+):
+    calls = _make_ws2812_fake_gateway(monkeypatch)
+    server = create_server()
+
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_init",
+                "arguments": {"led_count": 18, "color_order": "rgb"},
+            },
+        )
+    )
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_set_pixel",
+                "arguments": {
+                    "index": 2,
+                    "r": 255,
+                    "g": 0,
+                    "b": 64,
+                    "refresh": True,
+                },
+            },
+        )
+    )
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_set_strip",
+                "arguments": {"colors": [[255, 0, 64], [0, 16, 32]]},
+            },
+        )
+    )
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_init",
+                "arguments": {"led_count": 18},
+            },
+        )
+    )
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_set_pixel",
+                "arguments": {"index": 3, "r": 7, "g": 8, "b": 9},
+            },
+        )
+    )
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_set_strip",
+                "arguments": {"colors": [[7, 8, 9]]},
+            },
+        )
+    )
+
+    assert calls == [
+        (f"self.{port}.ws2812.init", {"led_count": 18}),
+        (
+            f"self.{port}.ws2812.set_pixel",
+            {"index": 2, "r": 0, "g": 255, "b": 64, "refresh": True},
+        ),
+        (
+            f"self.{port}.ws2812.set_strip",
+            {"colors": json.dumps([[0, 255, 64], [16, 0, 32]])},
+        ),
+        (f"self.{port}.ws2812.init", {"led_count": 18}),
+        (f"self.{port}.ws2812.set_pixel", {"index": 3, "r": 7, "g": 8, "b": 9}),
+        (f"self.{port}.ws2812.set_strip", {"colors": json.dumps([[7, 8, 9]])}),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("port", ["port_b", "port_c"])
+async def test_ws2812_init_rejects_invalid_color_order(monkeypatch, port):
+    calls = _make_ws2812_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": f"{port}_ws2812_init",
+                "arguments": {"led_count": 18, "color_order": "bgr"},
+            },
+        )
+    )
+
+    assert calls == []
+    assert "Input validation error" in result.root.content[0].text
+    assert "'bgr' is not one of ['grb', 'rgb']" in result.root.content[0].text
 
 
 # ---------------------------------------------------------------------------
@@ -1564,6 +1683,16 @@ async def test_list_tools_includes_follow_led_stream_schema():
         "port_c",
     ]
     assert schema["properties"]["led_count"]["maximum"] == 256
+    assert schema["properties"]["color_order"] == {
+        "type": "string",
+        "enum": ["grb", "rgb"],
+        "default": "grb",
+        "description": (
+            "WS2812 strip color order for target=port_b or target=port_c. "
+            "Use rgb for RGB-wired LEDs; the gateway swaps R/G before "
+            "forwarding to the firmware. base_ring only supports grb."
+        ),
+    }
     assert schema["properties"]["max_fps"]["maximum"] == 30
     assert "kind='event'" in tool.description
 
@@ -1579,6 +1708,7 @@ async def test_follow_led_ws2812_target_arguments_propagate(monkeypatch, target)
             target=target,
             led_count=18,
             max_fps=24,
+            color_order="rgb",
             source_filter="stage",
             frame_filter="calibrated",
             reconnect_initial_backoff_s=0.25,
@@ -1591,6 +1721,7 @@ async def test_follow_led_ws2812_target_arguments_propagate(monkeypatch, target)
     assert cfg.target == target
     assert cfg.led_count == 18
     assert cfg.max_fps == 24
+    assert cfg.color_order == "rgb"
     assert cfg.source_filter == "stage"
     assert cfg.frame_filter == "calibrated"
     assert cfg.reconnect_initial_backoff_s == 0.25
@@ -1608,6 +1739,7 @@ async def test_follow_led_reads_user_defaults(monkeypatch, tmp_path):
         'target = "port_c"\n'
         "led_count = 7\n"
         "max_fps = 12\n"
+        'color_order = "rgb"\n'
         'source_filter = "stage"\n',
         encoding="utf-8",
     )
@@ -1631,6 +1763,7 @@ async def test_follow_led_reads_user_defaults(monkeypatch, tmp_path):
     assert captured[0].target == "port_c"
     assert captured[0].led_count == 7
     assert captured[0].max_fps == 12
+    assert captured[0].color_order == "rgb"
     assert captured[0].source_filter == "stage"
 
 
@@ -1647,3 +1780,32 @@ async def test_follow_led_rejects_bad_target_led_count(monkeypatch):
     payload = json.loads(result.root.content[0].text)
     assert payload["ok"] is False
     assert "base_ring" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_follow_led_rejects_color_order_for_base_ring(monkeypatch):
+    captured = _make_follow_led_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _follow_led_request(target="base_ring", color_order="rgb")
+    )
+
+    assert captured == []
+    payload = json.loads(result.root.content[0].text)
+    assert payload["ok"] is False
+    assert "color_order is only supported" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_follow_led_rejects_bad_color_order(monkeypatch):
+    captured = _make_follow_led_fake_gateway(monkeypatch)
+    server = create_server()
+
+    result = await server.request_handlers[CallToolRequest](
+        _follow_led_request(target="port_b", led_count=8, color_order="bgr")
+    )
+
+    assert captured == []
+    assert "Input validation error" in result.root.content[0].text
+    assert "'bgr' is not one of ['grb', 'rgb']" in result.root.content[0].text

--- a/gateway/tests/test_user_defaults.py
+++ b/gateway/tests/test_user_defaults.py
@@ -72,6 +72,24 @@ def test_resolve_default_uses_valid_tool_overlay(user_defaults_path):
     )
 
 
+def test_resolve_default_accepts_follow_led_color_order(user_defaults_path):
+    user_defaults_path.parent.mkdir(parents=True)
+    user_defaults_path.write_text(
+        "[tool.stackchan_follow_led_stream]\n"
+        'color_order = "rgb"\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        user_defaults.resolve_default(
+            "stackchan_follow_led_stream",
+            "color_order",
+            "grb",
+        )
+        == "rgb"
+    )
+
+
 def test_resolve_default_warns_and_falls_back_for_invalid_value(
     user_defaults_path,
     caplog,
@@ -97,3 +115,29 @@ def test_resolve_default_warns_and_falls_back_for_invalid_value(
         in caplog.text
     )
     assert "falling back to schema default (5)" in caplog.text
+
+
+def test_resolve_default_rejects_invalid_follow_led_color_order(
+    user_defaults_path,
+    caplog,
+):
+    user_defaults_path.parent.mkdir(parents=True)
+    user_defaults_path.write_text(
+        "[tool.stackchan_follow_led_stream]\n"
+        'color_order = "bgr"\n',
+        encoding="utf-8",
+    )
+    caplog.set_level(logging.WARNING, logger="stackchan_mcp.user_defaults")
+
+    assert (
+        user_defaults.resolve_default(
+            "stackchan_follow_led_stream",
+            "color_order",
+            "grb",
+        )
+        == "grb"
+    )
+    assert (
+        "invalid value for tool.stackchan_follow_led_stream.color_order"
+        in caplog.text
+    )


### PR DESCRIPTION
## Background

8 mm through-hole NeoPixel LEDs (WS2811-family die) use **RGB** wire order, while the firmware `led_strip` driver is configured for the WS2812 default **GRB**. With such units on Port B/C, requested colors render with red/green swapped (verified on device: pink `(255,0,64)` rendered as teal on both ports; pre-swapping the channels rendered the intended color).

Closes #343.

## Implementation

Gateway-side remap — accessory-specific semantics stay out of the base firmware (per the #223 design note), so no firmware change and no reflash:

- `port_b_ws2812_init` / `port_c_ws2812_init` accept optional `color_order`: `"grb"` (default, passthrough) or `"rgb"`. The order is stored per port in gateway memory; the parameter is **not** forwarded to the device (which only accepts `led_count`)
- When `"rgb"` is stored, the gateway swaps R/G once in `set_pixel` args and `set_strip` triples before relaying
- `stackchan_follow_led_stream` gains the same `color_order` option for `port_b`/`port_c` targets (rejected for `base_ring`); the stream path performs its own single swap and registers the per-port order at init, kept consistent with the tool path (a test pins single-swap end-to-end)
- `user_defaults` accepts `color_order` for the follow_led tool

## Validation

- `uv run pytest -q`: 693 passed, 1 skipped
- `uv run ruff check .`: clean
- `codex review` against main: no findings
- Real-device: channel-swap behavior confirmed on both Port B and Port C with 8 mm through-hole NeoPixel units before implementing

## Refs

- #343, #340 / #341 / #342 (Port C channel), #223 (design note on unit-specific semantics)
