### PR TITLE
docs: avatar authoring notes — geometry, sources, fetch window, blink cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ documented-only.
 ### Docs
 
 - Added avatar authoring notes (`docs/avatar-authoring-notes.md`):
-  frame-geometry consistency, edit-grade sources for moving parts, the
-  avatar-set fetch window, and per-face blink cadence.
+  frame-geometry consistency, full-frame exports from layered sources,
+  the avatar-set fetch window, and blink cadence tuning.
 
 ## [0.17.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ documented-only.
 
 ## [Unreleased]
 
+### Docs
+
+- Added avatar authoring notes (`docs/avatar-authoring-notes.md`):
+  frame-geometry consistency, edit-grade sources for moving parts, the
+  avatar-set fetch window, and per-face blink cadence.
+
 ## [0.17.0] - 2026-07-12
 
 ### Gateway

--- a/docs/avatar-authoring-notes.md
+++ b/docs/avatar-authoring-notes.md
@@ -1,0 +1,69 @@
+# Avatar authoring notes
+
+Field notes from building custom avatar sets for the `load_avatar_set`
+pipeline. The wire format is documented on the tool itself (layered mode =
+14 frames, face 6 + eyes 3 + mouth 5, 537,600 bytes; matrix mode = 90
+pre-composited frames, 6 × 3 × 5, 3,456,000 bytes; both raw RGB565).
+These notes cover the authoring side: what makes a set read well on the
+device, and the pitfalls we hit so you do not have to.
+
+They are advice, not requirements — nothing here is enforced by the
+gateway or the firmware.
+
+## Keep every frame in one geometry
+
+A matrix set is the cartesian product of face × eyes × mouth variants.
+The device cuts between those frames constantly (blink, lip-sync,
+expression changes), so all 90 frames must share one geometry: same
+canvas, same head position, same feature anchor points. A variant that
+is redrawn even slightly off — a face a few pixels larger, an eye line
+a few pixels higher — reads as a visible jump every time that frame is
+selected, not as a subtle difference.
+
+The practical rule: derive every variant from one master image, and
+never mix frames from sources drawn at different proportions. If a
+variant needs redrawing, redraw it on top of the master's geometry
+rather than importing from elsewhere. Scaling a near-miss frame to fit
+does not rescue it; the anchors drift even when the canvas matches.
+
+## Moving parts need edit-grade sources
+
+Eyes and mouths are compositing parts: the same part is combined with
+several faces (explicitly in layered mode, at bake time for a matrix
+set). A part cropped out of an already-composited picture carries its
+old background along its edges — anti-aliased pixels, compression
+artifacts, a halo of the previous face's shading. Composited onto a
+different face variant, that edge shows up as a faint outline that
+appears and disappears as frames cycle.
+
+Author the moving parts as separate layers with clean alpha from the
+start (or redraw them as such), and composite at export time. If all
+you have is a flat reference image, treat it as a reference to redraw
+from, not as a source to crop from.
+
+## Mind the fetch window
+
+A matrix set is a ~3.3 MB transfer. Over a healthy link it is quick,
+but with Wi-Fi power save active (the modem idles between beacons) we
+have measured a full fetch taking two to three minutes. During the
+fetch the device is busy downloading; queued commands wait, and a slow
+dispatch such as `say` issued right after `load_avatar_set` is likely
+to hit the MCP client's timeout before it ever reaches the device.
+
+Practical sequencing: stage the set, wait for the fetch to complete
+(the gateway logs the device's GET, and the `load_avatar_set` call
+itself blocks until the device confirms), and only then resume normal
+traffic. If your host automates a set load at connect time, give the
+commands that follow it generous timeouts.
+
+## Blink cadence is a per-face aesthetic
+
+The firmware blinks autonomously on a randomized gap (3–6 s by
+default, constants in `firmware/main/boards/stackchan/stackchan.cc`).
+How that cadence reads depends on the face: small, stylized faces tend
+to read better with quicker blinks, while realistic proportions stay
+calm on the stock gap. When a new set feels subtly wrong — too static,
+or too nervous — the blink gap is worth checking before touching the
+art. Changing the bounds currently means editing the constants and
+reflashing, so it is a bake-time decision per avatar set rather than a
+runtime knob.

--- a/docs/avatar-authoring-notes.md
+++ b/docs/avatar-authoring-notes.md
@@ -28,33 +28,46 @@ does not rescue it; the anchors drift even when the canvas matches.
 
 ## Moving parts need edit-grade sources
 
