### PR TITLE
feat(stackchan): show_caption subtitle overlay (firmware + gateway relay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Added a `show_caption` tool that relays to the new
+  `self.display.show_caption` device tool, for showing an utterance as an
+  on-screen subtitle in silent operation.
+
+### Firmware
+
+- Added a `self.display.show_caption` device tool: a translucent bottom
+  subtitle band (small white text over the avatar, at most two lines with
+  ellipsis truncation) that fades out automatically after a configurable
+  duration. Font size (14/16/20 px Montserrat, ASCII-only) and band
+  opacity are per-call arguments so the look can be tuned without
+  reflashing. Intended for silent-mode operation where speech is shown
+  instead of spoken.
+
 ## [0.17.0] - 2026-07-12
 
 ### Gateway

--- a/firmware/main/boards/stackchan/config.json
+++ b/firmware/main/boards/stackchan/config.json
@@ -8,7 +8,9 @@
                 "CONFIG_CAMERA_GC0308=y",
                 "CONFIG_CAMERA_GC0308_AUTO_DETECT_DVP_INTERFACE_SENSOR=y",
                 "CONFIG_CAMERA_GC0308_DVP_YUV422_320X240_20FPS=y",
-                "CONFIG_STACKCHAN_SERVO_FEETECH=y"
+                "CONFIG_STACKCHAN_SERVO_FEETECH=y",
+                "CONFIG_LV_FONT_MONTSERRAT_16=y",
+                "CONFIG_LV_FONT_MONTSERRAT_20=y"
             ]
         }
     ]

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -61,6 +61,11 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 
 #define TAG "StackChanBoard"
 
+// Caption overlay text font — reuse the board's builtin puhui face
+// (BUILTIN_TEXT_FONT for stackchan in main/CMakeLists.txt) so the caption
+// adds zero flash cost. The basic subset covers everyday CJK.
+LV_FONT_DECLARE(font_puhui_basic_20_4);
+
 class Pmic : public Axp2101 {
 public:
     // Power Init
@@ -550,6 +555,22 @@ private:
     lv_obj_t* listening_indicator_dot_ = nullptr;
     std::atomic<bool> listening_indicator_visible_{false};
     static constexpr int LISTENING_INDICATOR_DOT_SIZE_PX = 14;
+
+    // Bottom caption overlay (self.display.show_caption): a translucent
+    // black band with small white text above the full-screen avatar layer.
+    // One utterance per call; auto-fades after caption_duration; at most
+    // two lines (longer text is pre-truncated with an ellipsis — the chat
+    // channel carries the full transcript).
+    lv_obj_t* caption_band_ = nullptr;
+    lv_obj_t* caption_label_ = nullptr;
+    esp_timer_handle_t caption_hide_timer_ = nullptr;
+    static constexpr int CAPTION_PAD_HOR_PX = 8;
+    static constexpr int CAPTION_PAD_VER_PX = 3;
+    static constexpr int CAPTION_FADE_MS = 300;
+    // Width budget for pre-truncation, measured in CJK glyph columns of the
+    // 20 px builtin text font: (320 - 2*8) / 20 = 15.2 -> 15 per line.
+    static constexpr int CAPTION_COLS_PER_LINE = 15;
+    static constexpr int CAPTION_MAX_LINES = 2;
 
     // Dynamic avatar set loaded via the load_avatar_set MCP tool. Stays
     // unloaded by default — the index-based image lookups then fall back
@@ -2456,6 +2477,236 @@ private:
         SetListeningIndicatorVisibleLocked(is_listening);
     }
 
