### PR TITLE
release: cut pair release firmware-v1.15.0 + v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ documented-only.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-11
+
 ### Gateway
 
 - Added a `color_order` option (`grb` default, `rgb`) for Port B/C WS2812
@@ -43,6 +45,8 @@ documented-only.
   (#338)
 - Exposed the Port C WS2812 device tools and added `port_c` as a
   `stackchan_follow_led_stream` target. (#340)
+
+## [firmware-v1.15.0] - 2026-07-11
 
 ### Firmware
 
@@ -1797,7 +1801,9 @@ uv tool install stackchan-mcp
   alias, so the previous floating pin no longer resolved. ([#47])
 
 
-[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.15.0...v0.16.0
+[firmware-v1.15.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.14.0...firmware-v1.15.0
 [0.15.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/v0.14.0...v0.15.0
 [firmware-v1.14.0]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.1...firmware-v1.14.0
 [firmware-v1.13.1]: https://github.com/kisaragi-mochi/stackchan-mcp/compare/firmware-v1.13.0...firmware-v1.13.1

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stackchan-mcp"
-version = "0.15.0"
+version = "0.16.0"
 description = "Two-faced MCP gateway for StackChan (xiaozhi-esp32): bridges stdio MCP clients to the ESP32 over WebSocket + HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "stackchan-mcp"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Promotes the `[Unreleased]` entries to `[0.16.0]` (Gateway) and `[firmware-v1.15.0]` (Firmware), bumps `gateway/pyproject.toml` to 0.16.0, and regenerates `gateway/uv.lock`.

Release contents:
- **firmware-v1.15.0**: Port C (GPIO17) WS2812 generic MCP tools (#340 / #341)
- **v0.16.0**: `stackchan_follow_led_stream` (#335 / #337), Port C tool exposure + `port_c` stream target (#340 / #342), `color_order` option for RGB-wired NeoPixels (#343 / #344), enriched WebSocket disconnect logging + explicit keepalive policy (#338 / #345)

Pre-flight 4 checks passed (no open verification/blocker issues for the included PRs; CHANGELOG matches `git log` since the previous tags; no conflicting parallel work; no new priority bugs on the released paths). Port C + color_order verified on the real device today.

Tagging plan after merge (per CONTRIBUTING.md): `firmware-v1.15.0` first (workflow build + release), then `v0.16.0` (Trusted Publishing → PyPI + manual GitHub Release notes).