### PR TITLE
feat(gateway): command-queue watchdog — head timeout + saturation shedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- Added a command-queue watchdog to the HTTP daemon: a hung head-of-queue
+  dispatch is now force-dequeued after a per-tool timeout (default 30 s;
+  `say`/`listen`/`load_avatar_set` get longer budgets) instead of stalling
+  every queued command behind it, and a saturated queue sheds the oldest
+  cosmetic LED-class command to admit new commands (`say`, `set_avatar`,
+  `take_photo`, `move_head` and other one-shot commands are never
+  dropped). Interventions are logged and appended to the stackchan JSONL
+  event log (`event_type="queue"`), following the notify configuration's
+  JSONL path when one is set.
+
 ## [0.17.0] - 2026-07-12
 
 ### Gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,16 @@ documented-only.
 
 - Added a command-queue watchdog to the HTTP daemon: a hung head-of-queue
   dispatch is now force-dequeued after a per-tool timeout (default 30 s;
-  `say`/`listen`/`load_avatar_set` get longer budgets) instead of stalling
-  every queued command behind it, and a saturated queue sheds the oldest
-  cosmetic LED-class command to admit new commands (`say`, `set_avatar`,
-  `take_photo`, `move_head` and other one-shot commands are never
-  dropped). Interventions are logged and appended to the stackchan JSONL
-  event log (`event_type="queue"`), following the notify configuration's
-  JSONL path when one is set.
+  `say`/`listen`/`load_avatar_set` get longer budgets, and a
+  `load_avatar_set` call with an explicit `timeout` argument gets a
+  budget derived from that value so schema-legal long fetches are never
+  cut short) instead of stalling every queued command behind it, and a
+  saturated queue sheds the oldest cosmetic LED-class command (Port B
+  and Port C ws2812 frames alike) to admit new commands (`say`,
+  `set_avatar`, `take_photo`, `move_head` and other one-shot commands
+  are never dropped). Interventions are logged and appended to the
+  stackchan JSONL event log (`event_type="queue"`), following the
+  notify configuration's JSONL path and its `jsonl_enabled` gate.
 
 ## [0.17.0] - 2026-07-12
 

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -883,8 +883,13 @@ async def _run_streamable_http_daemon(
     set_notify_config = getattr(esp32, "set_notify_config", None)
     if callable(set_notify_config):
         set_notify_config(notify_config)
-    # Route queue-watchdog events into the same JSONL file as device events.
-    queue = CommandQueue(event_log_path=notify_config.jsonl_path)
+    # Route queue-watchdog events into the same JSONL file as device
+    # events, honoring the same jsonl_enabled gate as the device-event
+    # call sites.
+    queue = CommandQueue(
+        event_log_path=notify_config.jsonl_path,
+        event_log_enabled=notify_config.jsonl_enabled,
+    )
     app = build_app(
         queue,
         gateway=gateway,

--- a/gateway/stackchan_mcp/cli.py
+++ b/gateway/stackchan_mcp/cli.py
@@ -883,7 +883,8 @@ async def _run_streamable_http_daemon(
     set_notify_config = getattr(esp32, "set_notify_config", None)
     if callable(set_notify_config):
         set_notify_config(notify_config)
-    queue = CommandQueue()
+    # Route queue-watchdog events into the same JSONL file as device events.
+    queue = CommandQueue(event_log_path=notify_config.jsonl_path)
     app = build_app(
         queue,
         gateway=gateway,

--- a/gateway/stackchan_mcp/http_server.py
+++ b/gateway/stackchan_mcp/http_server.py
@@ -24,7 +24,16 @@ from starlette.routing import Route
 from starlette.types import Receive, Scope, Send
 
 from .notify_config import NotifyConfig
-from .queue import CommandQueue, QueueFull, QueueItem, build_queue_full_error
+from .queue import (
+    CommandDropped,
+    CommandQueue,
+    HeadTimeout,
+    QueueFull,
+    QueueItem,
+    build_dropped_error,
+    build_head_timeout_error,
+    build_queue_full_error,
+)
 from .stdio_server import _dispatch_mcp_tool, create_server
 
 # Follower lifecycle operations must remain callable when the ESP32 is
@@ -214,13 +223,20 @@ def _install_queue_tool_handler(
             enqueued_at=time.monotonic(),
         )
         try:
-            queue.enqueue(item)
+            queue.enqueue_with_backpressure(item)
+        except CommandDropped as exc:
+            return ErrorData(**build_dropped_error(exc))
         except QueueFull as exc:
             return ErrorData(**build_queue_full_error(exc.queue_depth))
 
         pending_items[item.correlation_id] = item
         try:
             content_or_error = await response_future
+        except HeadTimeout as exc:
+            return ErrorData(**build_head_timeout_error(exc))
+        except CommandDropped as exc:
+            # This item was queued, then evicted to admit a newer command.
+            return ErrorData(**build_dropped_error(exc))
         except asyncio.CancelledError:
             response_future.cancel()
             raise

--- a/gateway/stackchan_mcp/queue.py
+++ b/gateway/stackchan_mcp/queue.py
@@ -3,11 +3,40 @@
 This module follows the command-queue design in
 ``docs/178-http-transport-spike.md`` and intentionally stays independent from
 the HTTP MCP server, MCP SDK objects, and ESP32 gateway wiring.
+
+Queue watchdog
+--------------
+
+Two failure modes observed under sustained load are handled here rather
+than in the HTTP layer:
+
+* **Head-of-queue stall.** The dispatcher is single-flight: one hung
+  dispatch (a TTS engine that never answers, a device wedged mid-upload)
+  used to stall every queued command behind it until the process was
+  restarted. ``run_dispatcher`` now bounds each dispatch with a per-tool
+  timeout (:data:`DISPATCH_TIMEOUT_S`, long-running tools get overrides
+  in :data:`DISPATCH_TIMEOUT_OVERRIDES`), force-dequeues the head on
+  expiry, fails its response future with :class:`HeadTimeout`, and moves
+  on to the next item.
+
+* **Saturation lockout.** A full queue used to reject every newcomer
+  uniformly, so a burst of cosmetic LED frames could starve one-shot
+  commands (``say``, ``set_avatar``, ``take_photo``, ``move_head``).
+  :meth:`CommandQueue.enqueue_with_backpressure` instead evicts the
+  oldest queued *droppable* item (:data:`DROPPABLE_TOOLS` — cosmetic,
+  superseded-by-the-next-frame traffic) to admit the newcomer. Explicit
+  one-shot commands are never dropped; when nothing is evictable the
+  behaviour falls back to the original ``QueueFull`` rejection.
+
+Both interventions are logged at WARNING and appended to the stackchan
+JSONL event log (``event_type="queue"``) so drops are observable
+downstream rather than silent.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import time
 import uuid
@@ -16,13 +45,68 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 COMMAND_QUEUE_SIZE_ENV = "STACKCHAN_COMMAND_QUEUE_SIZE"
 DEFAULT_COMMAND_QUEUE_CAPACITY = 32
 QUEUE_FULL_ERROR_CODE = -32000
 QUEUE_FULL_MESSAGE = "stackchan command queue is full"
 QUEUE_FULL_RETRY_AFTER_MS = 250
 
+# Head-of-queue dispatch budget. Constants by design (not env-tunable):
+# the values encode protocol knowledge, not deployment preference.
+DISPATCH_TIMEOUT_S = 30.0
+# Tools whose legitimate runtime exceeds the default budget. Values are
+# upper bounds for a *healthy* run, with margin; they exist so the
+# watchdog never cuts a working call short:
+# - say: TTS synthesis + real-time-paced Opus streaming of the full
+#   utterance (a long paragraph can stream for over a minute).
+# - listen: capture window runs for the caller-requested duration plus
+#   STT turnaround.
+# - load_avatar_set: device-side HTTP fetch + SPIFFS/PSRAM adoption of a
+#   multi-hundred-KB archive (~40 s observed for a 90-frame set).
+DISPATCH_TIMEOUT_OVERRIDES: dict[str, float] = {
+    "say": 120.0,
+    "listen": 120.0,
+    "load_avatar_set": 180.0,
+}
+HEAD_TIMEOUT_ERROR_CODE = -32001
+HEAD_TIMEOUT_MESSAGE = "stackchan command timed out at queue head"
+
+# Cosmetic, high-frequency traffic where the next frame supersedes the
+# dropped one. Explicit one-shot commands (say / set_avatar /
+# take_photo / move_head / ...) are deliberately absent: they must
+# never be shed. port_b_ws2812_init is also excluded — it is setup, not
+# a frame.
+DROPPABLE_TOOLS = frozenset(
+    {
+        "set_led",
+        "set_leds",
+        "set_all_leds",
+        "clear_leds",
+        "port_b_ws2812_set_pixel",
+        "port_b_ws2812_set_strip",
+        "port_b_ws2812_refresh",
+        "port_b_ws2812_clear",
+    }
+)
+DROPPED_ERROR_CODE = -32002
+DROPPED_MESSAGE = "stackchan command dropped by queue backpressure"
+
+QUEUE_EVENT_TYPE = "queue"
+QUEUE_EVENT_SESSION_ID = "gateway"
+
 DispatchFn = Callable[["QueueItem"], Awaitable[Any]]
+
+
+def dispatch_timeout_for(tool_name: str) -> float:
+    """Return the head-of-queue dispatch budget for ``tool_name``."""
+    return DISPATCH_TIMEOUT_OVERRIDES.get(tool_name, DISPATCH_TIMEOUT_S)
+
+
+def is_droppable_tool(tool_name: str) -> bool:
+    """Return whether ``tool_name`` may be shed under queue saturation."""
+    return tool_name in DROPPABLE_TOOLS
 
 
 @dataclass(frozen=True)
@@ -47,6 +131,31 @@ class QueueFull(Exception):
         super().__init__(
             f"{QUEUE_FULL_MESSAGE} (queue_depth={queue_depth}, capacity={capacity})"
         )
+
+
+class HeadTimeout(Exception):
+    """Set on a response future when its dispatch exceeded the head budget."""
+
+    def __init__(self, tool_name: str, timeout_s: float) -> None:
+        self.tool_name = tool_name
+        self.timeout_s = timeout_s
+        super().__init__(
+            f"{HEAD_TIMEOUT_MESSAGE} (tool={tool_name}, timeout_s={timeout_s:g})"
+        )
+
+
+class CommandDropped(Exception):
+    """Command shed by queue backpressure.
+
+    Raised by :meth:`CommandQueue.enqueue_with_backpressure` when the
+    *incoming* droppable command is rejected, and set on the response
+    future of a queued victim evicted to admit a newer command.
+    """
+
+    def __init__(self, tool_name: str, reason: str) -> None:
+        self.tool_name = tool_name
+        self.reason = reason
+        super().__init__(f"{DROPPED_MESSAGE} (tool={tool_name}, reason={reason})")
 
 
 class CommandQueue:
@@ -77,6 +186,64 @@ class CommandQueue:
         except asyncio.QueueFull as exc:
             raise QueueFull(self.depth, self.capacity) from exc
 
+    def enqueue_with_backpressure(self, item: QueueItem) -> None:
+        """Enqueue ``item``, shedding droppable traffic when saturated.
+
+        On a full queue, the oldest queued droppable item is evicted (its
+        response future fails with :class:`CommandDropped`) and ``item``
+        takes its place. When nothing is evictable, a droppable ``item``
+        is itself rejected with :class:`CommandDropped`; a non-droppable
+        ``item`` falls back to the original :class:`QueueFull` rejection
+        so callers keep their retry/backoff behaviour.
+        """
+        try:
+            self.enqueue(item)
+            return
+        except QueueFull:
+            pass
+
+        victim = self._evict_oldest_droppable()
+        if victim is not None:
+            queued_ms = int((time.monotonic() - victim.enqueued_at) * 1000)
+            self._record_queue_event(
+                "drop_oldest",
+                victim.tool_name,
+                duration_ms=max(queued_ms, 0),
+                detail=f"evicted for incoming {item.tool_name}",
+            )
+            if not victim.response_future.done():
+                victim.response_future.set_exception(
+                    CommandDropped(victim.tool_name, "evicted_oldest_droppable")
+                )
+            # Capacity freed by the eviction; a concurrent producer cannot
+            # interleave here (single-threaded event loop, no awaits since
+            # the eviction).
+            self.enqueue(item)
+            return
+
+        if is_droppable_tool(item.tool_name):
+            self._record_queue_event(
+                "drop_incoming",
+                item.tool_name,
+                duration_ms=0,
+                detail="queue full, no evictable items",
+            )
+            raise CommandDropped(item.tool_name, "queue_full_incoming_droppable")
+
+        raise QueueFull(self.depth, self.capacity)
+
+    def _evict_oldest_droppable(self) -> QueueItem | None:
+        """Remove and return the oldest queued droppable item, if any."""
+        raw_queue = self._queue._queue  # deque[QueueItem]; owned by this class
+        for queued in raw_queue:
+            if is_droppable_tool(queued.tool_name):
+                raw_queue.remove(queued)
+                # Keep join()/unfinished-task bookkeeping consistent for
+                # the item that will never reach the dispatcher.
+                self._queue.task_done()
+                return queued
+        return None
+
     async def get(self) -> QueueItem:
         """Await the next queued item in FIFO order."""
         return await self._queue.get()
@@ -84,14 +251,31 @@ class CommandQueue:
     async def run_dispatcher(self, dispatch_fn: DispatchFn) -> None:
         """Dispatch commands one at a time and complete each response future.
 
-        The injected dispatch function is awaited to completion before the next
-        queue item is fetched. Exceptions from dispatch_fn are delivered to the
-        item's response_future so the dispatcher loop can continue.
+        The injected dispatch function is awaited to completion before the
+        next queue item is fetched, bounded by a per-tool watchdog timeout
+        (:func:`dispatch_timeout_for`). A dispatch that exceeds its budget
+        is cancelled and force-dequeued: its response future fails with
+        :class:`HeadTimeout` and the loop continues with the next item, so
+        one hung command can no longer stall the whole queue. Other
+        exceptions from dispatch_fn are delivered to the item's
+        response_future so the dispatcher loop can continue.
         """
         while True:
             item = await self.get()
+            timeout_s = dispatch_timeout_for(item.tool_name)
             try:
-                result = await dispatch_fn(item)
+                result = await asyncio.wait_for(dispatch_fn(item), timeout_s)
+            except (asyncio.TimeoutError, TimeoutError):
+                self._record_queue_event(
+                    "head_timeout",
+                    item.tool_name,
+                    duration_ms=int(timeout_s * 1000),
+                    detail="dispatch cancelled, continuing with next item",
+                )
+                if not item.response_future.done():
+                    item.response_future.set_exception(
+                        HeadTimeout(item.tool_name, timeout_s)
+                    )
             except Exception as exc:
                 if not item.response_future.done():
                     item.response_future.set_exception(exc)
@@ -100,6 +284,47 @@ class CommandQueue:
                     item.response_future.set_result(result)
             finally:
                 self._queue.task_done()
+
+    def _record_queue_event(
+        self,
+        subtype: str,
+        tool_name: str,
+        *,
+        duration_ms: int,
+        detail: str,
+    ) -> None:
+        """Log a watchdog intervention and append it to the JSONL event log.
+
+        Queue events reuse the stackchan event log so downstream consumers
+        see drops and head timeouts next to device events. ``ts`` (firmware
+        uptime) has no meaning for gateway-originated entries and is written
+        as 0; ``session_id`` is the fixed marker ``"gateway"``. Persistence
+        is fire-and-forget: the import is lazy and every failure is
+        swallowed after a WARNING, so event-log issues can never affect
+        dispatch.
+        """
+        logger.warning(
+            "queue watchdog: %s tool=%s duration_ms=%d depth=%d/%d (%s)",
+            subtype,
+            tool_name,
+            duration_ms,
+            self.depth,
+            self.capacity,
+            detail,
+        )
+        try:
+            from .event_log import log_event
+
+            log_event(
+                event_type=QUEUE_EVENT_TYPE,
+                subtype=subtype,
+                duration_ms=duration_ms,
+                ts=0,
+                session_id=QUEUE_EVENT_SESSION_ID,
+                action=tool_name,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.warning("queue event log persistence failed: %s", exc)
 
 
 def build_queue_full_error(
@@ -113,6 +338,30 @@ def build_queue_full_error(
         "data": {
             "queue_depth": queue_depth,
             "retry_after_ms": retry_after_ms,
+        },
+    }
+
+
+def build_head_timeout_error(exc: HeadTimeout) -> dict[str, Any]:
+    """Build the JSON-RPC inner error payload for a head-of-queue timeout."""
+    return {
+        "code": HEAD_TIMEOUT_ERROR_CODE,
+        "message": HEAD_TIMEOUT_MESSAGE,
+        "data": {
+            "tool_name": exc.tool_name,
+            "timeout_s": exc.timeout_s,
+        },
+    }
+
+
+def build_dropped_error(exc: CommandDropped) -> dict[str, Any]:
+    """Build the JSON-RPC inner error payload for a backpressure drop."""
+    return {
+        "code": DROPPED_ERROR_CODE,
+        "message": DROPPED_MESSAGE,
+        "data": {
+            "tool_name": exc.tool_name,
+            "reason": exc.reason,
         },
     }
 

--- a/gateway/stackchan_mcp/queue.py
+++ b/gateway/stackchan_mcp/queue.py
@@ -43,6 +43,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -161,13 +162,23 @@ class CommandDropped(Exception):
 class CommandQueue:
     """Asyncio-backed bounded FIFO queue for serialized command dispatch."""
 
-    def __init__(self, capacity: int | None = None) -> None:
+    def __init__(
+        self,
+        capacity: int | None = None,
+        *,
+        event_log_path: Path | None = None,
+    ) -> None:
         self._capacity = capacity if capacity is not None else _capacity_from_env()
         if self._capacity < 1:
             raise ValueError("command queue capacity must be at least 1")
         self._queue: asyncio.Queue[QueueItem] = asyncio.Queue(
             maxsize=self._capacity
         )
+        # Where watchdog events are appended. None falls back to the
+        # event log's own resolution (STACKCHAN_EVENTS_PATH env / default);
+        # the HTTP daemon passes the notify.yml JSONL path so queue events
+        # land in the same file as device events.
+        self._event_log_path = event_log_path
 
     @property
     def capacity(self) -> int:
@@ -322,6 +333,7 @@ class CommandQueue:
                 ts=0,
                 session_id=QUEUE_EVENT_SESSION_ID,
                 action=tool_name,
+                path=self._event_log_path,
             )
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.warning("queue event log persistence failed: %s", exc)

--- a/gateway/stackchan_mcp/queue.py
+++ b/gateway/stackchan_mcp/queue.py
@@ -14,10 +14,11 @@ than in the HTTP layer:
   dispatch (a TTS engine that never answers, a device wedged mid-upload)
   used to stall every queued command behind it until the process was
   restarted. ``run_dispatcher`` now bounds each dispatch with a per-tool
-  timeout (:data:`DISPATCH_TIMEOUT_S`, long-running tools get overrides
-  in :data:`DISPATCH_TIMEOUT_OVERRIDES`), force-dequeues the head on
-  expiry, fails its response future with :class:`HeadTimeout`, and moves
-  on to the next item.
+  timeout (:data:`DISPATCH_TIMEOUT_S`; long-running tools get overrides
+  in :data:`DISPATCH_TIMEOUT_OVERRIDES`, and tools whose schema accepts
+  a per-call timeout get a dynamic budget via :data:`CALL_TIMEOUT_ARGS`),
+  force-dequeues the head on expiry, fails its response future with
+  :class:`HeadTimeout`, and moves on to the next item.
 
 * **Saturation lockout.** A full queue used to reject every newcomer
   uniformly, so a burst of cosmetic LED frames could starve one-shot
@@ -71,14 +72,25 @@ DISPATCH_TIMEOUT_OVERRIDES: dict[str, float] = {
     "listen": 120.0,
     "load_avatar_set": 180.0,
 }
+# Tools whose public schema accepts a per-call timeout that may exceed
+# the static override. The dispatch budget follows the caller's value
+# plus margin so the watchdog never cuts short a call the schema
+# permits: the inner wait always expires (and reports its own error)
+# before the watchdog would. Values are (argument name, schema maximum)
+# — the cap mirrors the tool's declared "maximum" so an out-of-schema
+# argument cannot disable the watchdog.
+CALL_TIMEOUT_ARGS: dict[str, tuple[str, float]] = {
+    "load_avatar_set": ("timeout", 300.0),
+}
+CALL_TIMEOUT_MARGIN_S = 30.0
 HEAD_TIMEOUT_ERROR_CODE = -32001
 HEAD_TIMEOUT_MESSAGE = "stackchan command timed out at queue head"
 
 # Cosmetic, high-frequency traffic where the next frame supersedes the
 # dropped one. Explicit one-shot commands (say / set_avatar /
 # take_photo / move_head / ...) are deliberately absent: they must
-# never be shed. port_b_ws2812_init is also excluded — it is setup, not
-# a frame.
+# never be shed. The Port B/C ws2812 *_init tools are also excluded —
+# they are setup, not frames.
 DROPPABLE_TOOLS = frozenset(
     {
         "set_led",
@@ -89,6 +101,10 @@ DROPPABLE_TOOLS = frozenset(
         "port_b_ws2812_set_strip",
         "port_b_ws2812_refresh",
         "port_b_ws2812_clear",
+        "port_c_ws2812_set_pixel",
+        "port_c_ws2812_set_strip",
+        "port_c_ws2812_refresh",
+        "port_c_ws2812_clear",
     }
 )
 DROPPED_ERROR_CODE = -32002
@@ -100,9 +116,29 @@ QUEUE_EVENT_SESSION_ID = "gateway"
 DispatchFn = Callable[["QueueItem"], Awaitable[Any]]
 
 
-def dispatch_timeout_for(tool_name: str) -> float:
-    """Return the head-of-queue dispatch budget for ``tool_name``."""
-    return DISPATCH_TIMEOUT_OVERRIDES.get(tool_name, DISPATCH_TIMEOUT_S)
+def dispatch_timeout_for(
+    tool_name: str, arguments: dict[str, Any] | None = None
+) -> float:
+    """Return the head-of-queue dispatch budget for ``tool_name``.
+
+    For tools listed in :data:`CALL_TIMEOUT_ARGS` the caller's own
+    timeout argument (clamped to the tool's schema maximum) extends the
+    budget by :data:`CALL_TIMEOUT_MARGIN_S`, so a call the public schema
+    permits is never cancelled by the watchdog while still inside its
+    own wait window. A missing or malformed argument falls back to the
+    static budget.
+    """
+    budget = DISPATCH_TIMEOUT_OVERRIDES.get(tool_name, DISPATCH_TIMEOUT_S)
+    spec = CALL_TIMEOUT_ARGS.get(tool_name)
+    if spec is not None and arguments is not None:
+        arg_name, schema_max = spec
+        try:
+            caller_s = float(arguments.get(arg_name))
+        except (TypeError, ValueError):
+            return budget
+        if caller_s > 0:
+            budget = max(budget, min(caller_s, schema_max) + CALL_TIMEOUT_MARGIN_S)
+    return budget
 
 
 def is_droppable_tool(tool_name: str) -> bool:
@@ -167,6 +203,7 @@ class CommandQueue:
         capacity: int | None = None,
         *,
         event_log_path: Path | None = None,
+        event_log_enabled: bool = True,
     ) -> None:
         self._capacity = capacity if capacity is not None else _capacity_from_env()
         if self._capacity < 1:
@@ -177,8 +214,13 @@ class CommandQueue:
         # Where watchdog events are appended. None falls back to the
         # event log's own resolution (STACKCHAN_EVENTS_PATH env / default);
         # the HTTP daemon passes the notify.yml JSONL path so queue events
-        # land in the same file as device events.
+        # land in the same file as device events. ``event_log_enabled``
+        # mirrors the notify config's ``jsonl_enabled`` flag: when False
+        # no JSONL entry is written (WARNING logging is unaffected), so a
+        # deployment with JSONL logging disabled never gets the file
+        # created as a side effect of a queue intervention.
         self._event_log_path = event_log_path
+        self._event_log_enabled = event_log_enabled
 
     @property
     def capacity(self) -> int:
@@ -273,7 +315,7 @@ class CommandQueue:
         """
         while True:
             item = await self.get()
-            timeout_s = dispatch_timeout_for(item.tool_name)
+            timeout_s = dispatch_timeout_for(item.tool_name, item.arguments)
             try:
                 result = await asyncio.wait_for(dispatch_fn(item), timeout_s)
             except (asyncio.TimeoutError, TimeoutError):
@@ -323,6 +365,8 @@ class CommandQueue:
             self.capacity,
             detail,
         )
+        if not self._event_log_enabled:
+            return
         try:
             from .event_log import log_event
 

--- a/gateway/tests/test_queue_watchdog.py
+++ b/gateway/tests/test_queue_watchdog.py
@@ -1,0 +1,324 @@
+"""Command-queue watchdog tests: head-of-queue timeout + saturation shedding.
+
+Covers the two failure modes the watchdog exists for (a hung dispatch
+stalling every queued command; a saturated queue rejecting one-shot
+commands while cosmetic LED traffic occupies it) plus the JSONL event
+trail both interventions leave.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+
+import pytest
+
+import stackchan_mcp.queue as queue_module
+from stackchan_mcp.event_log import PATH_ENV_VAR
+from stackchan_mcp.http_server import build_app
+from stackchan_mcp.queue import (
+    DROPPED_ERROR_CODE,
+    HEAD_TIMEOUT_ERROR_CODE,
+    CommandDropped,
+    CommandQueue,
+    HeadTimeout,
+    QueueFull,
+    QueueItem,
+    build_dropped_error,
+    build_head_timeout_error,
+    dispatch_timeout_for,
+    is_droppable_tool,
+)
+from tests.test_http_server import (
+    FakeGateway,
+    _call_tool,
+    _client,
+    _initialize,
+    _wait_for_queue_depth,
+)
+
+
+def _make_item(tool_name: str, *, request_id: int = 1) -> QueueItem:
+    return QueueItem(
+        correlation_id=f"{tool_name}-{request_id}",
+        client_session_id=None,
+        client_request_id=request_id,
+        tool_name=tool_name,
+        arguments={},
+        response_future=asyncio.get_running_loop().create_future(),
+        enqueued_at=0.0,
+    )
+
+
+def _read_queue_events(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    lines = [json.loads(line) for line in path.read_text().splitlines() if line]
+    return [line for line in lines if line.get("event_type") == "queue"]
+
+
+def test_droppable_classification() -> None:
+    # Cosmetic LED-class traffic may be shed.
+    for tool in (
+        "set_led",
+        "set_leds",
+        "set_all_leds",
+        "clear_leds",
+        "port_b_ws2812_set_pixel",
+        "port_b_ws2812_set_strip",
+        "port_b_ws2812_refresh",
+        "port_b_ws2812_clear",
+    ):
+        assert is_droppable_tool(tool), tool
+    # Explicit one-shot commands must never be shed. move_head stays
+    # protected even though breathing micro-sway rides the same tool.
+    for tool in (
+        "say",
+        "set_avatar",
+        "take_photo",
+        "move_head",
+        "set_blink",
+        "load_avatar_set",
+        "take_photo",
+        "port_b_ws2812_init",
+    ):
+        assert not is_droppable_tool(tool), tool
+
+
+def test_dispatch_timeout_overrides() -> None:
+    assert dispatch_timeout_for("get_device_info") == queue_module.DISPATCH_TIMEOUT_S
+    assert dispatch_timeout_for("say") > queue_module.DISPATCH_TIMEOUT_S
+    assert dispatch_timeout_for("load_avatar_set") > queue_module.DISPATCH_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+async def test_head_timeout_force_dequeues_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(queue_module, "DISPATCH_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(queue_module, "DISPATCH_TIMEOUT_OVERRIDES", {})
+
+    queue = CommandQueue(capacity=4)
+    hung = _make_item("say", request_id=1)
+    healthy = _make_item("get_device_info", request_id=2)
+    queue.enqueue(hung)
+    queue.enqueue(healthy)
+
+    never = asyncio.Event()
+
+    async def dispatch(item: QueueItem) -> str:
+        if item.tool_name == "say":
+            await never.wait()
+        return item.tool_name
+
+    dispatcher = asyncio.create_task(queue.run_dispatcher(dispatch))
+    try:
+        # The queue self-heals: the item behind the hung head completes.
+        assert await asyncio.wait_for(healthy.response_future, timeout=2.0) == (
+            "get_device_info"
+        )
+        with pytest.raises(HeadTimeout) as excinfo:
+            await hung.response_future
+    finally:
+        dispatcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatcher
+
+    assert excinfo.value.tool_name == "say"
+    error = build_head_timeout_error(excinfo.value)
+    assert error["code"] == HEAD_TIMEOUT_ERROR_CODE
+    assert error["data"]["tool_name"] == "say"
+
+
+@pytest.mark.asyncio
+async def test_head_timeout_appends_jsonl_event(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events_path = tmp_path / "stackchan-events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(events_path))
+    monkeypatch.setattr(queue_module, "DISPATCH_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(queue_module, "DISPATCH_TIMEOUT_OVERRIDES", {})
+
+    queue = CommandQueue(capacity=2)
+    hung = _make_item("take_photo")
+    queue.enqueue(hung)
+
+    async def dispatch(item: QueueItem) -> str:
+        await asyncio.Event().wait()
+        return item.tool_name
+
+    dispatcher = asyncio.create_task(queue.run_dispatcher(dispatch))
+    try:
+        with pytest.raises(HeadTimeout):
+            await asyncio.wait_for(hung.response_future, timeout=2.0)
+    finally:
+        dispatcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatcher
+
+    events = _read_queue_events(events_path)
+    assert len(events) == 1
+    event = events[0]
+    assert event["subtype"] == "head_timeout"
+    assert event["action"] == "take_photo"
+    assert event["session_id"] == "gateway"
+    assert event["duration_ms"] == 50
+
+
+@pytest.mark.asyncio
+async def test_backpressure_evicts_oldest_droppable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events_path = tmp_path / "stackchan-events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(events_path))
+
+    queue = CommandQueue(capacity=3)
+    led_old = _make_item("set_all_leds", request_id=1)
+    keeper = _make_item("get_device_info", request_id=2)
+    led_new = _make_item("set_led", request_id=3)
+    for item in (led_old, keeper, led_new):
+        queue.enqueue(item)
+    assert queue.depth == 3
+
+    incoming = _make_item("say", request_id=4)
+    queue.enqueue_with_backpressure(incoming)
+
+    # Oldest droppable evicted; everything else (including the newer LED
+    # frame) kept, incoming admitted at the tail.
+    assert queue.depth == 3
+    with pytest.raises(CommandDropped) as excinfo:
+        await led_old.response_future
+    assert excinfo.value.reason == "evicted_oldest_droppable"
+    error = build_dropped_error(excinfo.value)
+    assert error["code"] == DROPPED_ERROR_CODE
+    assert error["data"]["tool_name"] == "set_all_leds"
+    assert not keeper.response_future.done()
+    assert not led_new.response_future.done()
+    assert not incoming.response_future.done()
+
+    remaining = [queued.tool_name for queued in queue._queue._queue]
+    assert remaining == ["get_device_info", "set_led", "say"]
+
+    events = _read_queue_events(events_path)
+    assert len(events) == 1
+    assert events[0]["subtype"] == "drop_oldest"
+    assert events[0]["action"] == "set_all_leds"
+
+
+@pytest.mark.asyncio
+async def test_backpressure_drops_incoming_droppable_when_nothing_evictable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events_path = tmp_path / "stackchan-events.jsonl"
+    monkeypatch.setenv(PATH_ENV_VAR, str(events_path))
+
+    queue = CommandQueue(capacity=2)
+    queue.enqueue(_make_item("say", request_id=1))
+    queue.enqueue(_make_item("move_head", request_id=2))
+
+    with pytest.raises(CommandDropped) as excinfo:
+        queue.enqueue_with_backpressure(_make_item("set_all_leds", request_id=3))
+    assert excinfo.value.reason == "queue_full_incoming_droppable"
+    assert queue.depth == 2
+
+    events = _read_queue_events(events_path)
+    assert len(events) == 1
+    assert events[0]["subtype"] == "drop_incoming"
+    assert events[0]["action"] == "set_all_leds"
+
+
+@pytest.mark.asyncio
+async def test_backpressure_keeps_queue_full_for_non_droppable() -> None:
+    queue = CommandQueue(capacity=2)
+    queue.enqueue(_make_item("say", request_id=1))
+    queue.enqueue(_make_item("take_photo", request_id=2))
+
+    with pytest.raises(QueueFull):
+        queue.enqueue_with_backpressure(_make_item("move_head", request_id=3))
+    assert queue.depth == 2
+
+
+@pytest.mark.asyncio
+async def test_http_head_timeout_returns_jsonrpc_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(queue_module, "DISPATCH_TIMEOUT_S", 0.1)
+    monkeypatch.setattr(queue_module, "DISPATCH_TIMEOUT_OVERRIDES", {})
+
+    async def hang(_item: QueueItem):
+        await asyncio.Event().wait()
+
+    queue = CommandQueue(capacity=2)
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+        dispatch_fn=hang,
+    )
+
+    async with _client(app) as client:
+        session_id = await _initialize(client)
+        response = await _call_tool(
+            client,
+            session_id=session_id,
+            name="get_device_info",
+            request_id=20,
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == 20
+    assert payload["error"]["code"] == HEAD_TIMEOUT_ERROR_CODE
+    assert payload["error"]["data"]["tool_name"] == "get_device_info"
+
+
+@pytest.mark.asyncio
+async def test_http_saturation_evicts_led_and_admits_say() -> None:
+    # No dispatcher: items stay queued, so capacity=1 saturates immediately.
+    queue = CommandQueue(capacity=1)
+    app = build_app(
+        queue,
+        gateway=FakeGateway(),
+        owner_id="owner-test",
+        host="127.0.0.1",
+        port=8767,
+    )
+
+    async with _client(app) as client:
+        session_id = await _initialize(client)
+        led_call = asyncio.create_task(
+            _call_tool(
+                client,
+                session_id=session_id,
+                name="set_all_leds",
+                arguments={"r": 1, "g": 2, "b": 3},
+                request_id=30,
+            )
+        )
+        await _wait_for_queue_depth(queue, 1)
+        say_call = asyncio.create_task(
+            _call_tool(
+                client,
+                session_id=session_id,
+                name="say",
+                arguments={"text": "hello"},
+                request_id=31,
+            )
+        )
+        # The LED call resolves with the drop error once evicted.
+        led_response = await asyncio.wait_for(led_call, timeout=2.0)
+        assert queue.depth == 1
+        say_call.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await say_call
+
+    assert led_response.status_code == 200
+    payload = led_response.json()
+    assert payload["id"] == 30
+    assert payload["error"]["code"] == DROPPED_ERROR_CODE
+    assert payload["error"]["data"]["tool_name"] == "set_all_leds"
+    assert payload["error"]["data"]["reason"] == "evicted_oldest_droppable"

--- a/gateway/tests/test_queue_watchdog.py
+++ b/gateway/tests/test_queue_watchdog.py
@@ -230,6 +230,24 @@ async def test_backpressure_drops_incoming_droppable_when_nothing_evictable(
 
 
 @pytest.mark.asyncio
+async def test_queue_events_honor_explicit_event_log_path(tmp_path: Path) -> None:
+    # The HTTP daemon passes the notify.yml JSONL path so queue events land
+    # in the same file as device events; env/default resolution is only the
+    # fallback.
+    events_path = tmp_path / "notify-configured.jsonl"
+    queue = CommandQueue(capacity=2, event_log_path=events_path)
+    queue.enqueue(_make_item("say", request_id=1))
+    queue.enqueue(_make_item("move_head", request_id=2))
+
+    with pytest.raises(CommandDropped):
+        queue.enqueue_with_backpressure(_make_item("set_all_leds", request_id=3))
+
+    events = _read_queue_events(events_path)
+    assert len(events) == 1
+    assert events[0]["subtype"] == "drop_incoming"
+
+
+@pytest.mark.asyncio
 async def test_backpressure_keeps_queue_full_for_non_droppable() -> None:
     queue = CommandQueue(capacity=2)
     queue.enqueue(_make_item("say", request_id=1))

--- a/gateway/tests/test_queue_watchdog.py
+++ b/gateway/tests/test_queue_watchdog.py
@@ -40,13 +40,18 @@ from tests.test_http_server import (
 )
 
 
-def _make_item(tool_name: str, *, request_id: int = 1) -> QueueItem:
+def _make_item(
+    tool_name: str,
+    *,
+    request_id: int = 1,
+    arguments: dict | None = None,
+) -> QueueItem:
     return QueueItem(
         correlation_id=f"{tool_name}-{request_id}",
         client_session_id=None,
         client_request_id=request_id,
         tool_name=tool_name,
-        arguments={},
+        arguments=arguments or {},
         response_future=asyncio.get_running_loop().create_future(),
         enqueued_at=0.0,
     )
@@ -60,7 +65,7 @@ def _read_queue_events(path: Path) -> list[dict]:
 
 
 def test_droppable_classification() -> None:
-    # Cosmetic LED-class traffic may be shed.
+    # Cosmetic LED-class traffic may be shed, Port B and Port C alike.
     for tool in (
         "set_led",
         "set_leds",
@@ -70,6 +75,10 @@ def test_droppable_classification() -> None:
         "port_b_ws2812_set_strip",
         "port_b_ws2812_refresh",
         "port_b_ws2812_clear",
+        "port_c_ws2812_set_pixel",
+        "port_c_ws2812_set_strip",
+        "port_c_ws2812_refresh",
+        "port_c_ws2812_clear",
     ):
         assert is_droppable_tool(tool), tool
     # Explicit one-shot commands must never be shed. move_head stays
@@ -83,6 +92,7 @@ def test_droppable_classification() -> None:
         "load_avatar_set",
         "take_photo",
         "port_b_ws2812_init",
+        "port_c_ws2812_init",
     ):
         assert not is_droppable_tool(tool), tool
 
@@ -91,6 +101,78 @@ def test_dispatch_timeout_overrides() -> None:
     assert dispatch_timeout_for("get_device_info") == queue_module.DISPATCH_TIMEOUT_S
     assert dispatch_timeout_for("say") > queue_module.DISPATCH_TIMEOUT_S
     assert dispatch_timeout_for("load_avatar_set") > queue_module.DISPATCH_TIMEOUT_S
+
+
+def test_dispatch_timeout_follows_caller_timeout() -> None:
+    static = dispatch_timeout_for("load_avatar_set")
+    margin = queue_module.CALL_TIMEOUT_MARGIN_S
+
+    # A caller timeout inside the static budget keeps the static budget.
+    assert dispatch_timeout_for("load_avatar_set", {"timeout": 60.0}) == static
+    # A schema-legal timeout above the static budget extends it: the
+    # watchdog must never cancel a call still inside its own wait window.
+    assert dispatch_timeout_for("load_avatar_set", {"timeout": 250.0}) == (
+        250.0 + margin
+    )
+    assert dispatch_timeout_for("load_avatar_set", {"timeout": 300.0}) == (
+        300.0 + margin
+    )
+    # Out-of-schema values are clamped to the schema maximum so a rogue
+    # argument cannot disable the watchdog.
+    assert dispatch_timeout_for("load_avatar_set", {"timeout": 100000}) == (
+        300.0 + margin
+    )
+    # Malformed or missing arguments fall back to the static budget.
+    assert dispatch_timeout_for("load_avatar_set", {"timeout": "soon"}) == static
+    assert dispatch_timeout_for("load_avatar_set", {"timeout": -5}) == static
+    assert dispatch_timeout_for("load_avatar_set", {}) == static
+    # Tools without a registered timeout argument ignore it entirely.
+    assert dispatch_timeout_for("get_device_info", {"timeout": 250.0}) == (
+        queue_module.DISPATCH_TIMEOUT_S
+    )
+
+
+@pytest.mark.asyncio
+async def test_caller_timeout_call_survives_static_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression for the schema/watchdog mismatch: a load_avatar_set call
+    # with a schema-legal timeout above the static budget used to be
+    # force-cancelled mid-transfer — and because the real fetch path
+    # swallows CancelledError and reports {"ok": False, "error":
+    # "superseded"}, the caller saw that misleading value instead of a
+    # head-timeout. With the dynamic budget the dispatch runs to
+    # completion inside the caller's own wait window.
+    monkeypatch.setattr(
+        queue_module, "DISPATCH_TIMEOUT_OVERRIDES", {"load_avatar_set": 0.05}
+    )
+    monkeypatch.setattr(
+        queue_module, "CALL_TIMEOUT_ARGS", {"load_avatar_set": ("timeout", 10.0)}
+    )
+    monkeypatch.setattr(queue_module, "CALL_TIMEOUT_MARGIN_S", 1.0)
+
+    queue = CommandQueue(capacity=2)
+    item = _make_item("load_avatar_set", arguments={"timeout": 0.2})
+    queue.enqueue(item)
+
+    async def dispatch(queued: QueueItem) -> dict:
+        # Mirror send_avatar_set_fetch: cancellation is absorbed and
+        # surfaced as a normal return value, never as an exception.
+        try:
+            await asyncio.sleep(0.2)
+            return {"ok": True}
+        except asyncio.CancelledError:
+            return {"ok": False, "error": "superseded"}
+
+    dispatcher = asyncio.create_task(queue.run_dispatcher(dispatch))
+    try:
+        result = await asyncio.wait_for(item.response_future, timeout=2.0)
+    finally:
+        dispatcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatcher
+
+    assert result == {"ok": True}
 
 
 @pytest.mark.asyncio
@@ -245,6 +327,23 @@ async def test_queue_events_honor_explicit_event_log_path(tmp_path: Path) -> Non
     events = _read_queue_events(events_path)
     assert len(events) == 1
     assert events[0]["subtype"] == "drop_incoming"
+
+
+@pytest.mark.asyncio
+async def test_queue_events_respect_jsonl_disabled(tmp_path: Path) -> None:
+    # jsonl_enabled=False in the notify config must suppress the JSONL
+    # side effect entirely — no file creation on the first intervention.
+    events_path = tmp_path / "disabled.jsonl"
+    queue = CommandQueue(
+        capacity=2, event_log_path=events_path, event_log_enabled=False
+    )
+    queue.enqueue(_make_item("say", request_id=1))
+    queue.enqueue(_make_item("move_head", request_id=2))
+
+    with pytest.raises(CommandDropped):
+        queue.enqueue_with_backpressure(_make_item("set_all_leds", request_id=3))
+
+    assert not events_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two failure modes of the HTTP daemon's command queue, addressed with a watchdog:

- **Hung head-of-queue**: a dispatch that never completes used to stall every queued command behind it. It is now force-dequeued after a per-tool timeout (default 30 s; `say`/`listen`/`load_avatar_set` get longer budgets).
- **Saturation lockout**: a full queue used to reject every newcomer uniformly, so a burst of cosmetic LED frames could starve one-shot commands. A saturated queue now sheds the oldest queued *droppable* item (cosmetic LED-class traffic where the next frame supersedes the dropped one); one-shot commands (`say`, `set_avatar`, `take_photo`, `move_head`, …) are never shed.

Interventions are logged and appended to the stackchan JSONL event log (`event_type="queue"`), following the notify configuration's JSONL path when one is set (second commit) so queue events land next to the device events they interleave with.

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (730 passed, 5 skipped — includes a dedicated `test_queue_watchdog.py`)
- [x] gateway: `uv run ruff check .`
- [x] Not applicable / not run: firmware build (gateway-only change)

### Hardware

- [x] Not applicable / hardware not available: gateway-only. Running in our deployment since 2026-07-10 — recovered several real hangs (device mid-reflash, Wi-Fi drop during a long TTS dispatch) without manual gateway restarts.

## Breaking changes

None; watchdog defaults preserve existing behaviour for fast tools.

## Related issues

None.