+    // ---- Bottom caption overlay (self.display.show_caption) -------------
+
+    // Pre-truncate UTF-8 text to the two-line width budget, counting
+    // half-column units: ASCII glyphs are half a CJK column in the puhui
+    // font, all other codepoints one column. Appends an ellipsis when
+    // truncated. The MCP caller keeps the full transcript on the chat
+    // channel, so clipping here is presentation-only.
+    static std::string TruncateCaptionUtf8(const std::string& text,
+                                           bool* truncated) {
+        constexpr int kBudgetHalfCols =
+            CAPTION_COLS_PER_LINE * CAPTION_MAX_LINES * 2;
+        // Reserve one full column for the ellipsis when we have to cut.
+        constexpr int kCutHalfCols = kBudgetHalfCols - 2;
+        int half_cols = 0;
+        size_t i = 0;
+        size_t cut_bytes = 0;
+        bool needs_cut = false;
+        while (i < text.size()) {
+            const unsigned char c = static_cast<unsigned char>(text[i]);
+            size_t seq_len = 1;
+            if ((c & 0x80) == 0x00) seq_len = 1;
+            else if ((c & 0xE0) == 0xC0) seq_len = 2;
+            else if ((c & 0xF0) == 0xE0) seq_len = 3;
+            else if ((c & 0xF8) == 0xF0) seq_len = 4;
+            if (i + seq_len > text.size()) break;  // malformed tail: stop
+            const int w = (seq_len == 1) ? 1 : 2;
+            if (half_cols + w > kBudgetHalfCols) {
+                needs_cut = true;
+                break;
+            }
+            if (half_cols + w <= kCutHalfCols) {
+                cut_bytes = i + seq_len;
+            }
+            half_cols += w;
+            i += seq_len;
+        }
+        if (truncated != nullptr) {
+            *truncated = needs_cut;
+        }
+        if (!needs_cut) {
+            return text.substr(0, i);  // also drops a malformed tail byte
+        }
+        return text.substr(0, cut_bytes) + "\xE2\x80\xA6";  // U+2026 …
+    }
+
+    bool EnsureCaptionObjectLocked() {
+        if (caption_band_ != nullptr) {
+            if (lv_obj_is_valid(caption_band_) && caption_label_ != nullptr &&
+                lv_obj_is_valid(caption_label_)) {
+                return true;
+            }
+            StopCaptionFadeLocked();
+            if (lv_obj_is_valid(caption_band_)) {
+                lv_obj_del(caption_band_);
+            }
+        }
+        caption_band_ = nullptr;
+        caption_label_ = nullptr;
+
+        lv_obj_t* screen = lv_screen_active();
+        if (screen == nullptr) {
+            return false;
+        }
+
+        caption_band_ = lv_obj_create(screen);
+        if (caption_band_ == nullptr) {
+            return false;
+        }
+        lv_obj_set_width(caption_band_, DISPLAY_WIDTH);
+        lv_obj_set_height(caption_band_, LV_SIZE_CONTENT);
+        lv_obj_align(caption_band_, LV_ALIGN_BOTTOM_MID, 0, 0);
+        lv_obj_clear_flag(caption_band_, LV_OBJ_FLAG_SCROLLABLE);
+        // Full-bleed band: no frame, no rounding (the band spans the whole
+        // screen width, per the surface-3 caption design).
+        lv_obj_set_style_radius(caption_band_, 0, 0);
+        lv_obj_set_style_bg_color(caption_band_, lv_color_black(), 0);
+        lv_obj_set_style_bg_opa(caption_band_, LV_OPA_70, 0);
+        lv_obj_set_style_border_width(caption_band_, 0, 0);
+        lv_obj_set_style_pad_hor(caption_band_, CAPTION_PAD_HOR_PX, 0);
+        lv_obj_set_style_pad_ver(caption_band_, CAPTION_PAD_VER_PX, 0);
+
+        caption_label_ = lv_label_create(caption_band_);
+        if (caption_label_ == nullptr) {
+            lv_obj_del(caption_band_);
+            caption_band_ = nullptr;
+            return false;
+        }
+        lv_obj_set_width(caption_label_,
+                         DISPLAY_WIDTH - 2 * CAPTION_PAD_HOR_PX);
+        lv_label_set_long_mode(caption_label_, LV_LABEL_LONG_WRAP);
+        lv_obj_set_style_text_font(caption_label_, &font_puhui_basic_20_4, 0);
+        lv_obj_set_style_text_color(caption_label_, lv_color_white(), 0);
+        lv_obj_set_style_text_align(caption_label_, LV_TEXT_ALIGN_CENTER, 0);
+        lv_label_set_text(caption_label_, "");
+
+        lv_obj_add_flag(caption_band_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(caption_band_);
+        ESP_LOGI(TAG, "Caption band created on active screen");
+        return true;
+    }
+
+    static void SetCaptionOpacity(void* obj, int32_t opa) {
+        auto* band = static_cast<lv_obj_t*>(obj);
+        if (band == nullptr || !lv_obj_is_valid(band)) {
+            return;
+        }
+        lv_obj_set_style_opa(band, static_cast<lv_opa_t>(opa), 0);
+    }
+
+    // Runs in the LVGL timer context when the fade-out completes.
+    static void CaptionFadeDone(lv_anim_t* anim) {
+        auto* band = static_cast<lv_obj_t*>(anim->var);
+        if (band == nullptr || !lv_obj_is_valid(band)) {
+            return;
+        }
+        lv_obj_add_flag(band, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_opa(band, LV_OPA_COVER, 0);
+    }
+
+    void StopCaptionFadeLocked() {
+        if (caption_band_ == nullptr) {
+            return;
+        }
+        lv_anim_delete(caption_band_, nullptr);
+        if (lv_obj_is_valid(caption_band_)) {
+            lv_obj_set_style_opa(caption_band_, LV_OPA_COVER, 0);
+        }
+    }
+
+    void HideCaptionLocked(bool fade) {
+        if (caption_band_ == nullptr || !lv_obj_is_valid(caption_band_)) {
+            return;
+        }
+        if (lv_obj_has_flag(caption_band_, LV_OBJ_FLAG_HIDDEN)) {
+            return;
+        }
+        if (!fade) {
+            StopCaptionFadeLocked();
+            lv_obj_add_flag(caption_band_, LV_OBJ_FLAG_HIDDEN);
+            return;
+        }
+        StopCaptionFadeLocked();
+        lv_anim_t anim;
+        lv_anim_init(&anim);
+        lv_anim_set_var(&anim, caption_band_);
+        lv_anim_set_values(&anim, LV_OPA_COVER, LV_OPA_TRANSP);
+        lv_anim_set_exec_cb(&anim, SetCaptionOpacity);
+        lv_anim_set_duration(&anim, CAPTION_FADE_MS);
+        lv_anim_set_path_cb(&anim, lv_anim_path_ease_out);
+        lv_anim_set_completed_cb(&anim, CaptionFadeDone);
+        lv_anim_start(&anim);
+    }
+
+    void BringCaptionToFrontLocked() {
+        if (caption_band_ == nullptr) {
+            return;
+        }
+        if (!lv_obj_is_valid(caption_band_)) {
+            caption_band_ = nullptr;
+            caption_label_ = nullptr;
+            return;
+        }
+        lv_obj_move_foreground(caption_band_);
+    }
+
+    // One-shot timer: auto-fade the caption after its display duration.
+    // Fires on ESP_TIMER_TASK, so take the display lock like the other
+    // timer-driven LVGL writers on this board.
+    void EnsureCaptionHideTimer() {
+        if (caption_hide_timer_ != nullptr) {
+            return;
+        }
+        esp_timer_create_args_t timer_args = {
+            .callback = [](void* arg) {
+                auto* board = static_cast<StackChanBoard*>(arg);
+                if (board->display_ == nullptr) {
+                    return;
+                }
+                DisplayLockGuard lock(board->display_);
+                // A ShowCaption racing with this expiry re-arms the one-shot
+                // timer while holding the display lock; seeing it active here
+                // means a newer caption owns the band — leave it alone.
+                if (board->caption_hide_timer_ != nullptr &&
+                    esp_timer_is_active(board->caption_hide_timer_)) {
+                    return;
+                }
+                board->HideCaptionLocked(true);
+            },
+            .arg = this,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "caption_hide",
+            .skip_unhandled_events = true,
+        };
+        ESP_ERROR_CHECK(esp_timer_create(&timer_args, &caption_hide_timer_));
+    }
+
+    // Entry point used by the MCP tool. Empty text dismisses the current
+    // caption immediately (no fade).
+    bool ShowCaption(const std::string& text, int duration_ms,
+                     bool* truncated_out, std::string* shown_out) {
+        if (display_ == nullptr) {
+            return false;
+        }
+        EnsureCaptionHideTimer();
+        esp_timer_stop(caption_hide_timer_);  // no-op when not armed
+
+        DisplayLockGuard lock(display_);
+        if (text.empty()) {
+            HideCaptionLocked(false);
+            if (truncated_out != nullptr) *truncated_out = false;
+            if (shown_out != nullptr) shown_out->clear();
+            return true;
+        }
+        if (!EnsureCaptionObjectLocked()) {
+            return false;
+        }
+        bool truncated = false;
+        std::string shown = TruncateCaptionUtf8(text, &truncated);
+        StopCaptionFadeLocked();
+        lv_label_set_text(caption_label_, shown.c_str());
+        lv_obj_clear_flag(caption_band_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(caption_band_);
+        if (truncated_out != nullptr) *truncated_out = truncated;
+        if (shown_out != nullptr) *shown_out = std::move(shown);
+        ESP_ERROR_CHECK(esp_timer_start_once(
+            caption_hide_timer_,
+            static_cast<uint64_t>(duration_ms) * 1000ULL));
+        return true;
+    }
+
     void PollTouchpad() {
         static bool was_touched = false;
         static int64_t touch_start_time = 0;
@@ -4351,6 +4602,7 @@ private:
         lv_image_set_src(avatar_img_, dsc);
         lv_obj_move_foreground(avatar_img_);
         BringListeningIndicatorToFrontLocked();
+        BringCaptionToFrontLocked();
         return true;
     }
 
@@ -6117,6 +6369,48 @@ private:
                          (int)enabled,
                          deferred_by_fetch ? 1 : 0,
                          deferred_by_mouth_seq ? 1 : 0);
+                return root;
+            });
+
+        // Surface-3 caption: one-line subtitle band at the bottom of the
+        // LCD, above the avatar. Intended for silent-mode operation where
+        // the utterance is shown on screen instead of spoken; the chat
+        // channel carries the full transcript, so on-screen text may be
+        // truncated to two lines.
+        mcp_server.AddTool(
+            "self.display.show_caption",
+            "Show one utterance as a subtitle at the bottom of the LCD: a "
+            "translucent black band with small white text over the avatar. "
+            "The text is clipped to at most two lines (an ellipsis marks "
+            "the cut) and fades out automatically after duration_ms. "
+            "Calling again replaces the current caption and restarts the "
+            "timer. An empty text dismisses the caption immediately.",
+            PropertyList({Property("text", kPropertyTypeString),
+                          Property("duration_ms", kPropertyTypeInteger,
+                                   5000, 1000, 15000)}),
+            [this](const PropertyList& properties) -> ReturnValue {
+                std::string text = properties["text"].value<std::string>();
+                int duration_ms = properties["duration_ms"].value<int>();
+                bool truncated = false;
+                std::string shown;
+                bool applied =
+                    ShowCaption(text, duration_ms, &truncated, &shown);
+                cJSON* root = cJSON_CreateObject();
+                cJSON_AddBoolToObject(root, "ok", applied);
+                if (!applied) {
+                    cJSON_AddStringToObject(root, "error",
+                        "Display not ready yet; retry after a moment.");
+                } else if (text.empty()) {
+                    cJSON_AddBoolToObject(root, "dismissed", true);
+                } else {
+                    cJSON_AddBoolToObject(root, "truncated", truncated);
+                    cJSON_AddNumberToObject(root, "duration_ms", duration_ms);
+                }
+                ESP_LOGI(TAG,
+                         "show_caption: len=%u truncated=%d duration=%d "
+                         "applied=%d",
+                         (unsigned)text.size(), truncated ? 1 : 0,
+                         duration_ms, applied ? 1 : 0);
                 return root;
             });
 

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -576,18 +576,34 @@ private:
     static constexpr int CAPTION_MAX_LINES = 2;
 
     // Caption font sizes are snapped to the three compiled-in Montserrat