-Eyes and mouths are compositing parts: the same part is combined with
-several faces (explicitly in layered mode, at bake time for a matrix
-set). A part cropped out of an already-composited picture carries its
-old background along its edges — anti-aliased pixels, compression
-artifacts, a halo of the previous face's shading. Composited onto a
-different face variant, that edge shows up as a faint outline that
-appears and disappears as frames cycle.
+Eyes and mouths recombine with several faces — but only in your
+authoring tool, at export time. On the device there is no compositor:
+the firmware always shows exactly one full-frame RGB565 image at a
+time, and RGB565 carries no alpha. In layered mode a blink or mouth
+change swaps the whole screen to the eyes or mouth frame; a matrix
+set bakes every face × eyes × mouth combination ahead of time. Either
+way, every exported frame must be a complete full-frame image — a
+part exported with transparency renders as a broken face the first
+time its frame is selected.
 
-Author the moving parts as separate layers with clean alpha from the
-start (or redraw them as such), and composite at export time. If all
-you have is a flat reference image, treat it as a reference to redraw
-from, not as a source to crop from.
+Inside the authoring file, still build the moving parts as separate
+layers with clean alpha: a part cropped out of an already-composited
+picture carries its old background along its edges — anti-aliased
+pixels, compression artifacts, a halo of the previous face's shading —
+and that edge shows up as a faint outline that appears and disappears
+as frames cycle. Composite the layers onto the face and flatten at
+export time. If all you have is a flat reference image, treat it as a
+reference to redraw from, not as a source to crop from.
 
 ## Mind the fetch window
 
 A matrix set is a ~3.3 MB transfer. Over a healthy link it is quick,
 but with Wi-Fi power save active (the modem idles between beacons) we
-have measured a full fetch taking two to three minutes. During the
-fetch the device is busy downloading; queued commands wait, and a slow
-dispatch such as `say` issued right after `load_avatar_set` is likely
-to hit the MCP client's timeout before it ever reaches the device.
+have measured a full fetch taking two to three minutes.
 
-Practical sequencing: stage the set, wait for the fetch to complete
-(the gateway logs the device's GET, and the `load_avatar_set` call
-itself blocks until the device confirms), and only then resume normal
-traffic. If your host automates a set load at connect time, give the
-commands that follow it generous timeouts.
+The fetch runs on its own task on the device: the WebSocket loop keeps
+processing commands, so `say` and other non-avatar traffic go through
+normally during the download. What is held back are the avatar-facing
+updates — face, mouth and blink changes are quiesced until the new set
+is adopted — so sequencing matters for avatar-affecting calls, not for
+commands in general.
+
+The wait itself belongs to `load_avatar_set`: the call blocks until
+the device confirms adoption, bounded by its own `timeout` argument
+(default 60 s, maximum 300 s). A multi-minute power-save fetch
+therefore needs that per-call `timeout` raised to the 180–300 s range,
+or the call returns `device_timeout` while the device is still
+downloading. Raising timeouts on subsequent commands does not extend
+the fetch wait. The gateway logs the device's GET, which is the
+easiest way to watch a slow fetch make progress.
 
 ## Blink cadence is a per-face aesthetic
 
@@ -64,6 +77,7 @@ How that cadence reads depends on the face: small, stylized faces tend
 to read better with quicker blinks, while realistic proportions stay
 calm on the stock gap. When a new set feels subtly wrong — too static,
 or too nervous — the blink gap is worth checking before touching the
-art. Changing the bounds currently means editing the constants and
-reflashing, so it is a bake-time decision per avatar set rather than a
-runtime knob.
+art. The bounds are build-time constants that apply to every avatar
+set on the device: changing them means editing the constants and
+reflashing, and the new cadence applies device-wide, not per set. Tune
+them for the set the device actually runs day to day.


### PR DESCRIPTION
## Summary

Adds `docs/avatar-authoring-notes.md` — field notes from building custom avatar sets for the `load_avatar_set` pipeline, covering the authoring side the tool docs do not:

- keeping all frames of a set in one geometry (why near-miss variants read as jumps),
- authoring moving parts (eyes/mouths) as edit-grade layered sources instead of cropping from composited art,
- sequencing around the multi-minute set fetch under Wi-Fi power save,
- treating blink cadence as a per-face aesthetic (and where the constants live).

Advice, not requirements — nothing in it is enforced by gateway or firmware.

## Test plan

### Code-level

- [x] Not applicable / not run: docs-only change (no code paths touched)

### Hardware

- [x] Not applicable / hardware not available: docs-only. The observations themselves come from a CoreS3 stack-chan in daily service (geometry/edge pitfalls hit while iterating a 90-frame matrix set; fetch timing measured on-device).

## Breaking changes

None.

## Related issues

None.
