### PR TITLE
feat(gateway): expose ws session_id in get_status for reboot detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ documented-only.
 
 ## [Unreleased]
 
+### Gateway
+
+- `get_status` now reports the WebSocket `session_id` alongside the
+  connection flags. The id changes on every (re)connection, so a polling
+  host can detect a device reboot even when the reconnect lands between
+  polls and `connected` never reads false.
+
 ## [0.17.0] - 2026-07-12
 
 ### Gateway

--- a/gateway/stackchan_mcp/esp32_client.py
+++ b/gateway/stackchan_mcp/esp32_client.py
@@ -1148,6 +1148,10 @@ class ESP32Manager:
         return {
             "connected": True,
             "device_id": self._connection.device_id,
+            # Changes on every WebSocket (re)connection. Lets pollers detect
+            # a device reboot even when the reconnect lands between polls and
+            # the connected flag never reads false (e.g. a firmware reflash).
+            "session_id": self._connection.session_id,
             "initialized": self._connection.initialized,
             "tools_count": len(self._connection.tools),
             "tools": [t.get("name", "") for t in self._connection.tools],


### PR DESCRIPTION
## Summary

`get_status` now reports the WebSocket `session_id` alongside the connection flags. The id changes on every (re)connection, so a polling host can detect a device reboot even when the reconnect lands between two polls and the `connected` flag never reads false (e.g. a firmware reflash).

## Test plan

### Code-level

- [x] gateway: `uv run pytest` (720 passed, 5 skipped)
- [x] gateway: `uv run ruff check .`
- [x] Not applicable / not run: firmware build (gateway-only, 4-line change)

### Hardware

- [x] Not applicable / hardware not available: gateway-only.

## Breaking changes

None (additive field).

## Related issues

None.