-    // faces. The per-line budgets for pre-truncation are conservative
+    // faces by minimum distance (a tie takes the smaller face — the
+    // smaller face has the larger per-line budget, so ties truncate
+    // less). The per-line budgets for pre-truncation are conservative
     // average-width ASCII character counts for the 304 px inner width
     // (Montserrat is variable-width); CJK codepoints count double.
+    static int SnapCaptionFontSize(int font_size) {
+        static constexpr int kFaces[] = {14, 16, 20};
+        int best = kFaces[0];
+        for (int face : kFaces) {
+            if (std::abs(font_size - face) < std::abs(font_size - best)) {
+                best = face;
+            }
+        }
+        return best;
+    }
     static const lv_font_t* CaptionFontForSize(int font_size) {
-        if (font_size <= 14) return &lv_font_montserrat_14;
-        if (font_size >= 20) return &lv_font_montserrat_20;
-        return &lv_font_montserrat_16;
+        switch (SnapCaptionFontSize(font_size)) {
+            case 14: return &lv_font_montserrat_14;
+            case 20: return &lv_font_montserrat_20;
+            default: return &lv_font_montserrat_16;
+        }
     }
     static int CaptionPerLineBudget(int font_size) {
-        if (font_size <= 14) return 36;
-        if (font_size >= 20) return 26;
-        return 32;
+        switch (SnapCaptionFontSize(font_size)) {
+            case 14: return 36;
+            case 20: return 26;
+            default: return 32;
+        }
     }
 
     // Dynamic avatar set loaded via the load_avatar_set MCP tool. Stays
