### PR TITLE
feat(gateway): log WebSocket close code/reason and explicit keepalive policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ documented-only.
 - Added `stackchan_follow_led_stream`, a gateway-side WebSocket LED-frame
   subscriber for driving the base ring or a Port B WS2812 strip from external
   `event` / `continuous` color frames. (#335)
+- Log ESP32 WebSocket disconnect close codes, reasons, close class, last-frame
+  age, and connection lifetime, and make the gateway keepalive policy explicit.
+  (#338)
 - Exposed the Port C WS2812 device tools and added `port_c` as a
   `stackchan_follow_led_stream` target. (#340)
 

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -95,6 +95,33 @@ def _monotonic() -> float:
     return time.monotonic()
 
 
+def _log_disconnect_details(
+    *,
+    device_id: str,
+    close_class: str,
+    rcvd_code: int | None,
+    rcvd_reason: str | None,
+    sent_code: int | None,
+    sent_reason: str | None,
+    connected_at: float,
+    last_frame_received_at: float | None,
+) -> None:
+    disconnected_at = _monotonic()
+    logger.info(
+        "ESP32 disconnected: device=%s close_class=%s "
+        "rcvd_code=%s rcvd_reason=%r sent_code=%s sent_reason=%r "
+        "last_frame_age_s=%s lifetime_s=%s",
+        device_id,
+        close_class,
+        rcvd_code,
+        rcvd_reason,
+        sent_code,
+        sent_reason,
+        _format_elapsed_s(last_frame_received_at, disconnected_at),
+        _format_elapsed_s(connected_at, disconnected_at),
+    )
+
+
 class ESP32Connection:
     """Manages a single ESP32 device connection."""
 
@@ -597,6 +624,7 @@ class ESP32Manager:
         connection.device_id = device_id
         connected_at = _monotonic()
         last_frame_received_at: float | None = None
+        disconnect_logged = False
 
         try:
             async for message in ws:
@@ -752,23 +780,33 @@ class ESP32Manager:
                 else:
                     logger.debug("ESP32 message type=%s (ignored)", msg_type)
 
+            if not disconnect_logged:
+                _log_disconnect_details(
+                    device_id=device_id,
+                    close_class="GracefulClose",
+                    rcvd_code=getattr(ws, "close_code", None),
+                    rcvd_reason=getattr(ws, "close_reason", None),
+                    sent_code=None,
+                    sent_reason=None,
+                    connected_at=connected_at,
+                    last_frame_received_at=last_frame_received_at,
+                )
+                disconnect_logged = True
+
         except websockets.exceptions.ConnectionClosed as exc:
-            disconnected_at = _monotonic()
             rcvd_code, rcvd_reason = _close_frame_fields(exc.rcvd)
             sent_code, sent_reason = _close_frame_fields(exc.sent)
-            logger.info(
-                "ESP32 disconnected: device=%s close_class=%s "
-                "rcvd_code=%s rcvd_reason=%r sent_code=%s sent_reason=%r "
-                "last_frame_age_s=%s lifetime_s=%s",
-                device_id,
-                exc.__class__.__name__,
-                rcvd_code,
-                rcvd_reason,
-                sent_code,
-                sent_reason,
-                _format_elapsed_s(last_frame_received_at, disconnected_at),
-                _format_elapsed_s(connected_at, disconnected_at),
+            _log_disconnect_details(
+                device_id=device_id,
+                close_class=exc.__class__.__name__,
+                rcvd_code=rcvd_code,
+                rcvd_reason=rcvd_reason,
+                sent_code=sent_code,
+                sent_reason=sent_reason,
+                connected_at=connected_at,
+                last_frame_received_at=last_frame_received_at,
             )
+            disconnect_logged = True
         finally:
             # If the device disconnected mid-capture, drop any partial
             # buffer rather than letting it leak into the next

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 
 # Timeout for waiting for ESP32 responses
 RESPONSE_TIMEOUT = 10.0
+WEBSOCKET_PING_INTERVAL_S = 20
+WEBSOCKET_PING_TIMEOUT_S = 20
 
 ToolCall = tuple[str, dict[str, Any]]
 ToolCallResult = tuple[Any, dict[str, Any] | None]
@@ -72,6 +74,25 @@ def _retrieve_future_exception(future: asyncio.Future[Any]) -> None:
     """Mark a completed Future exception as observed, if it has one."""
     if future.done() and not future.cancelled():
         future.exception()
+
+
+def _close_frame_fields(close_frame: Any | None) -> tuple[int | None, str | None]:
+    """Return log-friendly code/reason fields for a WebSocket close frame."""
+    if close_frame is None:
+        return None, None
+    return getattr(close_frame, "code", None), getattr(close_frame, "reason", None)
+
+
+def _format_elapsed_s(started_at: float | None, now: float) -> str:
+    """Format elapsed monotonic seconds for stable, compact log output."""
+    if started_at is None:
+        return "None"
+    return f"{now - started_at:.3f}"
+
+
+def _monotonic() -> float:
+    """Return monotonic time for connection observability."""
+    return time.monotonic()
 
 
 class ESP32Connection:
@@ -509,12 +530,21 @@ class ESP32Manager:
                 "Device-driven listen capture enabled (audio hook %s)",
                 audio_hook_url,
             )
-        logger.info("ESP32 WebSocket server starting on ws://%s:%d", host, port)
+        logger.info(
+            "ESP32 WebSocket server starting on ws://%s:%d "
+            "ping_interval=%s ping_timeout=%s",
+            host,
+            port,
+            WEBSOCKET_PING_INTERVAL_S,
+            WEBSOCKET_PING_TIMEOUT_S,
+        )
         self._server = await websockets.serve(
             self._handler,
             host,
             port,
             process_request=self._check_auth,
+            ping_interval=WEBSOCKET_PING_INTERVAL_S,
+            ping_timeout=WEBSOCKET_PING_TIMEOUT_S,
         )
 
     async def stop(self) -> None:
@@ -565,9 +595,12 @@ class ESP32Manager:
 
         connection = ESP32Connection(ws, session_id)
         connection.device_id = device_id
+        connected_at = _monotonic()
+        last_frame_received_at: float | None = None
 
         try:
             async for message in ws:
+                last_frame_received_at = _monotonic()
                 if isinstance(message, bytes):
                     # Binary = audio frame. Forward to the audio_stream
                     # module which buffers it for STT capture (Issue
@@ -719,8 +752,23 @@ class ESP32Manager:
                 else:
                     logger.debug("ESP32 message type=%s (ignored)", msg_type)
 
-        except websockets.exceptions.ConnectionClosed:
-            logger.info("ESP32 disconnected: device=%s", device_id)
+        except websockets.exceptions.ConnectionClosed as exc:
+            disconnected_at = _monotonic()
+            rcvd_code, rcvd_reason = _close_frame_fields(exc.rcvd)
+            sent_code, sent_reason = _close_frame_fields(exc.sent)
+            logger.info(
+                "ESP32 disconnected: device=%s close_class=%s "
+                "rcvd_code=%s rcvd_reason=%r sent_code=%s sent_reason=%r "
+                "last_frame_age_s=%s lifetime_s=%s",
+                device_id,
+                exc.__class__.__name__,
+                rcvd_code,
+                rcvd_reason,
+                sent_code,
+                sent_reason,
+                _format_elapsed_s(last_frame_received_at, disconnected_at),
+                _format_elapsed_s(connected_at, disconnected_at),
+            )
         finally:
             # If the device disconnected mid-capture, drop any partial
             # buffer rather than letting it leak into the next

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -71,6 +71,37 @@ class _ClosingHandlerWebSocket:
         self.closed = True
 
 
+class _GracefulCloseHandlerWebSocket:
+    """Fake server-side WebSocket whose iterator exits after a graceful close."""
+
+    def __init__(
+        self,
+        messages: list[str | bytes],
+        close_code: int | None,
+        close_reason: str | None,
+    ) -> None:
+        self._messages = messages
+        self.close_code = close_code
+        self.close_reason = close_reason
+        self.request = SimpleNamespace(headers={"Device-Id": "device-test"})
+        self.sent: list[str | bytes] = []
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return self._messages.pop(0)
+        raise StopAsyncIteration
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
 @pytest.mark.asyncio
 async def test_manager_starts_and_stops():
     """Manager can start and stop cleanly."""
@@ -288,6 +319,32 @@ async def test_esp32_disconnect_handling(manager):
     # Connection closed
     await asyncio.sleep(0.2)
     assert manager.device_connected is False
+
+
+@pytest.mark.asyncio
+async def test_handler_logs_graceful_close_details_once(monkeypatch, caplog):
+    """Normal async-for completion still logs enriched close details once."""
+    ticks = iter([100.0, 103.25, 105.5])
+    monkeypatch.setattr(esp32_client, "_monotonic", lambda: next(ticks))
+    ws = _GracefulCloseHandlerWebSocket(
+        [json.dumps({"type": "noop"})],
+        close_code=1000,
+        close_reason="normal",
+    )
+    caplog.set_level(logging.INFO, logger="stackchan_mcp.esp32_client")
+
+    await ESP32Manager()._handler(ws)  # type: ignore[arg-type]
+
+    disconnect_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("ESP32 disconnected:")
+    ]
+    assert disconnect_logs == [
+        "ESP32 disconnected: device=device-test close_class=GracefulClose "
+        "rcvd_code=1000 rcvd_reason='normal' sent_code=None sent_reason=None "
+        "last_frame_age_s=2.250 lifetime_s=5.500"
+    ]
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/test_esp32_client.py
+++ b/gateway/tests/test_esp32_client.py
@@ -4,11 +4,14 @@ import asyncio
 import gc
 import json
 import logging
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
 import websockets
+from websockets.frames import Close
 
+from stackchan_mcp import esp32_client
 from stackchan_mcp.esp32_client import ESP32Connection, ESP32Manager, _hardware_lane
 
 
@@ -27,6 +30,47 @@ async def manager():
     await mgr.stop()
 
 
+class _FakeServeServer:
+    def __init__(self) -> None:
+        self.closed = False
+        self.waited = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.waited = True
+
+
+class _ClosingHandlerWebSocket:
+    """Fake server-side WebSocket that raises a close exception from iteration."""
+
+    def __init__(
+        self,
+        messages: list[str | bytes],
+        close_exc: websockets.exceptions.ConnectionClosed,
+    ) -> None:
+        self._messages = messages
+        self._close_exc = close_exc
+        self.request = SimpleNamespace(headers={"Device-Id": "device-test"})
+        self.sent: list[str | bytes] = []
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return self._messages.pop(0)
+        raise self._close_exc
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
 @pytest.mark.asyncio
 async def test_manager_starts_and_stops():
     """Manager can start and stop cleanly."""
@@ -35,6 +79,40 @@ async def test_manager_starts_and_stops():
     assert mgr._server is not None
     await mgr.stop()
     assert mgr._server is None
+
+
+@pytest.mark.asyncio
+async def test_manager_start_sets_explicit_websocket_keepalive(monkeypatch, caplog):
+    """The gateway keeps websockets defaults explicit and visible in logs."""
+    captured: dict[str, object] = {}
+    fake_server = _FakeServeServer()
+
+    async def fake_serve(handler, host, port, **kwargs):
+        captured.update(
+            {
+                "handler": handler,
+                "host": host,
+                "port": port,
+                "kwargs": kwargs,
+            }
+        )
+        return fake_server
+
+    monkeypatch.setattr(websockets, "serve", fake_serve)
+    caplog.set_level(logging.INFO, logger="stackchan_mcp.esp32_client")
+    mgr = ESP32Manager()
+
+    await mgr.start("127.0.0.1", 8765)
+    await mgr.stop()
+
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 8765
+    kwargs = captured["kwargs"]
+    assert kwargs["ping_interval"] == 20
+    assert kwargs["ping_timeout"] == 20
+    assert fake_server.closed is True
+    assert fake_server.waited is True
+    assert "ping_interval=20 ping_timeout=20" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -210,6 +288,58 @@ async def test_esp32_disconnect_handling(manager):
     # Connection closed
     await asyncio.sleep(0.2)
     assert manager.device_connected is False
+
+
+@pytest.mark.asyncio
+async def test_handler_logs_close_details_with_last_frame_elapsed(monkeypatch, caplog):
+    """Disconnect logs include close class, close frames, and timing fields."""
+    ticks = iter([100.0, 103.25, 105.5])
+    monkeypatch.setattr(esp32_client, "_monotonic", lambda: next(ticks))
+    close_exc = websockets.exceptions.ConnectionClosedOK(
+        Close(1000, "normal"),
+        Close(1000, "ack"),
+        True,
+    )
+    ws = _ClosingHandlerWebSocket(
+        [json.dumps({"type": "noop"})],
+        close_exc,
+    )
+    caplog.set_level(logging.INFO, logger="stackchan_mcp.esp32_client")
+
+    await ESP32Manager()._handler(ws)  # type: ignore[arg-type]
+
+    assert "ESP32 disconnected: device=device-test" in caplog.text
+    assert "close_class=ConnectionClosedOK" in caplog.text
+    assert "rcvd_code=1000 rcvd_reason='normal'" in caplog.text
+    assert "sent_code=1000 sent_reason='ack'" in caplog.text
+    assert "last_frame_age_s=2.250" in caplog.text
+    assert "lifetime_s=5.500" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handler_logs_close_details_when_fields_are_missing(
+    monkeypatch,
+    caplog,
+):
+    """Missing close fields and missing inbound frames are logged safely."""
+    ticks = iter([200.0, 204.75])
+    monkeypatch.setattr(esp32_client, "_monotonic", lambda: next(ticks))
+    close_exc = websockets.exceptions.ConnectionClosedError(
+        Close(1006, "abnormal"),
+        None,
+        None,
+    )
+    ws = _ClosingHandlerWebSocket([], close_exc)
+    caplog.set_level(logging.INFO, logger="stackchan_mcp.esp32_client")
+
+    await ESP32Manager()._handler(ws)  # type: ignore[arg-type]
+
+    assert "ESP32 disconnected: device=device-test" in caplog.text
+    assert "close_class=ConnectionClosedError" in caplog.text
+    assert "rcvd_code=1006 rcvd_reason='abnormal'" in caplog.text
+    assert "sent_code=None sent_reason=None" in caplog.text
+    assert "last_frame_age_s=None" in caplog.text
+    assert "lifetime_s=4.750" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Background

When the ESP32 WebSocket connection dropped, the gateway logged only `ESP32 disconnected: device=<id>` — no close code, no reason, no clean-vs-abnormal distinction — which capped what could be learned from silent-disconnect incidents (see the 2026-07-10 data point on #239). The `websockets.serve()` keepalive policy (library defaults 20 s / 20 s) was also implicit and invisible in logs.

Closes #338.

## Implementation

Log-only; no behavioral change to reconnect or device handling:

- The disconnect log now includes the close class (`ConnectionClosedOK` / `ConnectionClosedError` / `GracefulClose`), `rcvd`/`sent` close codes and reason strings when present, elapsed time since the last frame received from the device, and total connection lifetime
- Graceful closes are covered too: when the receive loop exits normally (websockets consumes `ConnectionClosedOK` internally), the same enriched line is emitted from the post-loop path using `ws.close_code` / `ws.close_reason`, guarded to log exactly once per connection (flagged by `codex review` round 1)
- `ping_interval` / `ping_timeout` are now explicit in `websockets.serve()` (unchanged values, 20 s / 20 s) and logged once at server startup

## Validation

- `uv run pytest -q`: 682 passed, 1 skipped (includes new tests for abnormal-close logging, graceful-close logging exactly-once, and explicit keepalive settings)
- `uv run ruff check .`: clean
- `codex review` against main: round 1 P2 (graceful-close gap) fixed in the second commit; round 2 no findings

## Refs

- #338, #239 (diagnosability for the silent-break class; this does not fix the missing device-side keepalive itself — that remains PR #240 / upstream)