@@ -2499,15 +2515,25 @@ private:
 
     // Pre-truncate UTF-8 text to the two-line width budget. Units are
     // average ASCII character widths for the active caption font: ASCII
-    // glyphs count 1, all other codepoints 2. Appends an ellipsis when
-    // truncated. The MCP caller keeps the full transcript on the chat
-    // channel, so clipping here is presentation-only.
-    static std::string TruncateCaptionUtf8(const std::string& text,
+    // glyphs count 1, all other codepoints 2. Appends an ASCII "..."
+    // when truncated — the compiled-in ASCII Montserrat faces have no
+    // U+2026 glyph, and with LV_USE_FONT_PLACEHOLDER off a missing
+    // glyph draws nothing. The MCP caller keeps the full transcript on
+    // the chat channel, so clipping here is presentation-only.
+    static std::string TruncateCaptionUtf8(const std::string& raw,
                                            int budget_units,
                                            bool* truncated) {
+        // The caption is one text flow wrapped by LVGL. A literal
+        // newline would add a rendered line regardless of the width
+        // budget and break the two-line contract, so control
+        // whitespace is normalized to spaces before budgeting.
+        std::string text = raw;
+        for (char& ch : text) {
+            if (ch == '\n' || ch == '\r' || ch == '\t') ch = ' ';
+        }
         const int kBudgetHalfCols = budget_units;
-        // Reserve roughly one character for the ellipsis when we cut.
-        const int kCutHalfCols = kBudgetHalfCols - 2;
+        // Reserve room for the three "..." characters when we cut.
+        const int kCutHalfCols = kBudgetHalfCols - 3;
         int half_cols = 0;
         size_t i = 0;
         size_t cut_bytes = 0;
@@ -2537,7 +2563,7 @@ private:
         if (!needs_cut) {
             return text.substr(0, i);  // also drops a malformed tail byte
         }
-        return text.substr(0, cut_bytes) + "\xE2\x80\xA6";  // U+2026 …
+        return text.substr(0, cut_bytes) + "...";
     }
 
     bool EnsureCaptionObjectLocked() {
@@ -2719,8 +2745,16 @@ private:
             text, CaptionPerLineBudget(font_size) * CAPTION_MAX_LINES,
             &truncated);
         StopCaptionFadeLocked();
-        lv_obj_set_style_text_font(caption_label_,
-                                   CaptionFontForSize(font_size), 0);
+        const lv_font_t* font = CaptionFontForSize(font_size);
+        lv_obj_set_style_text_font(caption_label_, font, 0);
+        // Hard ceiling on the two-line contract: the width budget is a
+        // character-count heuristic, so a run of wide glyphs can still
+        // wrap to a third line. Clamping the label to two text lines
+        // clips that overflow instead of letting the content-sized band
+        // grow past its documented maximum.
+        lv_obj_set_style_max_height(
+            caption_label_,
+            lv_font_get_line_height(font) * CAPTION_MAX_LINES, 0);
         lv_obj_set_style_bg_opa(
             caption_band_,
             static_cast<lv_opa_t>((bg_opa_pct * 255 + 50) / 100), 0);

--- a/firmware/main/boards/stackchan/stackchan.cc
+++ b/firmware/main/boards/stackchan/stackchan.cc
@@ -61,10 +61,16 @@ static inline bool ServoWritePosOk(int r) { return r > 0; }
 
 #define TAG "StackChanBoard"
 
-// Caption overlay text font — reuse the board's builtin puhui face
-// (BUILTIN_TEXT_FONT for stackchan in main/CMakeLists.txt) so the caption
-// adds zero flash cost. The basic subset covers everyday CJK.
-LV_FONT_DECLARE(font_puhui_basic_20_4);
+// Caption overlay text fonts — the caption register is English, so the
+// LVGL builtin Montserrat ASCII faces are used (10-20 KB per size, vs
+// ~450 KB for one CJK size). Three sizes are compiled in (see
+// LV_FONT_MONTSERRAT_* in boards/stackchan/config.json sdkconfig_append)
+// and selected per call via the font_size tool argument. CJK codepoints
+// have no glyphs in these faces and render blank; the chat channel
+// carries the full transcript.
+LV_FONT_DECLARE(lv_font_montserrat_14);
+LV_FONT_DECLARE(lv_font_montserrat_16);
+LV_FONT_DECLARE(lv_font_montserrat_20);
 
 class Pmic : public Axp2101 {
 public:
@@ -567,10 +573,22 @@ private:
     static constexpr int CAPTION_PAD_HOR_PX = 8;
     static constexpr int CAPTION_PAD_VER_PX = 3;
     static constexpr int CAPTION_FADE_MS = 300;
-    // Width budget for pre-truncation, measured in CJK glyph columns of the
-    // 20 px builtin text font: (320 - 2*8) / 20 = 15.2 -> 15 per line.
-    static constexpr int CAPTION_COLS_PER_LINE = 15;
     static constexpr int CAPTION_MAX_LINES = 2;
+
+    // Caption font sizes are snapped to the three compiled-in Montserrat
+    // faces. The per-line budgets for pre-truncation are conservative
+    // average-width ASCII character counts for the 304 px inner width
+    // (Montserrat is variable-width); CJK codepoints count double.
+    static const lv_font_t* CaptionFontForSize(int font_size) {
+        if (font_size <= 14) return &lv_font_montserrat_14;
+        if (font_size >= 20) return &lv_font_montserrat_20;
+        return &lv_font_montserrat_16;
+    }
+    static int CaptionPerLineBudget(int font_size) {
+        if (font_size <= 14) return 36;
+        if (font_size >= 20) return 26;
+        return 32;
+    }
 
     // Dynamic avatar set loaded via the load_avatar_set MCP tool. Stays
     // unloaded by default — the index-based image lookups then fall back
@@ -2479,17 +2497,17 @@ private:
 
     // ---- Bottom caption overlay (self.display.show_caption) -------------
 
-    // Pre-truncate UTF-8 text to the two-line width budget, counting
-    // half-column units: ASCII glyphs are half a CJK column in the puhui
-    // font, all other codepoints one column. Appends an ellipsis when
+    // Pre-truncate UTF-8 text to the two-line width budget. Units are
+    // average ASCII character widths for the active caption font: ASCII
+    // glyphs count 1, all other codepoints 2. Appends an ellipsis when
     // truncated. The MCP caller keeps the full transcript on the chat
     // channel, so clipping here is presentation-only.
     static std::string TruncateCaptionUtf8(const std::string& text,
+                                           int budget_units,
                                            bool* truncated) {
-        constexpr int kBudgetHalfCols =
-            CAPTION_COLS_PER_LINE * CAPTION_MAX_LINES * 2;
-        // Reserve one full column for the ellipsis when we have to cut.
-        constexpr int kCutHalfCols = kBudgetHalfCols - 2;
+        const int kBudgetHalfCols = budget_units;
+        // Reserve roughly one character for the ellipsis when we cut.
+        const int kCutHalfCols = kBudgetHalfCols - 2;
         int half_cols = 0;
         size_t i = 0;
         size_t cut_bytes = 0;
@@ -2567,7 +2585,7 @@ private:
         lv_obj_set_width(caption_label_,
                          DISPLAY_WIDTH - 2 * CAPTION_PAD_HOR_PX);
         lv_label_set_long_mode(caption_label_, LV_LABEL_LONG_WRAP);
-        lv_obj_set_style_text_font(caption_label_, &font_puhui_basic_20_4, 0);
+        lv_obj_set_style_text_font(caption_label_, &lv_font_montserrat_16, 0);
         lv_obj_set_style_text_color(caption_label_, lv_color_white(), 0);
         lv_obj_set_style_text_align(caption_label_, LV_TEXT_ALIGN_CENTER, 0);
         lv_label_set_text(caption_label_, "");
@@ -2674,9 +2692,12 @@ private:
     }
 
     // Entry point used by the MCP tool. Empty text dismisses the current
-    // caption immediately (no fade).
-    bool ShowCaption(const std::string& text, int duration_ms,
-                     bool* truncated_out, std::string* shown_out) {
+    // caption immediately (no fade). font_size snaps to 14/16/20 and
+    // bg_opa_pct (0-100) sets the band translucency, so the caption look
+    // can be tuned live without reflashing.
+    bool ShowCaption(const std::string& text, int duration_ms, int font_size,
+                     int bg_opa_pct, bool* truncated_out,
+                     std::string* shown_out) {
         if (display_ == nullptr) {
             return false;
         }
@@ -2694,8 +2715,15 @@ private:
             return false;
         }
         bool truncated = false;
-        std::string shown = TruncateCaptionUtf8(text, &truncated);
+        std::string shown = TruncateCaptionUtf8(
+            text, CaptionPerLineBudget(font_size) * CAPTION_MAX_LINES,
+            &truncated);
         StopCaptionFadeLocked();
+        lv_obj_set_style_text_font(caption_label_,
+                                   CaptionFontForSize(font_size), 0);
+        lv_obj_set_style_bg_opa(
+            caption_band_,
+            static_cast<lv_opa_t>((bg_opa_pct * 255 + 50) / 100), 0);
         lv_label_set_text(caption_label_, shown.c_str());
         lv_obj_clear_flag(caption_band_, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(caption_band_);
@@ -6384,17 +6412,26 @@ private:
             "The text is clipped to at most two lines (an ellipsis marks "
             "the cut) and fades out automatically after duration_ms. "
             "Calling again replaces the current caption and restarts the "
-            "timer. An empty text dismisses the caption immediately.",
+            "timer. An empty text dismisses the caption immediately. "
+            "font_size snaps to the nearest of 14, 16, or 20 px; bg_opa "
+            "is the band opacity in percent. English text expected: the "
+            "compiled fonts are ASCII-only and CJK renders blank.",
             PropertyList({Property("text", kPropertyTypeString),
                           Property("duration_ms", kPropertyTypeInteger,
-                                   5000, 1000, 15000)}),
+                                   5000, 1000, 15000),
+                          Property("font_size", kPropertyTypeInteger,
+                                   16, 14, 20),
+                          Property("bg_opa", kPropertyTypeInteger,
+                                   70, 0, 100)}),
             [this](const PropertyList& properties) -> ReturnValue {
                 std::string text = properties["text"].value<std::string>();
                 int duration_ms = properties["duration_ms"].value<int>();
+                int font_size = properties["font_size"].value<int>();
+                int bg_opa = properties["bg_opa"].value<int>();
                 bool truncated = false;
                 std::string shown;
-                bool applied =
-                    ShowCaption(text, duration_ms, &truncated, &shown);
+                bool applied = ShowCaption(text, duration_ms, font_size,
+                                           bg_opa, &truncated, &shown);
                 cJSON* root = cJSON_CreateObject();
                 cJSON_AddBoolToObject(root, "ok", applied);
                 if (!applied) {

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1077,6 +1077,10 @@ async def _dispatch_mcp_tool(
             "self.display.set_avatar",
             arguments,
         ),
+        "show_caption": (
+            "self.display.show_caption",
+            arguments,
+        ),
         "set_mouth": (
             "self.display.set_mouth",
             arguments,
@@ -1726,6 +1730,42 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                         },
                     },
                     "required": ["face"],
+                },
+            ),
+            Tool(
+                name="show_caption",
+                description=(
+                    "Show one utterance as a subtitle at the bottom of the "
+                    "LCD: a translucent black band with small white text "
+                    "over the avatar. The device clips the text to at most "
+                    "two lines (an ellipsis marks the cut) and fades the "
+                    "band out automatically after duration_ms. Calling "
+                    "again replaces the current caption and restarts the "
+                    "timer; an empty text dismisses it immediately. "
+                    "Intended for silent-mode operation where speech is "
+                    "shown instead of spoken while the chat channel "
+                    "carries the full transcript."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": (
+                                "Utterance to display. Empty string "
+                                "dismisses the current caption."
+                            ),
+                        },
+                        "duration_ms": {
+                            "type": "integer",
+                            "description": (
+                                "How long the caption stays before fading "
+                                "out, 1000-15000 ms (default 5000; the "
+                                "caption design targets 4000-6000)."
+                            ),
+                        },
+                    },
+                    "required": ["text"],
                 },
             ),
             Tool(

--- a/gateway/stackchan_mcp/stdio_server.py
+++ b/gateway/stackchan_mcp/stdio_server.py
@@ -1742,9 +1742,11 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                     "band out automatically after duration_ms. Calling "
                     "again replaces the current caption and restarts the "
                     "timer; an empty text dismisses it immediately. "
-                    "Intended for silent-mode operation where speech is "
-                    "shown instead of spoken while the chat channel "
-                    "carries the full transcript."
+                    "English text expected (the compiled caption fonts are "
+                    "ASCII-only; CJK renders blank). Intended for "
+                    "silent-mode operation where speech is shown instead "
+                    "of spoken while the chat channel carries the full "
+                    "transcript."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1752,8 +1754,8 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                         "text": {
                             "type": "string",
                             "description": (
-                                "Utterance to display. Empty string "
-                                "dismisses the current caption."
+                                "Utterance to display (English). Empty "
+                                "string dismisses the current caption."
                             ),
                         },
                         "duration_ms": {
@@ -1762,6 +1764,20 @@ def create_server(notify_config: NotifyConfig | None = None) -> StackChanServer:
                                 "How long the caption stays before fading "
                                 "out, 1000-15000 ms (default 5000; the "
                                 "caption design targets 4000-6000)."
+                            ),
+                        },
+                        "font_size": {
+                            "type": "integer",
+                            "description": (
+                                "Caption text size in px; snaps to the "
+                                "nearest of 14, 16, or 20 (default 16)."
+                            ),
+                        },
+                        "bg_opa": {
+                            "type": "integer",
+                            "description": (
+                                "Band opacity in percent, 0-100 "
+                                "(default 70)."
                             ),
                         },
                     },

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -392,6 +392,8 @@ async def test_list_tools_includes_show_caption():
     schema = tool.inputSchema
     assert schema["properties"]["text"]["type"] == "string"
     assert schema["properties"]["duration_ms"]["type"] == "integer"
+    assert schema["properties"]["font_size"]["type"] == "integer"
+    assert schema["properties"]["bg_opa"]["type"] == "integer"
     assert schema["required"] == ["text"]
 
 
@@ -429,7 +431,12 @@ async def test_show_caption_relays_to_device(monkeypatch):
             method="tools/call",
             params={
                 "name": "show_caption",
-                "arguments": {"text": "今晚不出声，字幕在这。", "duration_ms": 4500},
+                "arguments": {
+                    "text": "Quiet mode tonight; captions on.",
+                    "duration_ms": 4500,
+                    "font_size": 14,
+                    "bg_opa": 55,
+                },
             },
         )
     )
@@ -437,7 +444,12 @@ async def test_show_caption_relays_to_device(monkeypatch):
     assert calls == [
         (
             "self.display.show_caption",
-            {"text": "今晚不出声，字幕在这。", "duration_ms": 4500},
+            {
+                "text": "Quiet mode tonight; captions on.",
+                "duration_ms": 4500,
+                "font_size": 14,
+                "bg_opa": 55,
+            },
         )
     ]
 

--- a/gateway/tests/test_stdio_server.py
+++ b/gateway/tests/test_stdio_server.py
@@ -378,6 +378,71 @@ async def test_list_tools_includes_set_mouth_sequence():
 
 
 @pytest.mark.asyncio
+async def test_list_tools_includes_show_caption():
+    """show_caption is exposed to MCP clients with text required."""
+    server = create_server()
+
+    result = await server.request_handlers[ListToolsRequest](
+        ListToolsRequest(method="tools/list")
+    )
+
+    tool = next((t for t in result.root.tools if t.name == "show_caption"), None)
+    assert tool is not None, "show_caption tool should be registered"
+
+    schema = tool.inputSchema
+    assert schema["properties"]["text"]["type"] == "string"
+    assert schema["properties"]["duration_ms"]["type"] == "integer"
+    assert schema["required"] == ["text"]
+
+
+@pytest.mark.asyncio
+async def test_show_caption_relays_to_device(monkeypatch):
+    """show_caption forwards text/duration_ms to self.display.show_caption."""
+    calls = []
+
+    class FakeESP32:
+        device_connected = True
+
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"ok": True, "truncated": False, "duration_ms": 4500}
+                        ),
+                    }
+                ],
+            }, None
+
+    class FakeGateway:
+        esp32 = FakeESP32()
+
+    import stackchan_mcp.stdio_server as stdio_server
+
+    monkeypatch.setattr(stdio_server, "get_gateway", lambda: FakeGateway())
+    server = create_server()
+
+    await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            method="tools/call",
+            params={
+                "name": "show_caption",
+                "arguments": {"text": "今晚不出声，字幕在这。", "duration_ms": 4500},
+            },
+        )
+    )
+
+    assert calls == [
+        (
+            "self.display.show_caption",
+            {"text": "今晚不出声，字幕在这。", "duration_ms": 4500},
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_list_tools_includes_say():
     """say is exposed to MCP clients with text required."""
     server = create_server()


### PR DESCRIPTION
## Summary

Adds an on-screen subtitle path for silent operation, where speech is shown instead of spoken:

- **Firmware**: a `self.display.show_caption` device tool — a translucent bottom subtitle band over the avatar: small white text, at most two lines with ellipsis truncation, fading out automatically after a configurable duration. Font size (14/16/20 px Montserrat, ASCII-only) and band opacity are per-call arguments so the look can be tuned without reflashing.
- **Gateway**: a `show_caption` MCP tool relaying to the device tool, plus list/relay tests.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (722 passed, 5 skipped)
- [x] gateway: `uv run ruff check .`
- [ ] firmware: `python ./scripts/release.py stackchan` — not run locally, CI covers the build

### Hardware

- [x] Device boots without crash
- [x] Existing MCP tools still work where affected: `move_head`, `take_photo`, `set_volume`, `get_head_angles`
- [x] Existing touch/servo behavior still works where affected: tap, stroke, wobble
- [x] New behavior verified on real hardware: in daily service on a CoreS3 stack-chan since 2026-07-09; coexists with lip-sync and avatar rendering, band fades as configured, truncation behaves on two-line overflow

## Breaking changes

None (new tools only).

## Related issues

None.
